### PR TITLE
fix: serialize provider config with correct YAML key names

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -1918,7 +1918,10 @@ func mustExecutablePath() string {
 }
 
 func writeGlobalConfig(cfg *config.Config) error {
-	configPath := config.GlobalConfigPath()
+	return writeGlobalConfigToPath(cfg, config.GlobalConfigPath())
+}
+
+func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
@@ -1943,7 +1946,20 @@ func writeGlobalConfig(cfg *config.Config) error {
 	v.Set("budget.snapshot_retention_days", cfg.Budget.SnapshotRetentionDays)
 	v.Set("budget.week_start_day", cfg.Budget.WeekStartDay)
 
-	v.Set("providers", cfg.Providers)
+	// Providers: set fields individually to match mapstructure tag names (fixes #20)
+	v.Set("providers.claude.enabled", cfg.Providers.Claude.Enabled)
+	v.Set("providers.claude.data_path", cfg.Providers.Claude.DataPath)
+	v.Set("providers.claude.dangerously_skip_permissions", cfg.Providers.Claude.DangerouslySkipPermissions)
+	v.Set("providers.claude.dangerously_bypass_approvals_and_sandbox", cfg.Providers.Claude.DangerouslyBypassApprovalsAndSandbox)
+	v.Set("providers.codex.enabled", cfg.Providers.Codex.Enabled)
+	v.Set("providers.codex.data_path", cfg.Providers.Codex.DataPath)
+	v.Set("providers.codex.dangerously_skip_permissions", cfg.Providers.Codex.DangerouslySkipPermissions)
+	v.Set("providers.codex.dangerously_bypass_approvals_and_sandbox", cfg.Providers.Codex.DangerouslyBypassApprovalsAndSandbox)
+	v.Set("providers.copilot.enabled", cfg.Providers.Copilot.Enabled)
+	v.Set("providers.copilot.data_path", cfg.Providers.Copilot.DataPath)
+	v.Set("providers.copilot.dangerously_skip_permissions", cfg.Providers.Copilot.DangerouslySkipPermissions)
+	v.Set("providers.copilot.dangerously_bypass_approvals_and_sandbox", cfg.Providers.Copilot.DangerouslyBypassApprovalsAndSandbox)
+	v.Set("providers.preference", cfg.Providers.Preference)
 	v.Set("projects", cfg.Projects)
 	v.Set("tasks.enabled", cfg.Tasks.Enabled)
 

--- a/cmd/nightshift/commands/setup_test.go
+++ b/cmd/nightshift/commands/setup_test.go
@@ -174,3 +174,67 @@ func TestMakeTaskItems_PreservesExplicitEnabledTasks(t *testing.T) {
 		t.Fatal("expected bug-finder task to exist in setup list")
 	}
 }
+
+func TestWriteGlobalConfig_ProviderYAMLKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	// Seed an initial config so WriteConfig can overwrite it.
+	if err := os.WriteFile(cfgPath, []byte("# nightshift config\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Providers.Claude.Enabled = true
+	cfg.Providers.Claude.DataPath = "/tmp/claude-data"
+	cfg.Providers.Claude.DangerouslySkipPermissions = true
+	cfg.Providers.Claude.DangerouslyBypassApprovalsAndSandbox = true
+	cfg.Providers.Codex.DataPath = "/tmp/codex-data"
+
+	if err := writeGlobalConfigToPath(cfg, cfgPath); err != nil {
+		t.Fatalf("writeGlobalConfigToPath: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(raw)
+
+	// Must use snake_case mapstructure tag names, not lowercased Go field names.
+	wantKeys := []string{
+		"data_path",
+		"dangerously_skip_permissions",
+		"dangerously_bypass_approvals_and_sandbox",
+	}
+	for _, key := range wantKeys {
+		if !containsStr(content, key) {
+			t.Errorf("expected YAML key %q in config output, got:\n%s", key, content)
+		}
+	}
+
+	// Must NOT contain the lowercased Go field name variants.
+	badKeys := []string{
+		"datapath",
+		"dangerouslyskippermissions",
+		"dangerouslybypassapprovalsandsandbox",
+	}
+	for _, key := range badKeys {
+		if containsStr(content, key) {
+			t.Errorf("found incorrect lowercased key %q in config output, got:\n%s", key, content)
+		}
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #20. Replaces bulk v.Set("providers", cfg.Providers) with individual field sets to preserve mapstructure tag names in generated YAML config.