### PR TITLE
feat: add --timeout flag to run and daemon commands

### DIFF
--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -64,9 +64,11 @@ var daemonStatusCmd = &cobra.Command{
 }
 
 var daemonForegroundFlag bool
+var daemonTimeoutFlag time.Duration
 
 func init() {
 	daemonStartCmd.Flags().BoolVarP(&daemonForegroundFlag, "foreground", "f", false, "Run in foreground (don't daemonize)")
+	daemonStartCmd.Flags().DurationVar(&daemonTimeoutFlag, "timeout", orchestrator.DefaultAgentTimeout, "Per-agent execution timeout")
 	daemonCmd.AddCommand(daemonStartCmd)
 	daemonCmd.AddCommand(daemonStopCmd)
 	daemonCmd.AddCommand(daemonStatusCmd)
@@ -155,7 +157,7 @@ func runDaemonStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting executable: %w", err)
 	}
 
-	daemonCmd := exec.Command(executable, "daemon", "start", "--foreground")
+	daemonCmd := exec.Command(executable, "daemon", "start", "--foreground", "--timeout", daemonTimeoutFlag.String())
 	daemonCmd.Stdout = nil
 	daemonCmd.Stderr = nil
 	daemonCmd.Stdin = nil
@@ -323,7 +325,7 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 			orchestrator.WithAgent(choice.agent),
 			orchestrator.WithConfig(orchestrator.Config{
 				MaxIterations: 3,
-				AgentTimeout:  30 * time.Minute,
+				AgentTimeout:  daemonTimeoutFlag,
 			}),
 			orchestrator.WithLogger(logging.Component("orchestrator")),
 		)

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -113,6 +113,7 @@ func init() {
 	runCmd.Flags().Bool("random-task", false, "Pick a random task from eligible tasks")
 	runCmd.Flags().StringP("branch", "b", "", "Base branch for new feature branches (defaults to current branch)")
 	runCmd.Flags().Bool("no-color", false, "Disable colored output")
+	runCmd.Flags().Duration("timeout", orchestrator.DefaultAgentTimeout, "Per-agent execution timeout")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -125,6 +126,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	ignoreBudget, _ := cmd.Flags().GetBool("ignore-budget")
 	yes, _ := cmd.Flags().GetBool("yes")
 	randomTask, _ := cmd.Flags().GetBool("random-task")
+	agentTimeout, _ := cmd.Flags().GetDuration("timeout")
 
 	branch, _ := cmd.Flags().GetString("branch")
 
@@ -245,6 +247,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		dryRun:       dryRun,
 		yes:          yes,
 		branch:       branch,
+		agentTimeout: agentTimeout,
 		log:          log,
 	}
 	if !dryRun {
@@ -266,6 +269,7 @@ type executeRunParams struct {
 	dryRun       bool
 	yes          bool
 	branch       string
+	agentTimeout time.Duration
 	report       *runReport
 	log          *logging.Logger
 }
@@ -650,7 +654,7 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 			orchestrator.WithAgent(choice.agent),
 			orchestrator.WithConfig(orchestrator.Config{
 				MaxIterations: 3,
-				AgentTimeout:  30 * time.Minute,
+				AgentTimeout:  p.agentTimeout,
 			}),
 			orchestrator.WithLogger(logging.Component("orchestrator")),
 		}


### PR DESCRIPTION
## Summary
- Add `--timeout` duration flag to `nightshift run` and `nightshift daemon start`, defaulting to 30min (`orchestrator.DefaultAgentTimeout`)
- Replace hardcoded timeouts so users can override via CLI (e.g. `--timeout 2h` for local testing)
- Forward `--timeout` through the daemon re-exec path so the daemonized child inherits the value

## Test plan
- [x] `go build ./cmd/nightshift/` compiles clean
- [x] `nightshift run --help` shows `--timeout` flag with 30m default
- [x] `nightshift daemon start --help` shows `--timeout` flag with 30m default
- [x] `nightshift task run adr-draft --provider claude --timeout 1h --dry-run` shows `Timeout: 1h0m0s`
- [x] Default behavior unchanged (30min) when flag is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)