### PR TITLE
fix: use codex exec for non-interactive runs

### DIFF
--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -84,9 +84,9 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Build command args for headless/non-interactive execution
-	// Codex CLI uses --quiet for non-interactive mode and accepts prompt directly
-	args := []string{"--quiet"}
+	// Build command args for headless/non-interactive execution.
+	// Codex CLI uses the `exec` subcommand for non-interactive mode.
+	args := []string{"exec"}
 	if a.bypassPerm {
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}

--- a/internal/agents/codex_test.go
+++ b/internal/agents/codex_test.go
@@ -79,8 +79,8 @@ func TestCodexAgent_Execute_Success(t *testing.T) {
 	if mock.CapturedName != "codex" {
 		t.Errorf("binary = %q, want %q", mock.CapturedName, "codex")
 	}
-	if len(mock.CapturedArgs) != 3 || mock.CapturedArgs[0] != "--quiet" || mock.CapturedArgs[1] != "--dangerously-bypass-approvals-and-sandbox" || mock.CapturedArgs[2] != "fix the bug" {
-		t.Errorf("args = %v, want [--quiet --dangerously-bypass-approvals-and-sandbox fix the bug]", mock.CapturedArgs)
+	if len(mock.CapturedArgs) != 3 || mock.CapturedArgs[0] != "exec" || mock.CapturedArgs[1] != "--dangerously-bypass-approvals-and-sandbox" || mock.CapturedArgs[2] != "fix the bug" {
+		t.Errorf("args = %v, want [exec --dangerously-bypass-approvals-and-sandbox fix the bug]", mock.CapturedArgs)
 	}
 	if mock.CapturedDir != "/project" {
 		t.Errorf("dir = %q, want %q", mock.CapturedDir, "/project")


### PR DESCRIPTION
## Summary
- Replace deprecated Codex non-interactive flag usage from `--quiet` to the `exec` subcommand in the Codex agent.
- Update Codex agent test expectations to match the new CLI invocation.

## Testing
- `go test ./internal/agents`

Closes #9 