### PR TITLE
feat: add Gemini CLI as a third provider

### DIFF
--- a/cmd/nightshift/commands/budget_helpers.go
+++ b/cmd/nightshift/commands/budget_helpers.go
@@ -19,8 +19,12 @@ func resolveProviderList(cfg *config.Config, filter string) ([]string, error) {
 			if !cfg.Providers.Codex.Enabled {
 				return nil, fmt.Errorf("codex provider not enabled")
 			}
+		case "gemini":
+			if !cfg.Providers.Gemini.Enabled {
+				return nil, fmt.Errorf("gemini provider not enabled")
+			}
 		default:
-			return nil, fmt.Errorf("unknown provider: %s (valid: claude, codex)", filter)
+			return nil, fmt.Errorf("unknown provider: %s (valid: claude, codex, gemini)", filter)
 		}
 		return []string{filter}, nil
 	}
@@ -31,6 +35,9 @@ func resolveProviderList(cfg *config.Config, filter string) ([]string, error) {
 	}
 	if cfg.Providers.Codex.Enabled {
 		providerList = append(providerList, "codex")
+	}
+	if cfg.Providers.Gemini.Enabled {
+		providerList = append(providerList, "gemini")
 	}
 
 	return providerList, nil

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -265,11 +265,12 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 	// Initialize providers
 	claudeProvider := providers.NewClaudeWithPath(cfg.ExpandedProviderPath("claude"))
 	codexProvider := providers.NewCodexWithPath(cfg.ExpandedProviderPath("codex"))
+	geminiProvider := providers.NewGeminiWithPath(cfg.ExpandedProviderPath("gemini"))
 
 	// Initialize budget manager
 	cal := calibrator.New(database, cfg)
 	trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
-	budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
+	budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, geminiProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
 
 	report := newRunReport(time.Now(), calculateRunBudgetStart(cfg, budgetMgr, log))
 

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -24,8 +24,14 @@ func agentByName(cfg *config.Config, provider string) (agents.Agent, error) {
 			return nil, fmt.Errorf("codex CLI not found in PATH")
 		}
 		return a, nil
+	case "gemini":
+		a := newGeminiAgentFromConfig(cfg)
+		if !a.Available() {
+			return nil, fmt.Errorf("gemini CLI not found in PATH")
+		}
+		return a, nil
 	default:
-		return nil, fmt.Errorf("unknown provider: %s (supported: claude, codex)", provider)
+		return nil, fmt.Errorf("unknown provider: %s (supported: claude, codex, gemini)", provider)
 	}
 }
 
@@ -45,4 +51,17 @@ func newCodexAgentFromConfig(cfg *config.Config) *agents.CodexAgent {
 	return agents.NewCodexAgent(
 		agents.WithDangerouslyBypassApprovalsAndSandbox(cfg.Providers.Codex.DangerouslyBypassApprovalsAndSandbox),
 	)
+}
+
+func newGeminiAgentFromConfig(cfg *config.Config) *agents.GeminiAgent {
+	if cfg == nil {
+		return agents.NewGeminiAgent()
+	}
+	opts := []agents.GeminiOption{
+		agents.WithGeminiAutoApprove(cfg.Providers.Gemini.DangerouslySkipPermissions),
+	}
+	if cfg.Providers.Gemini.Model != "" {
+		opts = append(opts, agents.WithGeminiModel(cfg.Providers.Gemini.Model))
+	}
+	return agents.NewGeminiAgent(opts...)
 }

--- a/cmd/nightshift/commands/preview.go
+++ b/cmd/nightshift/commands/preview.go
@@ -256,9 +256,10 @@ func buildPreviewResult(cfg *config.Config, database *db.DB, projects []string, 
 
 	claudeProvider := providers.NewClaudeWithPath(cfg.ExpandedProviderPath("claude"))
 	codexProvider := providers.NewCodexWithPath(cfg.ExpandedProviderPath("codex"))
+	geminiProvider := providers.NewGeminiWithPath(cfg.ExpandedProviderPath("gemini"))
 	cal := calibrator.New(database, cfg)
 	trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
-	budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
+	budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, geminiProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
 
 	selector := tasks.NewSelector(cfg, st)
 	orch := orchestrator.New()

--- a/cmd/nightshift/commands/snapshot.go
+++ b/cmd/nightshift/commands/snapshot.go
@@ -61,13 +61,13 @@ var budgetCalibrateCmd = &cobra.Command{
 }
 
 func init() {
-	budgetSnapshotCmd.Flags().StringP("provider", "p", "", "Provider to snapshot (claude, codex)")
+	budgetSnapshotCmd.Flags().StringP("provider", "p", "", "Provider to snapshot (claude, codex, gemini)")
 	budgetSnapshotCmd.Flags().Bool("local-only", false, "Skip tmux scraping and store local-only snapshot")
 
-	budgetHistoryCmd.Flags().StringP("provider", "p", "", "Provider to show history for (claude, codex)")
+	budgetHistoryCmd.Flags().StringP("provider", "p", "", "Provider to show history for (claude, codex, gemini)")
 	budgetHistoryCmd.Flags().IntP("n", "n", 20, "Number of snapshots to show")
 
-	budgetCalibrateCmd.Flags().StringP("provider", "p", "", "Provider to calibrate (claude, codex)")
+	budgetCalibrateCmd.Flags().StringP("provider", "p", "", "Provider to calibrate (claude, codex, gemini)")
 
 	budgetCmd.AddCommand(budgetSnapshotCmd)
 	budgetCmd.AddCommand(budgetHistoryCmd)
@@ -191,6 +191,8 @@ func providerDataSource(provider string) string {
 		return "stats-cache.json"
 	case "codex":
 		return "session JSONL files"
+	case "gemini":
+		return "session JSON files"
 	default:
 		return "local files"
 	}

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -47,7 +47,7 @@ Use --json for structured output.`,
 }
 
 var taskRunCmd = &cobra.Command{
-	Use:   "run <task-type> --provider <claude|codex>",
+	Use:   "run <task-type> --provider <claude|codex|gemini>",
 	Short: "Run a task immediately",
 	Long: `Execute a task immediately against a specific provider.
 
@@ -66,7 +66,7 @@ func init() {
 	taskShowCmd.Flags().Bool("json", false, "Output as JSON")
 	taskShowCmd.Flags().StringP("project", "p", "", "Project directory (used in prompt context)")
 
-	taskRunCmd.Flags().String("provider", "", "Provider to run against (claude, codex)")
+	taskRunCmd.Flags().String("provider", "", "Provider to run against (claude, codex, gemini)")
 	taskRunCmd.Flags().StringP("project", "p", "", "Project directory to run in")
 	taskRunCmd.Flags().Bool("dry-run", false, "Show prompt without executing")
 	taskRunCmd.Flags().Duration("timeout", 30*time.Minute, "Execution timeout")

--- a/internal/agents/gemini.go
+++ b/internal/agents/gemini.go
@@ -1,0 +1,252 @@
+// gemini.go implements the Agent interface for Google Gemini CLI.
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// GeminiAgent spawns Gemini CLI for task execution.
+type GeminiAgent struct {
+	binaryPath  string        // Path to gemini binary (default: "gemini")
+	timeout     time.Duration // Default timeout
+	runner      CommandRunner // Command executor (for testing)
+	autoApprove bool          // Pass -y (--yolo) to auto-approve actions
+	model       string        // Model to use (e.g., "gemini-3-pro-preview"); empty = CLI default
+}
+
+// GeminiOption configures a GeminiAgent.
+type GeminiOption func(*GeminiAgent)
+
+// WithGeminiBinaryPath sets a custom path to the gemini binary.
+func WithGeminiBinaryPath(path string) GeminiOption {
+	return func(a *GeminiAgent) {
+		a.binaryPath = path
+	}
+}
+
+// WithGeminiDefaultTimeout sets the default execution timeout.
+func WithGeminiDefaultTimeout(d time.Duration) GeminiOption {
+	return func(a *GeminiAgent) {
+		a.timeout = d
+	}
+}
+
+// WithGeminiAutoApprove sets whether to pass -y (--yolo) for auto-approval.
+func WithGeminiAutoApprove(enabled bool) GeminiOption {
+	return func(a *GeminiAgent) {
+		a.autoApprove = enabled
+	}
+}
+
+// WithGeminiModel sets the model to use (e.g., "gemini-3-pro-preview").
+func WithGeminiModel(model string) GeminiOption {
+	return func(a *GeminiAgent) {
+		a.model = model
+	}
+}
+
+// WithGeminiRunner sets a custom command runner (for testing).
+func WithGeminiRunner(r CommandRunner) GeminiOption {
+	return func(a *GeminiAgent) {
+		a.runner = r
+	}
+}
+
+// NewGeminiAgent creates a Gemini CLI agent.
+func NewGeminiAgent(opts ...GeminiOption) *GeminiAgent {
+	a := &GeminiAgent{
+		binaryPath:  "gemini",
+		timeout:     DefaultTimeout,
+		runner:      &ExecRunner{},
+		autoApprove: true,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// Name returns "gemini".
+func (a *GeminiAgent) Name() string {
+	return "gemini"
+}
+
+// Execute runs gemini in headless mode with the given prompt.
+func (a *GeminiAgent) Execute(ctx context.Context, opts ExecuteOptions) (*ExecuteResult, error) {
+	start := time.Now()
+
+	// Determine timeout
+	timeout := a.timeout
+	if opts.Timeout > 0 {
+		timeout = opts.Timeout
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Build command args for headless execution.
+	// Gemini CLI uses -p <prompt> for non-interactive (headless) mode.
+	// The prompt must immediately follow -p as its value.
+	var args []string
+
+	if opts.Prompt != "" {
+		args = append(args, "-p", opts.Prompt)
+	}
+
+	if a.model != "" {
+		args = append(args, "-m", a.model)
+	}
+
+	if a.autoApprove {
+		args = append(args, "-y")
+	}
+
+	// Request JSON output for structured results
+	args = append(args, "--output-format", "json")
+
+	// Build stdin content from files if provided
+	var stdinContent string
+	if len(opts.Files) > 0 {
+		var err error
+		stdinContent, err = a.buildFileContext(opts.Files)
+		if err != nil {
+			return &ExecuteResult{
+				Error:    fmt.Sprintf("building file context: %v", err),
+				Duration: time.Since(start),
+			}, err
+		}
+	}
+
+	// Run command
+	stdout, stderr, exitCode, err := a.runner.Run(ctx, a.binaryPath, args, opts.WorkDir, stdinContent)
+
+	result := &ExecuteResult{
+		Output:   stdout,
+		ExitCode: exitCode,
+		Duration: time.Since(start),
+	}
+
+	// Check for context timeout
+	if ctx.Err() == context.DeadlineExceeded {
+		result.Error = fmt.Sprintf("timeout after %v", timeout)
+		result.ExitCode = -1
+		return result, ctx.Err()
+	}
+
+	// Check for other errors
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+			result.Error = stderr
+		} else {
+			result.Error = err.Error()
+		}
+		return result, err
+	}
+
+	// Try to parse JSON output
+	result.JSON = a.extractJSON([]byte(stdout))
+
+	return result, nil
+}
+
+// ExecuteWithFiles runs gemini with file context included.
+func (a *GeminiAgent) ExecuteWithFiles(ctx context.Context, prompt string, files []string, workDir string) (*ExecuteResult, error) {
+	return a.Execute(ctx, ExecuteOptions{
+		Prompt:  prompt,
+		Files:   files,
+		WorkDir: workDir,
+	})
+}
+
+// buildFileContext reads files and formats them as context.
+func (a *GeminiAgent) buildFileContext(files []string) (string, error) {
+	var sb strings.Builder
+
+	sb.WriteString("# Context Files\n\n")
+
+	for _, path := range files {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		displayPath := path
+		if abs, err := filepath.Abs(path); err == nil {
+			displayPath = abs
+		}
+
+		fmt.Fprintf(&sb, "## File: %s\n\n```\n%s\n```\n\n", displayPath, string(content))
+	}
+
+	return sb.String(), nil
+}
+
+// extractJSON attempts to find and parse JSON from the output.
+func (a *GeminiAgent) extractJSON(output []byte) []byte {
+	if json.Valid(output) {
+		return output
+	}
+
+	start := -1
+	var opener, closer byte
+
+	for i, b := range output {
+		if b == '{' || b == '[' {
+			start = i
+			opener = b
+			if b == '{' {
+				closer = '}'
+			} else {
+				closer = ']'
+			}
+			break
+		}
+	}
+
+	if start == -1 {
+		return nil
+	}
+
+	depth := 0
+	for i := start; i < len(output); i++ {
+		if output[i] == opener {
+			depth++
+		} else if output[i] == closer {
+			depth--
+			if depth == 0 {
+				candidate := output[start : i+1]
+				if json.Valid(candidate) {
+					return candidate
+				}
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// Available checks if the gemini binary is available in PATH.
+func (a *GeminiAgent) Available() bool {
+	_, err := exec.LookPath(a.binaryPath)
+	return err == nil
+}
+
+// Version returns the gemini CLI version.
+func (a *GeminiAgent) Version() (string, error) {
+	cmd := exec.Command(a.binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("getting version: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/agents/gemini_test.go
+++ b/internal/agents/gemini_test.go
@@ -1,0 +1,196 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewGeminiAgent_Defaults(t *testing.T) {
+	agent := NewGeminiAgent()
+
+	if agent.binaryPath != "gemini" {
+		t.Errorf("binaryPath = %q, want %q", agent.binaryPath, "gemini")
+	}
+	if agent.timeout != DefaultTimeout {
+		t.Errorf("timeout = %v, want %v", agent.timeout, DefaultTimeout)
+	}
+	if agent.runner == nil {
+		t.Error("expected non-nil runner")
+	}
+	if !agent.autoApprove {
+		t.Error("expected autoApprove to be true by default")
+	}
+}
+
+func TestNewGeminiAgent_WithOptions(t *testing.T) {
+	mockRunner := &MockRunner{}
+	agent := NewGeminiAgent(
+		WithGeminiBinaryPath("/custom/gemini"),
+		WithGeminiDefaultTimeout(5*time.Minute),
+		WithGeminiRunner(mockRunner),
+		WithGeminiAutoApprove(false),
+	)
+
+	if agent.binaryPath != "/custom/gemini" {
+		t.Errorf("binaryPath = %q, want %q", agent.binaryPath, "/custom/gemini")
+	}
+	if agent.timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want %v", agent.timeout, 5*time.Minute)
+	}
+	if agent.runner != mockRunner {
+		t.Error("expected custom runner")
+	}
+	if agent.autoApprove {
+		t.Error("expected autoApprove to be false")
+	}
+}
+
+func TestGeminiAgent_Name(t *testing.T) {
+	agent := NewGeminiAgent()
+	if agent.Name() != "gemini" {
+		t.Errorf("Name() = %q, want %q", agent.Name(), "gemini")
+	}
+}
+
+func TestGeminiAgent_Execute_Basic(t *testing.T) {
+	mockRunner := &MockRunner{
+		Stdout:   `{"response": "Hello!", "stats": {}}`,
+		ExitCode: 0,
+	}
+	agent := NewGeminiAgent(WithGeminiRunner(mockRunner))
+
+	result, err := agent.Execute(context.Background(), ExecuteOptions{
+		Prompt:  "say hello",
+		WorkDir: "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if result.Output != `{"response": "Hello!", "stats": {}}` {
+		t.Errorf("unexpected output: %s", result.Output)
+	}
+	if result.JSON == nil {
+		t.Error("expected JSON output to be parsed")
+	}
+
+	// Verify command args
+	if mockRunner.CapturedName != "gemini" {
+		t.Errorf("command = %q, want %q", mockRunner.CapturedName, "gemini")
+	}
+
+	// Should contain -p, -y, --output-format, json, and the prompt
+	args := mockRunner.CapturedArgs
+	hasP := false
+	hasY := false
+	hasFormat := false
+	hasPrompt := false
+	for i, a := range args {
+		if a == "-p" {
+			hasP = true
+		}
+		if a == "-y" {
+			hasY = true
+		}
+		if a == "--output-format" && i+1 < len(args) && args[i+1] == "json" {
+			hasFormat = true
+		}
+		if a == "say hello" {
+			hasPrompt = true
+		}
+	}
+	if !hasP {
+		t.Error("missing -p flag")
+	}
+	if !hasY {
+		t.Error("missing -y flag")
+	}
+	if !hasFormat {
+		t.Error("missing --output-format json")
+	}
+	if !hasPrompt {
+		t.Error("missing prompt in args")
+	}
+}
+
+func TestGeminiAgent_Execute_NoAutoApprove(t *testing.T) {
+	mockRunner := &MockRunner{Stdout: "ok", ExitCode: 0}
+	agent := NewGeminiAgent(
+		WithGeminiRunner(mockRunner),
+		WithGeminiAutoApprove(false),
+	)
+
+	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	for _, a := range mockRunner.CapturedArgs {
+		if a == "-y" {
+			t.Error("-y flag should not be present when autoApprove is false")
+		}
+	}
+}
+
+func TestGeminiAgent_Execute_Timeout(t *testing.T) {
+	mockRunner := &MockRunner{
+		Delay: 2 * time.Second,
+	}
+	agent := NewGeminiAgent(WithGeminiRunner(mockRunner))
+
+	result, err := agent.Execute(context.Background(), ExecuteOptions{
+		Prompt:  "slow task",
+		Timeout: 50 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if result.ExitCode != -1 {
+		t.Errorf("ExitCode = %d, want -1", result.ExitCode)
+	}
+}
+
+func TestGeminiAgent_Execute_WithFiles(t *testing.T) {
+	tmpFile := t.TempDir() + "/test.go"
+	if err := os.WriteFile(tmpFile, []byte("package main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mockRunner := &MockRunner{Stdout: "done", ExitCode: 0}
+	agent := NewGeminiAgent(WithGeminiRunner(mockRunner))
+
+	_, err := agent.Execute(context.Background(), ExecuteOptions{
+		Prompt: "review this",
+		Files:  []string{tmpFile},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if mockRunner.CapturedStdin == "" {
+		t.Error("expected file context in stdin")
+	}
+}
+
+func TestGeminiAgent_Execute_Error(t *testing.T) {
+	mockRunner := &MockRunner{
+		Stderr:   "something went wrong",
+		ExitCode: 1,
+		Err:      errors.New("exit status 1"),
+	}
+	agent := NewGeminiAgent(WithGeminiRunner(mockRunner))
+
+	result, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "fail"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+}

--- a/internal/providers/gemini.go
+++ b/internal/providers/gemini.go
@@ -1,0 +1,272 @@
+// gemini.go implements the Provider interface for Google Gemini CLI.
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GeminiSession represents a Gemini CLI session JSON file.
+type GeminiSession struct {
+	SessionID   string          `json:"sessionId"`
+	ProjectHash string          `json:"projectHash"`
+	StartTime   string          `json:"startTime"`   // ISO 8601
+	LastUpdated string          `json:"lastUpdated"` // ISO 8601
+	Messages    []GeminiMessage `json:"messages"`
+}
+
+// GeminiMessage represents a single message in a Gemini session.
+type GeminiMessage struct {
+	ID        string       `json:"id"`
+	Timestamp string       `json:"timestamp"` // ISO 8601
+	Type      string       `json:"type"`      // "user" or "gemini"
+	Tokens    *GeminiTokens `json:"tokens,omitempty"`
+	Model     string       `json:"model,omitempty"`
+}
+
+// GeminiTokens holds per-message token counts from a Gemini session.
+type GeminiTokens struct {
+	Input    int64 `json:"input"`
+	Output   int64 `json:"output"`
+	Cached   int64 `json:"cached"`
+	Thoughts int64 `json:"thoughts"`
+	Tool     int64 `json:"tool"`
+	Total    int64 `json:"total"`
+}
+
+// Gemini wraps the Gemini CLI as a provider.
+type Gemini struct {
+	dataPath              string // Path to ~/.gemini
+	mu                    sync.RWMutex
+	lastUsedPercentSource string
+}
+
+// NewGemini creates a Gemini CLI provider.
+func NewGemini() *Gemini {
+	home, _ := os.UserHomeDir()
+	return &Gemini{
+		dataPath: filepath.Join(home, ".gemini"),
+	}
+}
+
+// NewGeminiWithPath creates a Gemini provider with a custom data path.
+func NewGeminiWithPath(dataPath string) *Gemini {
+	return &Gemini{
+		dataPath: dataPath,
+	}
+}
+
+// Name returns "gemini".
+func (g *Gemini) Name() string {
+	return "gemini"
+}
+
+// Execute runs a task via Gemini CLI.
+func (g *Gemini) Execute(ctx context.Context, task Task) (Result, error) {
+	// TODO: Implement - spawn gemini CLI process
+	return Result{}, nil
+}
+
+// Cost returns Gemini's token pricing (cents per 1K tokens).
+// Based on Gemini 2.5 Pro pricing.
+func (g *Gemini) Cost() (inputCents, outputCents int64) {
+	// Gemini 2.5 Pro: $1.25/M input, $10/M output (>200K context)
+	// Per 1K: 0.125 cents input, 1 cent output
+	return 13, 100 // in hundredths of a cent for precision
+}
+
+// DataPath returns the configured data path.
+func (g *Gemini) DataPath() string {
+	return g.dataPath
+}
+
+// ListSessionFiles finds all session JSON files under tmp/<project_hash>/chats/.
+func (g *Gemini) ListSessionFiles() ([]string, error) {
+	tmpDir := filepath.Join(g.dataPath, "tmp")
+	var sessions []string
+
+	err := filepath.WalkDir(tmpDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsPermission(err) {
+				return nil
+			}
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".json") && strings.Contains(path, "chats") {
+			sessions = append(sessions, path)
+		}
+		return nil
+	})
+
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return sessions, err
+}
+
+// ParseSessionFile reads and parses a Gemini session JSON file.
+func ParseGeminiSession(path string) (*GeminiSession, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading gemini session: %w", err)
+	}
+
+	var session GeminiSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("parsing gemini session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// SessionTokenUsage computes total token usage for a single session file.
+// Sums tokens across all gemini messages in the session.
+func SessionTokenUsage(session *GeminiSession) *GeminiTokens {
+	total := &GeminiTokens{}
+	for _, msg := range session.Messages {
+		if msg.Type != "gemini" || msg.Tokens == nil {
+			continue
+		}
+		total.Input += msg.Tokens.Input
+		total.Output += msg.Tokens.Output
+		total.Cached += msg.Tokens.Cached
+		total.Thoughts += msg.Tokens.Thoughts
+		total.Tool += msg.Tokens.Tool
+		total.Total += msg.Tokens.Total
+	}
+	return total
+}
+
+// GetTodayUsage returns today's total token usage across all sessions.
+func (g *Gemini) GetTodayUsage() (int64, error) {
+	usage, _, err := g.getTodayUsageWithSource()
+	return usage, err
+}
+
+func (g *Gemini) getTodayUsageWithSource() (int64, string, error) {
+	today := time.Now().Format("2006-01-02")
+	tokens, err := g.scanTokensSince(today)
+	if err != nil {
+		return 0, "", err
+	}
+	return tokens, "session-files", nil
+}
+
+// GetWeeklyUsage returns the last 7 days total token usage.
+func (g *Gemini) GetWeeklyUsage() (int64, error) {
+	usage, _, err := g.getWeeklyUsageWithSource()
+	return usage, err
+}
+
+func (g *Gemini) getWeeklyUsageWithSource() (int64, string, error) {
+	cutoff := time.Now().AddDate(0, 0, -6).Format("2006-01-02")
+	tokens, err := g.scanTokensSince(cutoff)
+	if err != nil {
+		return 0, "", err
+	}
+	return tokens, "session-files", nil
+}
+
+// scanTokensSince walks session files and sums tokens for sessions
+// whose startTime is on or after cutoffDate (YYYY-MM-DD).
+func (g *Gemini) scanTokensSince(cutoffDate string) (int64, error) {
+	sessions, err := g.ListSessionFiles()
+	if err != nil {
+		return 0, err
+	}
+
+	cutoff, err := time.Parse("2006-01-02", cutoffDate)
+	if err != nil {
+		return 0, fmt.Errorf("parsing cutoff date: %w", err)
+	}
+
+	var total int64
+	for _, path := range sessions {
+		// Quick mtime filter: skip files not modified since cutoff
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			continue
+		}
+
+		session, err := ParseGeminiSession(path)
+		if err != nil {
+			continue // skip corrupt files
+		}
+
+		// Parse session start time to check if it's in range
+		startTime, err := time.Parse(time.RFC3339, session.StartTime)
+		if err != nil {
+			startTime, err = time.Parse(time.RFC3339Nano, session.StartTime)
+			if err != nil {
+				continue
+			}
+		}
+		sessionDate := startTime.Local().Format("2006-01-02")
+		if sessionDate < cutoffDate {
+			continue
+		}
+
+		usage := SessionTokenUsage(session)
+		total += usage.Total
+	}
+
+	return total, nil
+}
+
+// GetUsedPercent calculates the used percentage based on mode and budget.
+func (g *Gemini) GetUsedPercent(mode string, weeklyBudget int64) (float64, error) {
+	if weeklyBudget <= 0 {
+		g.setLastUsedPercentSource("")
+		return 0, fmt.Errorf("invalid weekly budget: %d", weeklyBudget)
+	}
+
+	switch mode {
+	case "daily":
+		usage, source, err := g.getTodayUsageWithSource()
+		if err != nil {
+			g.setLastUsedPercentSource("")
+			return 0, err
+		}
+		g.setLastUsedPercentSource(source)
+		dailyBudget := weeklyBudget / 7
+		if dailyBudget <= 0 {
+			return 0, nil
+		}
+		return float64(usage) / float64(dailyBudget) * 100, nil
+
+	case "weekly":
+		usage, source, err := g.getWeeklyUsageWithSource()
+		if err != nil {
+			g.setLastUsedPercentSource("")
+			return 0, err
+		}
+		g.setLastUsedPercentSource(source)
+		return float64(usage) / float64(weeklyBudget) * 100, nil
+
+	default:
+		g.setLastUsedPercentSource("")
+		return 0, fmt.Errorf("invalid mode: %s (must be 'daily' or 'weekly')", mode)
+	}
+}
+
+// LastUsedPercentSource reports where the last GetUsedPercent call sourced data.
+func (g *Gemini) LastUsedPercentSource() string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.lastUsedPercentSource
+}
+
+func (g *Gemini) setLastUsedPercentSource(source string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lastUsedPercentSource = source
+}

--- a/internal/providers/gemini_test.go
+++ b/internal/providers/gemini_test.go
@@ -1,0 +1,248 @@
+package providers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewGemini_Defaults(t *testing.T) {
+	g := NewGemini()
+	if g.Name() != "gemini" {
+		t.Errorf("Name() = %q, want %q", g.Name(), "gemini")
+	}
+	if g.DataPath() == "" {
+		t.Error("expected non-empty DataPath")
+	}
+}
+
+func TestNewGeminiWithPath(t *testing.T) {
+	g := NewGeminiWithPath("/custom/path")
+	if g.DataPath() != "/custom/path" {
+		t.Errorf("DataPath() = %q, want %q", g.DataPath(), "/custom/path")
+	}
+}
+
+func TestGemini_Cost(t *testing.T) {
+	g := NewGemini()
+	input, output := g.Cost()
+	if input <= 0 || output <= 0 {
+		t.Errorf("Cost() = (%d, %d), want positive values", input, output)
+	}
+}
+
+func TestParseGeminiSession_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "session.json")
+
+	session := GeminiSession{
+		SessionID:   "test-session",
+		ProjectHash: "abc123",
+		StartTime:   time.Now().Format(time.RFC3339),
+		LastUpdated: time.Now().Format(time.RFC3339),
+		Messages: []GeminiMessage{
+			{ID: "1", Type: "user", Timestamp: time.Now().Format(time.RFC3339)},
+			{
+				ID: "2", Type: "gemini", Timestamp: time.Now().Format(time.RFC3339),
+				Model: "gemini-2.5-pro",
+				Tokens: &GeminiTokens{
+					Input: 1000, Output: 200, Cached: 500, Thoughts: 50, Tool: 0, Total: 1250,
+				},
+			},
+			{
+				ID: "3", Type: "gemini", Timestamp: time.Now().Format(time.RFC3339),
+				Model: "gemini-2.5-pro",
+				Tokens: &GeminiTokens{
+					Input: 2000, Output: 300, Cached: 1000, Thoughts: 100, Tool: 0, Total: 2400,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sessionPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseGeminiSession(sessionPath)
+	if err != nil {
+		t.Fatalf("ParseGeminiSession error: %v", err)
+	}
+
+	if parsed.SessionID != "test-session" {
+		t.Errorf("SessionID = %q, want %q", parsed.SessionID, "test-session")
+	}
+	if len(parsed.Messages) != 3 {
+		t.Errorf("messages count = %d, want 3", len(parsed.Messages))
+	}
+}
+
+func TestParseGeminiSession_NotExist(t *testing.T) {
+	_, err := ParseGeminiSession("/nonexistent/path/session.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestSessionTokenUsage(t *testing.T) {
+	session := &GeminiSession{
+		Messages: []GeminiMessage{
+			{Type: "user"},
+			{
+				Type:   "gemini",
+				Tokens: &GeminiTokens{Input: 1000, Output: 200, Total: 1200},
+			},
+			{
+				Type:   "gemini",
+				Tokens: &GeminiTokens{Input: 2000, Output: 300, Total: 2300},
+			},
+			{Type: "user"},
+			{
+				Type:   "gemini",
+				Tokens: nil, // no tokens (e.g., tool call)
+			},
+		},
+	}
+
+	usage := SessionTokenUsage(session)
+	if usage.Input != 3000 {
+		t.Errorf("Input = %d, want 3000", usage.Input)
+	}
+	if usage.Output != 500 {
+		t.Errorf("Output = %d, want 500", usage.Output)
+	}
+	if usage.Total != 3500 {
+		t.Errorf("Total = %d, want 3500", usage.Total)
+	}
+}
+
+func TestSessionTokenUsage_Empty(t *testing.T) {
+	session := &GeminiSession{
+		Messages: []GeminiMessage{
+			{Type: "user"},
+		},
+	}
+	usage := SessionTokenUsage(session)
+	if usage.Total != 0 {
+		t.Errorf("Total = %d, want 0", usage.Total)
+	}
+}
+
+func TestGemini_ListSessionFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create the expected directory structure
+	chatDir := filepath.Join(tmpDir, "tmp", "projecthash", "chats")
+	if err := os.MkdirAll(chatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a session file
+	sessionPath := filepath.Join(chatDir, "session-2026-02-17.json")
+	if err := os.WriteFile(sessionPath, []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a non-session file (should be ignored)
+	otherPath := filepath.Join(chatDir, "other.txt")
+	if err := os.WriteFile(otherPath, []byte("not a session"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGeminiWithPath(tmpDir)
+	sessions, err := g.ListSessionFiles()
+	if err != nil {
+		t.Fatalf("ListSessionFiles error: %v", err)
+	}
+
+	if len(sessions) != 1 {
+		t.Errorf("session count = %d, want 1", len(sessions))
+	}
+	if len(sessions) > 0 && sessions[0] != sessionPath {
+		t.Errorf("session path = %q, want %q", sessions[0], sessionPath)
+	}
+}
+
+func TestGemini_ListSessionFiles_NoDir(t *testing.T) {
+	g := NewGeminiWithPath("/nonexistent/path")
+	sessions, err := g.ListSessionFiles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	}
+}
+
+func TestGemini_GetUsedPercent_Daily(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create session with today's date
+	chatDir := filepath.Join(tmpDir, "tmp", "proj", "chats")
+	if err := os.MkdirAll(chatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	session := GeminiSession{
+		SessionID: "test",
+		StartTime: now.Format(time.RFC3339),
+		Messages: []GeminiMessage{
+			{
+				Type:   "gemini",
+				Tokens: &GeminiTokens{Total: 10000},
+			},
+		},
+	}
+	data, _ := json.Marshal(session)
+	sessionPath := filepath.Join(chatDir, "session-today.json")
+	if err := os.WriteFile(sessionPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGeminiWithPath(tmpDir)
+	// weeklyBudget = 70000 -> dailyBudget = 10000 -> 10000/10000 = 100%
+	pct, err := g.GetUsedPercent("daily", 70000)
+	if err != nil {
+		t.Fatalf("GetUsedPercent error: %v", err)
+	}
+	if pct != 100.0 {
+		t.Errorf("pct = %.1f, want 100.0", pct)
+	}
+}
+
+func TestGemini_GetUsedPercent_InvalidMode(t *testing.T) {
+	g := NewGeminiWithPath(t.TempDir())
+	_, err := g.GetUsedPercent("invalid", 70000)
+	if err == nil {
+		t.Error("expected error for invalid mode")
+	}
+}
+
+func TestGemini_GetUsedPercent_InvalidBudget(t *testing.T) {
+	g := NewGeminiWithPath(t.TempDir())
+	_, err := g.GetUsedPercent("daily", 0)
+	if err == nil {
+		t.Error("expected error for zero budget")
+	}
+}
+
+func TestGemini_LastUsedPercentSource(t *testing.T) {
+	g := NewGemini()
+	if src := g.LastUsedPercentSource(); src != "" {
+		t.Errorf("initial source = %q, want empty", src)
+	}
+
+	// Trigger a GetUsedPercent call to set the source
+	tmpDir := t.TempDir()
+	g = NewGeminiWithPath(tmpDir)
+	_, _ = g.GetUsedPercent("daily", 70000)
+	if src := g.LastUsedPercentSource(); src != "session-files" {
+		t.Errorf("source = %q, want %q", src, "session-files")
+	}
+}


### PR DESCRIPTION
## Summary

- Add full Gemini CLI provider support following the existing Claude/Codex two-layer architecture
- Provider layer reads `~/.gemini/tmp/` session files for budget/usage tracking
- Agent layer spawns `gemini -p <prompt> -m <model> -y --output-format json` for headless task execution
- Config adds `gemini` with `enabled`, `data_path`, and `model` fields
- Wired into all subcommands: run, daemon, budget, preview, doctor, task, snapshot

## Test plan

- [x] 10 provider unit tests (session parsing, token summing, usage percent, edge cases)
- [x] 8 agent unit tests (defaults, options, execution, timeout, file context, errors)
- [x] All 23 packages pass (`go test ./...`)
- [x] Verified end-to-end locally: ran real tasks, confirmed token consumption tracked correctly in `nightshift budget`
- [x] Confirmed model selection works (`gemini-3-pro-preview` via config)

Closes #24