### PR TITLE
refactor: replace WriteString(fmt.Sprintf) with fmt.Fprintf

### DIFF
--- a/cmd/nightshift/commands/report.go
+++ b/cmd/nightshift/commands/report.go
@@ -896,14 +896,14 @@ func renderReportBudget(styles reportStyles, runs []reportRun) string {
 		b.WriteString("\n")
 
 		if summary.BudgetStart > 0 {
-			b.WriteString(fmt.Sprintf("  %s %s used / %s start (%s remaining)\n",
+			fmt.Fprintf(&b, "  %s %s used / %s start (%s remaining)\n",
 				styles.Label.Render("Budget:"),
 				formatTokensCompact(summary.TokensUsed),
 				formatTokensCompact(summary.BudgetStart),
 				formatTokensCompact(summary.BudgetRemaining),
-			))
+			)
 		} else if summary.TokensUsed > 0 {
-			b.WriteString(fmt.Sprintf("  %s %s\n", styles.Label.Render("Tokens:"), formatTokensCompact(summary.TokensUsed)))
+			fmt.Fprintf(&b, "  %s %s\n", styles.Label.Render("Tokens:"), formatTokensCompact(summary.TokensUsed))
 		} else {
 			b.WriteString("  No budget data recorded\n")
 		}

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -341,7 +341,7 @@ func (m *setupModel) View() string {
 	case stepConfig:
 		b.WriteString(styleAccent.Render("Global config"))
 		b.WriteString("\n")
-		b.WriteString(fmt.Sprintf("  %s\n", m.configPath))
+		fmt.Fprintf(&b, "  %s\n", m.configPath)
 		if m.configExist {
 			b.WriteString("  Status: found (will update in place)\n")
 		} else {
@@ -372,7 +372,7 @@ func (m *setupModel) View() string {
 			if label == "" {
 				label = "(unset)"
 			}
-			b.WriteString(fmt.Sprintf(" %s %s\n", cursor, label))
+			fmt.Fprintf(&b, " %s %s\n", cursor, label)
 		}
 		if m.projectErr != "" {
 			b.WriteString("\nError: " + m.projectErr + "\n")
@@ -419,7 +419,7 @@ func (m *setupModel) View() string {
 			if preset == setup.PresetBalanced {
 				label += " (recommended)"
 			}
-			b.WriteString(fmt.Sprintf(" %s %s\n", cursor, label))
+			fmt.Fprintf(&b, " %s %s\n", cursor, label)
 		}
 	case stepTaskSelect:
 		b.WriteString(styleAccent.Render("Tasks"))
@@ -438,7 +438,7 @@ func (m *setupModel) View() string {
 				if item.selected {
 					check = "x"
 				}
-				b.WriteString(fmt.Sprintf(" %s [%s] %-22s %s\n", cursor, check, item.def.Type, item.def.Name))
+				fmt.Fprintf(&b, " %s [%s] %-22s %s\n", cursor, check, item.def.Type, item.def.Name)
 			}
 		}
 		if m.taskErr != "" {
@@ -510,8 +510,8 @@ func (m *setupModel) View() string {
 		}
 		b.WriteString("Nightshift isn’t in PATH yet. The daemon and CLI shortcuts need it there.\n")
 		if m.pathShell != "" && m.pathConfig != "" {
-			b.WriteString(fmt.Sprintf("Shell: %s\n", m.pathShell))
-			b.WriteString(fmt.Sprintf("Config: %s\n", m.pathConfig))
+			fmt.Fprintf(&b, "Shell: %s\n", m.pathShell)
+			fmt.Fprintf(&b, "Config: %s\n", m.pathConfig)
 		}
 		b.WriteString("\nSelect action:\n")
 		for i, option := range m.pathOptions {
@@ -519,7 +519,7 @@ func (m *setupModel) View() string {
 			if i == m.pathCursor {
 				cursor = ">"
 			}
-			b.WriteString(fmt.Sprintf(" %s %s\n", cursor, option.label))
+			fmt.Fprintf(&b, " %s %s\n", cursor, option.label)
 		}
 		if m.pathErr != "" {
 			b.WriteString("\nError: " + m.pathErr + "\n")
@@ -538,7 +538,7 @@ func (m *setupModel) View() string {
 	case stepDaemon:
 		b.WriteString(styleAccent.Render("Daemon setup"))
 		b.WriteString("\n\n")
-		b.WriteString(fmt.Sprintf("Service: %s\n", m.serviceType))
+		fmt.Fprintf(&b, "Service: %s\n", m.serviceType)
 		if m.serviceState.installed {
 			b.WriteString("Status: installed\n")
 		} else {
@@ -555,7 +555,7 @@ func (m *setupModel) View() string {
 			if i == m.daemonCursor {
 				cursor = ">"
 			}
-			b.WriteString(fmt.Sprintf(" %s %s\n", cursor, label))
+			fmt.Fprintf(&b, " %s %s\n", cursor, label)
 		}
 		b.WriteString("\nPress Enter to apply.\n")
 	case stepFinish:
@@ -1495,37 +1495,37 @@ func copyFile(src, dst string) error {
 func renderEnvChecks(cfg *config.Config) string {
 	var b strings.Builder
 	if _, err := execLookPath("nightshift"); err != nil {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleWarn.Render("Heads up:"), "nightshift not found in PATH yet. Setup can add it for you."))
+		fmt.Fprintf(&b, "  %s %s\n", styleWarn.Render("Heads up:"), "nightshift not found in PATH yet. Setup can add it for you.")
 	} else {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "nightshift is in PATH"))
+		fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "nightshift is in PATH")
 	}
 	if _, err := execLookPath("tmux"); err != nil {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleWarn.Render("Note:"), "tmux not found (calibration will be local-only)"))
+		fmt.Fprintf(&b, "  %s %s\n", styleWarn.Render("Note:"), "tmux not found (calibration will be local-only)")
 	} else {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "tmux available"))
+		fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "tmux available")
 	}
 	// Check for Copilot CLI (gh or copilot binary)
 	_, ghErr := execLookPath("gh")
 	_, copilotErr := execLookPath("copilot")
 	if ghErr != nil && copilotErr != nil {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleWarn.Render("Note:"), "Copilot CLI not found (install via 'gh' or native 'copilot')"))
+		fmt.Fprintf(&b, "  %s %s\n", styleWarn.Render("Note:"), "Copilot CLI not found (install via 'gh' or native 'copilot')")
 	} else if ghErr == nil {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "gh CLI available (use 'gh copilot')"))
+		fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "gh CLI available (use 'gh copilot')")
 	} else {
-		b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "copilot CLI available"))
+		fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "copilot CLI available")
 	}
 	if cfg.Providers.Claude.Enabled {
 		if _, err := os.Stat(cfg.ExpandedProviderPath("claude")); err != nil {
-			b.WriteString(fmt.Sprintf("  %s %s\n", styleWarn.Render("Note:"), "Claude data path not found"))
+			fmt.Fprintf(&b, "  %s %s\n", styleWarn.Render("Note:"), "Claude data path not found")
 		} else {
-			b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "Claude data path found"))
+			fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "Claude data path found")
 		}
 	}
 	if cfg.Providers.Codex.Enabled {
 		if _, err := os.Stat(cfg.ExpandedProviderPath("codex")); err != nil {
-			b.WriteString(fmt.Sprintf("  %s %s\n", styleWarn.Render("Note:"), "Codex data path not found"))
+			fmt.Fprintf(&b, "  %s %s\n", styleWarn.Render("Note:"), "Codex data path not found")
 		} else {
-			b.WriteString(fmt.Sprintf("  %s %s\n", styleOk.Render("OK:"), "Codex data path found"))
+			fmt.Fprintf(&b, "  %s %s\n", styleOk.Render("OK:"), "Codex data path found")
 		}
 	}
 	return b.String()

--- a/internal/analysis/report.go
+++ b/internal/analysis/report.go
@@ -87,8 +87,8 @@ func (rg *ReportGenerator) RenderMarkdown(report *Report) string {
 	var buf bytes.Buffer
 
 	// Header
-	buf.WriteString(fmt.Sprintf("# Bus Factor Analysis - %s\n\n", report.Component))
-	buf.WriteString(fmt.Sprintf("*Generated: %s*\n\n", report.ReportedAt))
+	fmt.Fprintf(&buf, "# Bus Factor Analysis - %s\n\n", report.Component)
+	fmt.Fprintf(&buf, "*Generated: %s*\n\n", report.ReportedAt)
 
 	// Metrics section
 	buf.WriteString("## Ownership Metrics\n\n")

--- a/internal/reporting/run_report.go
+++ b/internal/reporting/run_report.go
@@ -34,22 +34,22 @@ func RenderRunReport(results *RunResults, logPath string) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("# Nightshift Run - %s\n\n", results.StartTime.Format("2006-01-02 15:04")))
+	fmt.Fprintf(&buf, "# Nightshift Run - %s\n\n", results.StartTime.Format("2006-01-02 15:04"))
 
 	buf.WriteString("## Summary\n")
 	duration := results.EndTime.Sub(results.StartTime)
-	buf.WriteString(fmt.Sprintf("- Duration: %s\n", formatDuration(duration)))
+	fmt.Fprintf(&buf, "- Duration: %s\n", formatDuration(duration))
 	if results.StartBudget > 0 {
-		buf.WriteString(fmt.Sprintf("- Budget: %s start, %s used, %s remaining\n",
+		fmt.Fprintf(&buf, "- Budget: %s start, %s used, %s remaining\n",
 			formatTokens(results.StartBudget),
 			formatTokens(results.UsedBudget),
 			formatTokens(results.RemainingBudget),
-		))
+		)
 	}
-	buf.WriteString(fmt.Sprintf("- Tasks: %d completed, %d failed, %d skipped\n",
-		len(completed), len(failed), len(skipped)))
+	fmt.Fprintf(&buf, "- Tasks: %d completed, %d failed, %d skipped\n",
+		len(completed), len(failed), len(skipped))
 	if logPath != "" {
-		buf.WriteString(fmt.Sprintf("- Logs: %s\n", logPath))
+		fmt.Fprintf(&buf, "- Logs: %s\n", logPath)
 	}
 	buf.WriteString("\n")
 

--- a/internal/reporting/summary.go
+++ b/internal/reporting/summary.go
@@ -111,7 +111,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	var buf bytes.Buffer
 
 	// Header
-	buf.WriteString(fmt.Sprintf("# Nightshift Summary - %s\n\n", summary.Date.Format("2006-01-02")))
+	fmt.Fprintf(&buf, "# Nightshift Summary - %s\n\n", summary.Date.Format("2006-01-02"))
 
 	// Budget section
 	buf.WriteString("## Budget\n")
@@ -119,9 +119,9 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	if summary.BudgetStart > 0 {
 		usedPercent = (summary.BudgetUsed * 100) / summary.BudgetStart
 	}
-	buf.WriteString(fmt.Sprintf("- Started with: %s tokens\n", formatTokens(summary.BudgetStart)))
-	buf.WriteString(fmt.Sprintf("- Used: %s tokens (%d%%)\n", formatTokens(summary.BudgetUsed), usedPercent))
-	buf.WriteString(fmt.Sprintf("- Remaining: %s tokens\n\n", formatTokens(summary.BudgetRemaining)))
+	fmt.Fprintf(&buf, "- Started with: %s tokens\n", formatTokens(summary.BudgetStart))
+	fmt.Fprintf(&buf, "- Used: %s tokens (%d%%)\n", formatTokens(summary.BudgetUsed), usedPercent)
+	fmt.Fprintf(&buf, "- Remaining: %s tokens\n\n", formatTokens(summary.BudgetRemaining))
 
 	// Projects processed section
 	if len(summary.ProjectCounts) > 0 {
@@ -145,7 +145,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 			if p.count != 1 {
 				taskWord = "tasks"
 			}
-			buf.WriteString(fmt.Sprintf("%d. **%s** (%d %s)\n", i+1, filepath.Base(p.name), p.count, taskWord))
+			fmt.Fprintf(&buf, "%d. **%s** (%d %s)\n", i+1, filepath.Base(p.name), p.count, taskWord)
 		}
 		buf.WriteString("\n")
 	}
@@ -163,7 +163,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	if len(summary.FailedTasks) > 0 {
 		buf.WriteString("## Tasks Failed\n")
 		for _, task := range summary.FailedTasks {
-			buf.WriteString(fmt.Sprintf("- **%s**: %s\n", task.Title, task.SkipReason))
+			fmt.Fprintf(&buf, "- **%s**: %s\n", task.Title, task.SkipReason)
 		}
 		buf.WriteString("\n")
 	}
@@ -176,7 +176,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 			if reason == "" {
 				reason = "insufficient budget"
 			}
-			buf.WriteString(fmt.Sprintf("- %s (%s)\n", task.Title, reason))
+			fmt.Fprintf(&buf, "- %s (%s)\n", task.Title, reason)
 		}
 		buf.WriteString("\n")
 	}
@@ -186,7 +186,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	if len(whatsNext) > 0 {
 		buf.WriteString("## What's Next?\n")
 		for _, item := range whatsNext {
-			buf.WriteString(fmt.Sprintf("- %s\n", item))
+			fmt.Fprintf(&buf, "- %s\n", item)
 		}
 		buf.WriteString("\n")
 	}
@@ -194,7 +194,7 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	// Run duration
 	if !results.StartTime.IsZero() && !results.EndTime.IsZero() {
 		duration := results.EndTime.Sub(results.StartTime)
-		buf.WriteString(fmt.Sprintf("---\n*Run duration: %s*\n", formatDuration(duration)))
+		fmt.Fprintf(&buf, "---\n*Run duration: %s*\n", formatDuration(duration))
 	}
 
 	return buf.String()
@@ -398,26 +398,26 @@ func (g *Generator) formatSlackSummary(summary *Summary) string {
 	if summary.BudgetStart > 0 {
 		usedPercent = (summary.BudgetUsed * 100) / summary.BudgetStart
 	}
-	buf.WriteString(fmt.Sprintf("*Budget:* %s used (%d%%) of %s\n\n",
-		formatTokens(summary.BudgetUsed), usedPercent, formatTokens(summary.BudgetStart)))
+	fmt.Fprintf(&buf, "*Budget:* %s used (%d%%) of %s\n\n",
+		formatTokens(summary.BudgetUsed), usedPercent, formatTokens(summary.BudgetStart))
 
 	// Tasks completed
 	if len(summary.CompletedTasks) > 0 {
-		buf.WriteString(fmt.Sprintf("*Tasks Completed:* %d\n", len(summary.CompletedTasks)))
+		fmt.Fprintf(&buf, "*Tasks Completed:* %d\n", len(summary.CompletedTasks))
 		for _, task := range summary.CompletedTasks {
-			buf.WriteString(fmt.Sprintf("  - %s\n", task.Title))
+			fmt.Fprintf(&buf, "  - %s\n", task.Title)
 		}
 		buf.WriteString("\n")
 	}
 
 	// Projects
 	if len(summary.ProjectCounts) > 0 {
-		buf.WriteString(fmt.Sprintf("*Projects:* %d processed\n", len(summary.ProjectCounts)))
+		fmt.Fprintf(&buf, "*Projects:* %d processed\n", len(summary.ProjectCounts))
 	}
 
 	// Skipped
 	if len(summary.SkippedTasks) > 0 {
-		buf.WriteString(fmt.Sprintf("\n_Skipped %d tasks (budget constraints)_", len(summary.SkippedTasks)))
+		fmt.Fprintf(&buf, "\n_Skipped %d tasks (budget constraints)_", len(summary.SkippedTasks))
 	}
 
 	return buf.String()


### PR DESCRIPTION
Extracts the formatting refactor from #31.

  buf.WriteString(fmt.Sprintf(...)) allocates a temporary string unnecessarily. fmt.Fprintf(&buf, ...) writes directly to the buffer, avoiding the intermediate allocation. staticcheck flags this as S1039.

  43 occurrences replaced across:

   - cmd/nightshift/commands/report.go
   - cmd/nightshift/commands/setup.go
   - internal/analysis/report.go
   - internal/reporting/run_report.go
   - internal/reporting/summary.goes.