### PR TITLE
feat: branch selection ability

### DIFF
--- a/cmd/nightshift/commands/run_output.go
+++ b/cmd/nightshift/commands/run_output.go
@@ -207,6 +207,13 @@ func displayPreflightColored(plan *preflightPlan) {
 	fmt.Println(s.Title.Render("Preflight Summary"))
 	fmt.Println(s.Muted.Render(hr))
 
+	// Show branch info
+	if plan.branch != "" {
+		fmt.Printf("  %s %s\n",
+			s.Label.Render("Branch:"),
+			s.Value.Render(plan.branch))
+	}
+
 	// Show provider info from first project that has one
 	for _, pp := range plan.projects {
 		if pp.provider != nil {

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -35,6 +35,11 @@ var migrations = []Migration{
 		Description: "add bus_factor_results table for code ownership analysis",
 		SQL:         migration004SQL,
 	},
+	{
+		Version:     5,
+		Description: "add branch column to run_history",
+		SQL:         migration005SQL,
+	},
 }
 
 const migration002SQL = `
@@ -110,6 +115,10 @@ CREATE TABLE snapshots (
 CREATE INDEX idx_snapshots_provider_time ON snapshots(provider, timestamp DESC);
 CREATE INDEX idx_snapshots_provider_week ON snapshots(provider, week_start);
 CREATE INDEX idx_run_history_time ON run_history(start_time DESC);
+`
+
+const migration005SQL = `
+ALTER TABLE run_history ADD COLUMN branch TEXT NOT NULL DEFAULT '';
 `
 
 // Migrate runs all pending migrations inside transactions.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -320,6 +320,59 @@ func TestRunHistoryProviderPersisted(t *testing.T) {
 	}
 }
 
+func TestRunHistoryBranchPersisted(t *testing.T) {
+	s := newTestState(t)
+
+	start := time.Now().Add(-2 * time.Minute)
+	record := RunRecord{
+		ID:         "run-branch-test",
+		StartTime:  start,
+		EndTime:    start.Add(45 * time.Second),
+		Provider:   "claude",
+		Project:    "/tmp/project",
+		Tasks:      []string{"lint-fix"},
+		TokensUsed: 30000,
+		Status:     "success",
+		Branch:     "develop",
+	}
+
+	s.AddRunRecord(record)
+
+	runs := s.GetRunHistory(1)
+	if len(runs) != 1 {
+		t.Fatalf("GetRunHistory() returned %d runs, want 1", len(runs))
+	}
+	if runs[0].Branch != "develop" {
+		t.Fatalf("run branch = %q, want %q", runs[0].Branch, "develop")
+	}
+}
+
+func TestRunHistoryBranchEmpty(t *testing.T) {
+	s := newTestState(t)
+
+	start := time.Now().Add(-2 * time.Minute)
+	record := RunRecord{
+		ID:         "run-no-branch-test",
+		StartTime:  start,
+		EndTime:    start.Add(30 * time.Second),
+		Provider:   "claude",
+		Project:    "/tmp/project",
+		Tasks:      []string{"lint-fix"},
+		TokensUsed: 20000,
+		Status:     "success",
+	}
+
+	s.AddRunRecord(record)
+
+	runs := s.GetRunHistory(1)
+	if len(runs) != 1 {
+		t.Fatalf("GetRunHistory() returned %d runs, want 1", len(runs))
+	}
+	if runs[0].Branch != "" {
+		t.Fatalf("run branch = %q, want empty", runs[0].Branch)
+	}
+}
+
 func newTestState(t *testing.T) *State {
 	t.Helper()
 


### PR DESCRIPTION
Thanks for this project, really enjoying using it. I hit an issue with branch assignment for a recent project. Let me know if this is something you would like to support.

Let users specify which branch AI agents create feature branches from
via `--branch` / `-b` on both `run` and `task run` commands. Defaults
to the current git branch when omitted.

- Add flag to `run` and `task run` commands
- Inject branch instructions into plan and implement prompts
- Include branch in PR metadata block and run history
- Show branch in preflight summary (plain and colored)
- Add DB migration for run_history.branch column
- Add comprehensive test coverage (13 new tests)

My default branch in the repo was set to develop but for some reason it worked from main. This was after one iteration, was unfortunate unusable.

<img width="650" height="526" alt="main-diff" src="https://github.com/user-attachments/assets/bdc8ccdd-6c4d-41f5-bf26-5b00b7c1661a" />


related to #10 