### PR TITLE
fix: resolve lint warnings in copilot provider and helpers

### DIFF
--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -70,9 +70,6 @@ func newCopilotAgentFromConfig(cfg *config.Config) *agents.CopilotAgent {
 	opts := []agents.CopilotOption{
 		agents.WithCopilotBinaryPath(binaryPath),
 	}
-	if cfg.Providers.Copilot.DangerouslySkipPermissions {
-		// When enabled, this should pass --allow-all-tools
-		// Currently handled via config, future: add agent option
-	}
+	// TODO: when DangerouslySkipPermissions is enabled, pass --allow-all-tools flag to copilot agent
 	return agents.NewCopilotAgent(opts...)
 }

--- a/internal/providers/copilot.go
+++ b/internal/providers/copilot.go
@@ -24,9 +24,7 @@ import (
 // - No way to query remaining quota from GitHub servers
 // - Assumes each prompt execution = 1 premium request (conservative estimate)
 type Copilot struct {
-	dataPath     string    // Path to ~/.copilot for tracking data
-	requestCount int64     // Local request counter
-	lastReset    time.Time // Last monthly reset timestamp
+	dataPath string // Path to ~/.copilot for tracking data
 }
 
 // CopilotUsageData persists usage tracking between sessions.


### PR DESCRIPTION
Fixes CI lint failures:

- Remove unused `requestCount` and `lastReset` fields from `Copilot` struct (the separate `CopilotUsageData` struct handles persistence)
- Remove empty `if` branch (SA9003) for `cfg.Providers.Copilot.DangerouslySkipPermissions`, replaced with TODO comment