### PR TITLE
fix: capture partial output on timeout and kill process groups

### DIFF
--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -40,3 +40,11 @@ type ExecuteResult struct {
 func (r *ExecuteResult) IsSuccess() bool {
 	return r.ExitCode == 0 && r.Error == ""
 }
+
+// truncate returns s trimmed to maxLen characters, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -26,6 +27,14 @@ func (r *ExecRunner) Run(ctx context.Context, name string, args []string, dir st
 	cmd := exec.CommandContext(ctx, name, args...)
 	if dir != "" {
 		cmd.Dir = dir
+	}
+
+	// Use process group so timeout kills the entire process tree,
+	// not just the direct child (e.g. Node wrapper leaves Rust child alive).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Kill the entire process group (negative PID)
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
 
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -154,6 +163,12 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 	// Check for context timeout
 	if ctx.Err() == context.DeadlineExceeded {
 		result.Error = fmt.Sprintf("timeout after %v", timeout)
+		if stderr != "" {
+			result.Error = fmt.Sprintf("timeout after %v; stderr: %s", timeout, truncate(stderr, 2000))
+		}
+		if stdout != "" {
+			result.Output = stdout
+		}
 		result.ExitCode = -1
 		return result, ctx.Err()
 	}
@@ -165,6 +180,9 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 			result.Error = stderr
 		} else {
 			result.Error = err.Error()
+			if stderr != "" {
+				result.Error = fmt.Sprintf("%s; stderr: %s", err.Error(), truncate(stderr, 2000))
+			}
 		}
 		return result, err
 	}

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -121,6 +121,12 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 	// Check for context timeout
 	if ctx.Err() == context.DeadlineExceeded {
 		result.Error = fmt.Sprintf("timeout after %v", timeout)
+		if stderr != "" {
+			result.Error = fmt.Sprintf("timeout after %v; stderr: %s", timeout, truncate(stderr, 2000))
+		}
+		if stdout != "" {
+			result.Output = stdout
+		}
 		result.ExitCode = -1
 		return result, ctx.Err()
 	}
@@ -132,6 +138,9 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 			result.Error = stderr
 		} else {
 			result.Error = err.Error()
+			if stderr != "" {
+				result.Error = fmt.Sprintf("%s; stderr: %s", err.Error(), truncate(stderr, 2000))
+			}
 		}
 		return result, err
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -445,10 +445,24 @@ func (o *Orchestrator) plan(ctx context.Context, task *tasks.Task, workDir strin
 		Timeout: o.config.AgentTimeout,
 	})
 	if err != nil {
+		if execResult != nil && execResult.Output != "" {
+			o.logger.WarnCtx("agent produced partial output before error", map[string]any{
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent execution: %w", err)
 	}
 
 	if !execResult.IsSuccess() {
+		if execResult.Output != "" {
+			o.logger.WarnCtx("agent produced output but reported error", map[string]any{
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent returned error: %s", execResult.Error)
 	}
 
@@ -492,10 +506,26 @@ func (o *Orchestrator) implement(ctx context.Context, task *tasks.Task, plan *Pl
 		Timeout: o.config.AgentTimeout,
 	})
 	if err != nil {
+		if execResult != nil && execResult.Output != "" {
+			o.logger.WarnCtx("agent produced partial output before error", map[string]any{
+				"phase":      "implement",
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent execution: %w", err)
 	}
 
 	if !execResult.IsSuccess() {
+		if execResult.Output != "" {
+			o.logger.WarnCtx("agent produced output but reported error", map[string]any{
+				"phase":      "implement",
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent returned error: %s", execResult.Error)
 	}
 
@@ -590,10 +620,26 @@ func (o *Orchestrator) review(ctx context.Context, task *tasks.Task, impl *Imple
 		Timeout: o.config.AgentTimeout,
 	})
 	if err != nil {
+		if execResult != nil && execResult.Output != "" {
+			o.logger.WarnCtx("agent produced partial output before error", map[string]any{
+				"phase":      "review",
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent execution: %w", err)
 	}
 
 	if !execResult.IsSuccess() {
+		if execResult.Output != "" {
+			o.logger.WarnCtx("agent produced output but reported error", map[string]any{
+				"phase":      "review",
+				"output_len": len(execResult.Output),
+				"output":     truncateStr(execResult.Output, 1000),
+				"error":      execResult.Error,
+			})
+		}
 		return nil, fmt.Errorf("agent returned error: %s", execResult.Error)
 	}
 
@@ -888,4 +934,12 @@ func CurrentBranch(ctx context.Context, workDir string) (string, error) {
 		return "", fmt.Errorf("git rev-parse --abbrev-ref HEAD: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// truncateStr returns s trimmed to maxLen characters, appending "..." if truncated.
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }


### PR DESCRIPTION
## Summary
- `ExecRunner` now uses `Setpgid` + process group kill (`syscall.Kill(-pid, SIGKILL)`) so context timeouts kill the entire process tree. Previously, `exec.CommandContext` only killed the direct child process — this was specifically a problem with the Codex provider, where the `codex` Node.js wrapper spawns a separate Rust binary as a child process. On timeout, Go killed the Node wrapper but the Rust child kept running, causing `cmd.Run()` to block on open stdout/stderr pipes until the orphaned process eventually exited. In practice this meant agent timeouts were completely non-functional for Codex.
- Agent `Execute()` methods now preserve partial stdout/stderr on timeout and include stderr in error messages, instead of discarding all output.
- Orchestrator `plan()`, `implement()`, and `review()` now log partial agent output as a warning when the agent errors but produced output, aiding debugging of timeout/crash scenarios.

## Test plan
- [x] Verified with `nightshift task run --timeout 15s`: before fix, Codex process hung 2+ min past timeout (Node wrapper killed, Rust child alive); after fix, clean kill at exactly 15s with no orphaned processes
- [x] `go test ./internal/agents/... ./internal/orchestrator/...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)