### PR TITLE
docs: add missing godoc comments to packages and exported symbols

### DIFF
--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -462,10 +462,12 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 
 type tmuxScraper struct{}
 
+// ScrapeClaudeUsage delegates to tmux.ScrapeClaudeUsage.
 func (tmuxScraper) ScrapeClaudeUsage(ctx context.Context) (tmux.UsageResult, error) {
 	return tmux.ScrapeClaudeUsage(ctx)
 }
 
+// ScrapeCodexUsage delegates to tmux.ScrapeCodexUsage.
 func (tmuxScraper) ScrapeCodexUsage(ctx context.Context) (tmux.UsageResult, error) {
 	return tmux.ScrapeCodexUsage(ctx)
 }

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -236,10 +236,12 @@ func newSetupModel() (*setupModel, error) {
 	return model, nil
 }
 
+// Init implements tea.Model.
 func (m *setupModel) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
+// Update implements tea.Model.
 func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.spinner, cmd = m.spinner.Update(msg)
@@ -305,6 +307,7 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// View implements tea.Model.
 func (m *setupModel) View() string {
 	var b strings.Builder
 	b.WriteString(styleHeader.Render("Nightshift Setup"))

--- a/internal/calibrator/calibrator.go
+++ b/internal/calibrator/calibrator.go
@@ -1,3 +1,4 @@
+// Package calibrator tunes task budgets and scheduling based on historical usage data.
 package calibrator
 
 import (

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,3 +1,4 @@
+// Package db provides SQLite-backed storage for nightshift state and snapshots.
 package db
 
 import (

--- a/internal/integrations/agentsmd.go
+++ b/internal/integrations/agentsmd.go
@@ -23,10 +23,12 @@ func NewAgentsMDReader(cfg *config.Config) *AgentsMDReader {
 	}
 }
 
+// Name returns the integration identifier.
 func (r *AgentsMDReader) Name() string {
 	return "agents.md"
 }
 
+// Enabled reports whether agents.md integration is configured.
 func (r *AgentsMDReader) Enabled() bool {
 	return r.enabled
 }

--- a/internal/integrations/claudemd.go
+++ b/internal/integrations/claudemd.go
@@ -23,10 +23,12 @@ func NewClaudeMDReader(cfg *config.Config) *ClaudeMDReader {
 	}
 }
 
+// Name returns the integration identifier.
 func (r *ClaudeMDReader) Name() string {
 	return "claude.md"
 }
 
+// Enabled reports whether claude.md integration is configured.
 func (r *ClaudeMDReader) Enabled() bool {
 	return r.enabled
 }

--- a/internal/integrations/github.go
+++ b/internal/integrations/github.go
@@ -34,10 +34,12 @@ func NewGitHubReader(cfg *config.Config) *GitHubReader {
 	return r
 }
 
+// Name returns the integration identifier.
 func (r *GitHubReader) Name() string {
 	return "github"
 }
 
+// Enabled reports whether GitHub issue integration is configured.
 func (r *GitHubReader) Enabled() bool {
 	return r.enabled
 }

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -64,6 +64,7 @@ const (
 	HintContext                        // Background context
 )
 
+// String returns the machine-readable name of the hint type.
 func (h HintType) String() string {
 	switch h {
 	case HintTaskSuggestion:
@@ -156,6 +157,7 @@ type ReaderError struct {
 	Err    error
 }
 
+// Error returns a formatted error string identifying the failed reader.
 func (e ReaderError) Error() string {
 	return e.Reader + ": " + e.Err.Error()
 }

--- a/internal/integrations/td.go
+++ b/internal/integrations/td.go
@@ -32,10 +32,12 @@ func NewTDReader(cfg *config.Config) *TDReader {
 	return r
 }
 
+// Name returns the integration identifier.
 func (r *TDReader) Name() string {
 	return "td"
 }
 
+// Enabled reports whether td integration is configured.
 func (r *TDReader) Enabled() bool {
 	return r.enabled
 }

--- a/internal/security/credentials.go
+++ b/internal/security/credentials.go
@@ -187,6 +187,7 @@ type CredentialError struct {
 	Message    string
 }
 
+// Error returns a formatted credential error message.
 func (e *CredentialError) Error() string {
 	return fmt.Sprintf("credential error (%s): %s", e.Credential, e.Message)
 }

--- a/internal/setup/presets.go
+++ b/internal/setup/presets.go
@@ -1,3 +1,4 @@
+// Package setup provides interactive configuration and task preset selection for new projects.
 package setup
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/marcus/nightshift/internal/tasks"
 )
 
+// Preset identifies a task selection profile (safe, balanced, aggressive).
 type Preset string
 
 const (
@@ -16,6 +18,7 @@ const (
 	PresetAggressive Preset = "aggressive"
 )
 
+// RepoSignals holds detected project characteristics that influence task selection.
 type RepoSignals struct {
 	HasRelease bool
 	HasADR     bool
@@ -47,6 +50,7 @@ func DetectRepoSignals(projects []string) RepoSignals {
 	return signals
 }
 
+// PresetTasks returns the set of enabled task types for the given preset and repo signals.
 func PresetTasks(preset Preset, defs []tasks.TaskDefinition, signals RepoSignals) map[tasks.TaskType]bool {
 	selected := make(map[tasks.TaskType]bool)
 	for _, def := range defs {

--- a/internal/snapshots/collector.go
+++ b/internal/snapshots/collector.go
@@ -1,3 +1,4 @@
+// Package snapshots collects and stores periodic usage data from AI providers.
 package snapshots
 
 import (

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -19,6 +19,7 @@ const (
 	CostVeryHigh                 // 500k+ tokens
 )
 
+// String returns a human-readable label for the cost tier.
 func (c CostTier) String() string {
 	switch c {
 	case CostLow:
@@ -59,6 +60,7 @@ const (
 	RiskHigh
 )
 
+// String returns a human-readable label for the risk level.
 func (r RiskLevel) String() string {
 	switch r {
 	case RiskLow:
@@ -101,6 +103,7 @@ const (
 	CategoryEmergency
 )
 
+// String returns a human-readable description of the task category.
 func (c TaskCategory) String() string {
 	switch c {
 	case CategoryPR:

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,3 +1,4 @@
+// Package tmux scrapes tmux sessions to detect running AI agent processes and their usage.
 package tmux
 
 import (

--- a/internal/trends/analyzer.go
+++ b/internal/trends/analyzer.go
@@ -1,3 +1,4 @@
+// Package trends analyzes historical snapshot data to surface usage patterns and anomalies.
 package trends
 
 import (

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -29,6 +29,7 @@ const (
 	StatusIdle
 )
 
+// String returns a human-readable label for the daemon status.
 func (s DaemonStatus) String() string {
 	switch s {
 	case StatusStopped:
@@ -52,6 +53,7 @@ const (
 	TaskFailed
 )
 
+// String returns a human-readable label for the task status.
 func (s TaskStatus) String() string {
 	switch s {
 	case TaskPending:


### PR DESCRIPTION
## Summary
- Add package-level doc comments to 6 packages: `db`, `snapshots`, `calibrator`, `tmux`, `trends`, `setup`
- Add doc comments to ~25 exported symbols: `String()`, `Name()`, `Enabled()`, `Error()`, and Bubbletea interface methods (`Init`, `Update`, `View`)
- No code changes — only comment additions across 16 files

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Verify godoc renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)