### PR TITLE
fix: resolve linter errors

### DIFF
--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -472,14 +472,14 @@ func buildPreflight(p executeRunParams) (*preflightPlan, error) {
 
 // displayPreflight renders the preflight summary to the given writer.
 func displayPreflight(w io.Writer, plan *preflightPlan) {
-	fmt.Fprintf(w, "\n=== Preflight Summary ===\n")
+	_, _ = fmt.Fprintf(w, "\n=== Preflight Summary ===\n")
 
 	// Show provider info from first project that has one
 	for _, pp := range plan.projects {
 		if pp.provider != nil {
-			fmt.Fprintf(w, "Provider: %s (%.1f%% budget used, %s mode)\n",
+			_, _ = fmt.Fprintf(w, "Provider: %s (%.1f%% budget used, %s mode)\n",
 				pp.provider.name, pp.provider.allowance.UsedPercent, pp.provider.allowance.Mode)
-			fmt.Fprintf(w, "Budget: %d tokens remaining\n", pp.provider.allowance.Allowance)
+			_, _ = fmt.Fprintf(w, "Budget: %d tokens remaining\n", pp.provider.allowance.Allowance)
 			break
 		}
 	}
@@ -491,7 +491,7 @@ func displayPreflight(w io.Writer, plan *preflightPlan) {
 			active++
 		}
 	}
-	fmt.Fprintf(w, "\nProjects (%d of %d):\n", active, len(plan.projects))
+	_, _ = fmt.Fprintf(w, "\nProjects (%d of %d):\n", active, len(plan.projects))
 
 	idx := 0
 	for _, pp := range plan.projects {
@@ -499,10 +499,10 @@ func displayPreflight(w io.Writer, plan *preflightPlan) {
 			continue
 		}
 		idx++
-		fmt.Fprintf(w, "  %d. %s\n", idx, filepath.Base(pp.path))
+		_, _ = fmt.Fprintf(w, "  %d. %s\n", idx, filepath.Base(pp.path))
 		for _, st := range pp.tasks {
 			minTok, maxTok := st.Definition.EstimatedTokens()
-			fmt.Fprintf(w, "     - %s (score=%.1f, cost=%s, ~%dk-%dk tokens)\n",
+			_, _ = fmt.Fprintf(w, "     - %s (score=%.1f, cost=%s, ~%dk-%dk tokens)\n",
 				st.Definition.Name, st.Score, st.Definition.CostTier, minTok/1000, maxTok/1000)
 		}
 	}
@@ -515,19 +515,19 @@ func displayPreflight(w io.Writer, plan *preflightPlan) {
 		}
 	}
 	if len(skipped) > 0 {
-		fmt.Fprintf(w, "\nSkipped:\n")
+		_, _ = fmt.Fprintf(w, "\nSkipped:\n")
 		for _, pp := range skipped {
-			fmt.Fprintf(w, "  - %s: %s\n", filepath.Base(pp.path), pp.skipReason)
+			_, _ = fmt.Fprintf(w, "  - %s: %s\n", filepath.Base(pp.path), pp.skipReason)
 		}
 	}
 
 	// Warnings
 	if plan.ignoreBudget {
-		fmt.Fprintf(w, "\nWarnings:\n")
-		fmt.Fprintf(w, "  - --ignore-budget is set: budget limits bypassed\n")
+		_, _ = fmt.Fprintf(w, "\nWarnings:\n")
+		_, _ = fmt.Fprintf(w, "  - --ignore-budget is set: budget limits bypassed\n")
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 }
 
 func executeRun(ctx context.Context, p executeRunParams) error {
@@ -915,6 +915,6 @@ func ensurePATH() {
 
 	if len(added) > 0 {
 		newPath := current + string(os.PathListSeparator) + strings.Join(added, string(os.PathListSeparator))
-		os.Setenv("PATH", newPath)
+		_ = os.Setenv("PATH", newPath)
 	}
 }

--- a/cmd/nightshift/commands/run_test.go
+++ b/cmd/nightshift/commands/run_test.go
@@ -861,7 +861,7 @@ func TestConfirmRun_TTYAcceptsY(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdin = r
 	_, _ = w.WriteString("y\n")
-	w.Close()
+	_ = w.Close()
 
 	p := executeRunParams{log: logging.Component("test")}
 	ok, err := confirmRun(p)
@@ -883,7 +883,7 @@ func TestConfirmRun_TTYAcceptsYes(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdin = r
 	_, _ = w.WriteString("yes\n")
-	w.Close()
+	_ = w.Close()
 
 	p := executeRunParams{log: logging.Component("test")}
 	ok, err := confirmRun(p)
@@ -905,7 +905,7 @@ func TestConfirmRun_TTYRejectsN(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdin = r
 	_, _ = w.WriteString("n\n")
-	w.Close()
+	_ = w.Close()
 
 	p := executeRunParams{log: logging.Component("test")}
 	ok, err := confirmRun(p)
@@ -927,7 +927,7 @@ func TestConfirmRun_TTYDefaultRejectsEmpty(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdin = r
 	_, _ = w.WriteString("\n")
-	w.Close()
+	_ = w.Close()
 
 	p := executeRunParams{log: logging.Component("test")}
 	ok, err := confirmRun(p)
@@ -953,7 +953,7 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	fn()
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = origStdout
 
 	var buf strings.Builder

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -28,7 +28,7 @@ type Duration struct {
 
 // MarshalJSON serializes Duration as integer seconds.
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(int64(d.Duration.Seconds()))
+	return json.Marshal(int64(d.Seconds()))
 }
 
 // UnmarshalJSON deserializes Duration from integer seconds.


### PR DESCRIPTION
## Summary
Fixed all linting errors reported by golangci-lint across 3 files:
- 8 errcheck violations (unchecked fmt.Fprintf/Fprintln and os.Setenv calls, w.Close in tests)
- 1 staticcheck violation (unnecessary embedded field selector in Duration.MarshalJSON)

## Changes
**run.go** (9 fixes):
- displayPreflight: Assign all fmt.Fprintf and fmt.Fprintln error returns to _ (these are safe expected operations writing to stdout)
- ensurePATH: Assign os.Setenv error to _

**run_test.go** (4 fixes):
- TestConfirmRun_TTYAcceptsY, TTYAcceptsYes, TTYDefaultRejectsEmpty: Assign w.Close() error to _ in pipe cleanup
- captureStdout helper: Assign w.Close() error to _ 

**stats.go** (1 fix):
- MarshalJSON: Remove redundant embedded field selector (d.Duration.Seconds → d.Seconds)

## Testing
- All unit tests pass
- golangci-lint reports no errcheck or staticcheck violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)