### PR TITLE
Add binary project parallel execution mode for run and daemon

### DIFF
--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -291,7 +291,7 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 	// Create task selector
 	selector := tasks.NewSelector(cfg, st)
 
-	var tasksRun, tasksCompleted, tasksFailed int
+	runnableProjects := make([]preflightProject, 0, len(projects))
 
 	// Process each project
 	for _, projectPath := range projects {
@@ -321,15 +321,6 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 			break
 		}
 
-		orch := orchestrator.New(
-			orchestrator.WithAgent(choice.agent),
-			orchestrator.WithConfig(orchestrator.Config{
-				MaxIterations: 3,
-				AgentTimeout:  daemonTimeoutFlag,
-			}),
-			orchestrator.WithLogger(logging.Component("orchestrator")),
-		)
-
 		// Select tasks
 		selectedTasks := selector.SelectTopN(allowance.Allowance, projectPath, 5)
 		if len(selectedTasks) == 0 {
@@ -345,147 +336,28 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 			continue
 		}
 
-		log.InfoCtx("processing project", map[string]any{
-			"project":  projectPath,
-			"tasks":    len(selectedTasks),
-			"budget":   allowance.Allowance,
-			"provider": choice.name,
+		runnableProjects = append(runnableProjects, preflightProject{
+			path:     projectPath,
+			tasks:    selectedTasks,
+			provider: choice,
 		})
+	}
 
-		// Execute each selected task
-		projectStart := time.Now()
-		projectTaskTypes := make([]string, 0, len(selectedTasks))
-		projectTokensUsed := 0
-		projectCompleted := 0
-		projectFailed := 0
-		for _, scoredTask := range selectedTasks {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			tasksRun++
-			projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
-
-			// Create task instance
-			taskInstance := &tasks.Task{
-				ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
-				Title:       scoredTask.Definition.Name,
-				Description: scoredTask.Definition.Description,
-				Priority:    int(scoredTask.Score),
-				Type:        scoredTask.Definition.Type,
-			}
-
-			// Mark as assigned
-			st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))
-
-			// Execute via orchestrator
-			result, err := orch.RunTask(ctx, taskInstance, projectPath)
-
-			// Clear assignment
-			st.ClearAssigned(taskInstance.ID)
-
-			if err != nil {
-				tasksFailed++
-				projectFailed++
-				log.Errorf("task %s failed: %v", taskInstance.ID, err)
-				if report != nil {
-					report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						TokensUsed: 0,
-						Duration:   result.Duration,
-					})
-				}
-				continue
-			}
-
-			// Record result
-			switch result.Status {
-			case orchestrator.StatusCompleted:
-				tasksCompleted++
-				projectCompleted++
-				st.RecordTaskRun(projectPath, string(scoredTask.Definition.Type))
-				log.InfoCtx("task completed", map[string]any{
-					"task":       taskInstance.ID,
-					"iterations": result.Iterations,
-					"duration":   result.Duration.String(),
-				})
-				_, maxTok := scoredTask.Definition.EstimatedTokens()
-				projectTokensUsed += maxTok
-				if report != nil {
-					report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "completed",
-						OutputType: result.OutputType,
-						OutputRef:  result.OutputRef,
-						TokensUsed: maxTok,
-						Duration:   result.Duration,
-					})
-				}
-			case orchestrator.StatusAbandoned:
-				tasksFailed++
-				projectFailed++
-				log.Warnf("task %s abandoned: %s", taskInstance.ID, result.Error)
-				if report != nil {
-					report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						SkipReason: result.Error,
-						Duration:   result.Duration,
-					})
-				}
-			default:
-				tasksFailed++
-				projectFailed++
-				log.Errorf("task %s failed: %s", taskInstance.ID, result.Error)
-				if report != nil {
-					report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						SkipReason: result.Error,
-						Duration:   result.Duration,
-					})
-				}
-			}
-		}
-
-		// Record project run
-		st.RecordProjectRun(projectPath)
-		projectStatus := "partial"
-		if projectFailed == 0 && projectCompleted > 0 {
-			projectStatus = "success"
-		}
-		if projectCompleted == 0 && projectFailed > 0 {
-			projectStatus = "failed"
-		}
-		st.AddRunRecord(state.RunRecord{
-			StartTime:  projectStart,
-			EndTime:    time.Now(),
-			Provider:   choice.name,
-			Project:    projectPath,
-			Tasks:      projectTaskTypes,
-			TokensUsed: projectTokensUsed,
-			Status:     projectStatus,
-		})
+	counts, err := executeProjects(ctx, runnableProjects, cfg.Schedule.ProjectParallel, func(projectCtx context.Context, pp preflightProject) (projectRunCounts, error) {
+		return executeDaemonProject(projectCtx, pp, st, report, log)
+	})
+	if err != nil {
+		log.Info("run cancelled")
+		return err
 	}
 
 	// Summary
 	duration := time.Since(start)
 	log.InfoCtx("scheduled run complete", map[string]any{
 		"duration":  duration.String(),
-		"tasks_run": tasksRun,
-		"completed": tasksCompleted,
-		"failed":    tasksFailed,
+		"tasks_run": counts.tasksRun,
+		"completed": counts.tasksCompleted,
+		"failed":    counts.tasksFailed,
 		"projects":  len(projects),
 	})
 
@@ -494,6 +366,157 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 	}
 
 	return nil
+}
+
+func executeDaemonProject(ctx context.Context, pp preflightProject, st *state.State, report *runReport, log *logging.Logger) (projectRunCounts, error) {
+	counts := projectRunCounts{}
+	choice := pp.provider
+	projectPath := pp.path
+	selectedTasks := pp.tasks
+
+	log.InfoCtx("processing project", map[string]any{
+		"project":  projectPath,
+		"tasks":    len(selectedTasks),
+		"budget":   choice.allowance.Allowance,
+		"provider": choice.name,
+	})
+
+	orch := orchestrator.New(
+		orchestrator.WithAgent(choice.agent),
+		orchestrator.WithConfig(orchestrator.Config{
+			MaxIterations: 3,
+			AgentTimeout:  daemonTimeoutFlag,
+		}),
+		orchestrator.WithLogger(logging.Component("orchestrator")),
+	)
+
+	projectStart := time.Now()
+	projectTaskTypes := make([]string, 0, len(selectedTasks))
+	projectTokensUsed := 0
+	projectCompleted := 0
+	projectFailed := 0
+
+	for _, scoredTask := range selectedTasks {
+		select {
+		case <-ctx.Done():
+			return counts, ctx.Err()
+		default:
+		}
+
+		counts.tasksRun++
+		projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
+
+		// Create task instance
+		taskInstance := &tasks.Task{
+			ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
+			Title:       scoredTask.Definition.Name,
+			Description: scoredTask.Definition.Description,
+			Priority:    int(scoredTask.Score),
+			Type:        scoredTask.Definition.Type,
+		}
+
+		// Mark as assigned
+		st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))
+
+		// Execute via orchestrator
+		result, err := orch.RunTask(ctx, taskInstance, projectPath)
+
+		// Clear assignment
+		st.ClearAssigned(taskInstance.ID)
+
+		if err != nil {
+			counts.tasksFailed++
+			projectFailed++
+			log.Errorf("task %s failed: %v", taskInstance.ID, err)
+			if report != nil {
+				report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					TokensUsed: 0,
+					Duration:   result.Duration,
+				})
+			}
+			continue
+		}
+
+		// Record result
+		switch result.Status {
+		case orchestrator.StatusCompleted:
+			counts.tasksCompleted++
+			projectCompleted++
+			st.RecordTaskRun(projectPath, string(scoredTask.Definition.Type))
+			log.InfoCtx("task completed", map[string]any{
+				"task":       taskInstance.ID,
+				"iterations": result.Iterations,
+				"duration":   result.Duration.String(),
+			})
+			_, maxTok := scoredTask.Definition.EstimatedTokens()
+			projectTokensUsed += maxTok
+			if report != nil {
+				report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "completed",
+					OutputType: result.OutputType,
+					OutputRef:  result.OutputRef,
+					TokensUsed: maxTok,
+					Duration:   result.Duration,
+				})
+			}
+		case orchestrator.StatusAbandoned:
+			counts.tasksFailed++
+			projectFailed++
+			log.Warnf("task %s abandoned: %s", taskInstance.ID, result.Error)
+			if report != nil {
+				report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		default:
+			counts.tasksFailed++
+			projectFailed++
+			log.Errorf("task %s failed: %s", taskInstance.ID, result.Error)
+			if report != nil {
+				report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		}
+	}
+
+	// Record project run
+	st.RecordProjectRun(projectPath)
+	projectStatus := "partial"
+	if projectFailed == 0 && projectCompleted > 0 {
+		projectStatus = "success"
+	}
+	if projectCompleted == 0 && projectFailed > 0 {
+		projectStatus = "failed"
+	}
+	st.AddRunRecord(state.RunRecord{
+		StartTime:  projectStart,
+		EndTime:    time.Now(),
+		Provider:   choice.name,
+		Project:    projectPath,
+		Tasks:      projectTaskTypes,
+		TokensUsed: projectTokensUsed,
+		Status:     projectStatus,
+	})
+
+	return counts, nil
 }
 
 type tmuxScraper struct{}

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -80,6 +81,7 @@ executing anything.
 Flags:
   --max-projects N   Limit how many projects are processed (default 1).
                      Ignored when --project is set.
+                     Ignored when schedule.project_parallelism is true.
   --max-tasks N      Limit how many tasks run per project (default 1).
                      Ignored when --task is set.
   --random-task      Pick a random task from eligible tasks (exactly 1).
@@ -106,7 +108,7 @@ func init() {
 	runCmd.Flags().Bool("dry-run", false, "Simulate execution without making changes")
 	runCmd.Flags().StringP("project", "p", "", "Path to project directory")
 	runCmd.Flags().StringP("task", "t", "", "Run specific task by name")
-	runCmd.Flags().Int("max-projects", 1, "Max projects to process per run (ignored when --project is set)")
+	runCmd.Flags().Int("max-projects", 1, "Max projects to process per run (ignored when --project is set or schedule.project_parallelism=true)")
 	runCmd.Flags().Int("max-tasks", 1, "Max tasks to run per project (ignored when --task is set)")
 	runCmd.Flags().Bool("ignore-budget", false, "Bypass budget checks (use with caution)")
 	runCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -170,6 +172,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	if !maxTasksChanged && cfg.Schedule.MaxTasks > 0 {
 		maxTasks = cfg.Schedule.MaxTasks
 	}
+	projectParallel := cfg.Schedule.ProjectParallel
 
 	// Initialize logging
 	if err := initLogging(cfg); err != nil {
@@ -240,21 +243,22 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	params := executeRunParams{
-		cfg:          cfg,
-		budgetMgr:    budgetMgr,
-		selector:     selector,
-		st:           st,
-		projects:     projects,
-		taskFilter:   taskFilter,
-		maxProjects:  maxProjects,
-		maxTasks:     maxTasks,
-		randomTask:   randomTask,
-		ignoreBudget: ignoreBudget,
-		dryRun:       dryRun,
-		yes:          yes,
-		branch:       branch,
-		agentTimeout: agentTimeout,
-		log:          log,
+		cfg:             cfg,
+		budgetMgr:       budgetMgr,
+		selector:        selector,
+		st:              st,
+		projects:        projects,
+		taskFilter:      taskFilter,
+		maxProjects:     maxProjects,
+		maxTasks:        maxTasks,
+		projectParallel: projectParallel,
+		randomTask:      randomTask,
+		ignoreBudget:    ignoreBudget,
+		dryRun:          dryRun,
+		yes:             yes,
+		branch:          branch,
+		agentTimeout:    agentTimeout,
+		log:             log,
 	}
 	if !dryRun {
 		params.report = newRunReport(time.Now(), calculateRunBudgetStart(cfg, budgetMgr, log))
@@ -263,22 +267,24 @@ func runRun(cmd *cobra.Command, args []string) error {
 }
 
 type executeRunParams struct {
-	cfg          *config.Config
-	budgetMgr    *budget.Manager
-	selector     *tasks.Selector
-	st           *state.State
-	projects     []string
-	taskFilter   string
-	maxProjects  int
-	maxTasks     int
-	randomTask   bool
-	ignoreBudget bool
-	dryRun       bool
-	yes          bool
-	branch       string
-	agentTimeout time.Duration
-	report       *runReport
-	log          *logging.Logger
+	cfg             *config.Config
+	budgetMgr       *budget.Manager
+	selector        *tasks.Selector
+	st              *state.State
+	projects        []string
+	taskFilter      string
+	maxProjects     int
+	maxTasks        int
+	randomTask      bool
+	ignoreBudget    bool
+	dryRun          bool
+	yes             bool
+	branch          string
+	projectParallel bool
+	agentTimeout    time.Duration
+	report          *runReport
+	log             *logging.Logger
+	outputMu        *sync.Mutex
 }
 
 // providerChoice holds a selected provider's agent and name.
@@ -421,24 +427,38 @@ type preflightProject struct {
 
 // preflightPlan collects all planned work before execution.
 type preflightPlan struct {
-	projects     []preflightProject
-	skipReasons  []string // global skip reasons (e.g., no provider)
-	ignoreBudget bool
-	branch       string // base branch for feature branches
+	projects        []preflightProject
+	skipReasons     []string // global skip reasons (e.g., no provider)
+	ignoreBudget    bool
+	branch          string // base branch for feature branches
+	projectParallel bool
+}
+
+type projectRunCounts struct {
+	tasksRun       int
+	tasksCompleted int
+	tasksFailed    int
 }
 
 // buildPreflight performs the planning phase: resolve provider, select tasks
 // per project, but does NOT execute anything.
 func buildPreflight(p executeRunParams) (*preflightPlan, error) {
 	plan := &preflightPlan{
-		ignoreBudget: p.ignoreBudget,
-		branch:       p.branch,
+		ignoreBudget:    p.ignoreBudget,
+		branch:          p.branch,
+		projectParallel: p.projectParallel,
+	}
+
+	maxProjects := p.maxProjects
+	if p.projectParallel {
+		// Binary mode: process all eligible projects in parallel.
+		maxProjects = 0
 	}
 
 	eligibleCount := 0
 	for _, projectPath := range p.projects {
 		// Apply --max-projects limit (counts only eligible, non-skipped projects)
-		if p.maxProjects > 0 && eligibleCount >= p.maxProjects {
+		if maxProjects > 0 && eligibleCount >= maxProjects {
 			break
 		}
 
@@ -532,6 +552,11 @@ func displayPreflight(w io.Writer, plan *preflightPlan) {
 	if plan.branch != "" {
 		_, _ = fmt.Fprintf(w, "Branch: %s\n", plan.branch)
 	}
+	parallelMode := "disabled"
+	if plan.projectParallel {
+		parallelMode = "enabled"
+	}
+	_, _ = fmt.Fprintf(w, "Project Parallelism: %s\n", parallelMode)
 
 	// Show provider info from first project that has one
 	for _, pp := range plan.projects {
@@ -622,10 +647,13 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 	}
 
 	// Execute based on the plan
-	var tasksRun, tasksCompleted, tasksFailed int
 	var skipReasons []string
 	skipReasons = append(skipReasons, plan.skipReasons...)
+	if plan.projectParallel {
+		p.outputMu = &sync.Mutex{}
+	}
 
+	runnableProjects := make([]preflightProject, 0, len(plan.projects))
 	for _, pp := range plan.projects {
 		select {
 		case <-ctx.Done():
@@ -656,196 +684,24 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 		if len(pp.tasks) == 0 {
 			continue
 		}
-
-		choice := pp.provider
-		projectPath := pp.path
-
-		if isInteractive() {
-			displayProjectHeaderColored(projectPath, choice.name, choice.allowance, len(pp.tasks), pp.tasks)
-		} else {
-			fmt.Printf("\n=== Project: %s ===\n", projectPath)
-			fmt.Printf("Provider: %s\n", choice.name)
-			fmt.Printf("Budget: %d tokens available (%.1f%% used, mode=%s)\n",
-				choice.allowance.Allowance, choice.allowance.UsedPercent, choice.allowance.Mode)
-
-			fmt.Printf("Selected %d task(s):\n", len(pp.tasks))
-			for i, st := range pp.tasks {
-				minTok, maxTok := st.Definition.EstimatedTokens()
-				fmt.Printf("  %d. %s (score=%.1f, cost=%s, tokens=%d-%d)\n",
-					i+1, st.Definition.Name, st.Score, st.Definition.CostTier, minTok, maxTok)
-			}
-		}
-
-		// Create orchestrator with the selected agent
-		var renderer *liveRenderer
-		if isInteractive() {
-			renderer = newLiveRenderer()
-			defer renderer.cleanup()
-		}
-
-		orchOpts := []orchestrator.Option{
-			orchestrator.WithAgent(choice.agent),
-			orchestrator.WithConfig(orchestrator.Config{
-				MaxIterations: 3,
-				AgentTimeout:  p.agentTimeout,
-			}),
-			orchestrator.WithLogger(logging.Component("orchestrator")),
-		}
-		if renderer != nil {
-			orchOpts = append(orchOpts, orchestrator.WithEventHandler(renderer.HandleEvent))
-		}
-		orch := orchestrator.New(orchOpts...)
-
-		projectStart := time.Now()
-		projectTaskTypes := make([]string, 0, len(pp.tasks))
-		projectTokensUsed := 0
-		projectCompleted := 0
-		projectFailed := 0
-
-		// Execute each selected task
-		for _, scoredTask := range pp.tasks {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			tasksRun++
-			if !isInteractive() {
-				fmt.Printf("\n--- Running: %s (via %s) ---\n", scoredTask.Definition.Name, choice.name)
-			}
-			projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
-
-			// Create task instance
-			taskInstance := &tasks.Task{
-				ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
-				Title:       scoredTask.Definition.Name,
-				Description: scoredTask.Definition.Description,
-				Priority:    int(scoredTask.Score),
-				Type:        scoredTask.Definition.Type,
-			}
-
-			// Mark as assigned
-			p.st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))
-
-			// Inject run metadata for PR traceability
-			orch.SetRunMetadata(&orchestrator.RunMetadata{
-				Provider:  choice.name,
-				TaskType:  string(scoredTask.Definition.Type),
-				TaskScore: scoredTask.Score,
-				CostTier:  scoredTask.Definition.CostTier.String(),
-				RunStart:  projectStart,
-				Branch:    p.branch,
-			})
-
-			// Execute via orchestrator
-			result, err := orch.RunTask(ctx, taskInstance, projectPath)
-
-			// Clear assignment
-			p.st.ClearAssigned(taskInstance.ID)
-
-			if err != nil {
-				tasksFailed++
-				projectFailed++
-				if !isInteractive() {
-					fmt.Printf("  FAILED: %v\n", err)
-				}
-				p.log.Errorf("task %s failed: %v", taskInstance.ID, err)
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						TokensUsed: 0,
-						Duration:   result.Duration,
-					})
-				}
-				continue
-			}
-
-			// Record result
-			switch result.Status {
-			case orchestrator.StatusCompleted:
-				tasksCompleted++
-				projectCompleted++
-				if !isInteractive() {
-					fmt.Printf("  COMPLETED in %d iteration(s) (%s)\n", result.Iterations, result.Duration)
-				}
-				p.st.RecordTaskRun(projectPath, string(scoredTask.Definition.Type))
-				_, maxTok := scoredTask.Definition.EstimatedTokens()
-				projectTokensUsed += maxTok
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "completed",
-						OutputType: result.OutputType,
-						OutputRef:  result.OutputRef,
-						TokensUsed: maxTok,
-						Duration:   result.Duration,
-					})
-				}
-			case orchestrator.StatusAbandoned:
-				tasksFailed++
-				projectFailed++
-				if !isInteractive() {
-					fmt.Printf("  ABANDONED after %d iteration(s): %s\n", result.Iterations, result.Error)
-				}
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						SkipReason: result.Error,
-						Duration:   result.Duration,
-					})
-				}
-			default:
-				tasksFailed++
-				projectFailed++
-				if !isInteractive() {
-					fmt.Printf("  FAILED: %s\n", result.Error)
-				}
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    projectPath,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						SkipReason: result.Error,
-						Duration:   result.Duration,
-					})
-				}
-			}
-		}
-
-		// Record project run
-		p.st.RecordProjectRun(projectPath)
-		projectStatus := "partial"
-		if projectFailed == 0 && projectCompleted > 0 {
-			projectStatus = "success"
-		}
-		if projectCompleted == 0 && projectFailed > 0 {
-			projectStatus = "failed"
-		}
-		p.st.AddRunRecord(state.RunRecord{
-			StartTime:  projectStart,
-			EndTime:    time.Now(),
-			Provider:   choice.name,
-			Project:    projectPath,
-			Tasks:      projectTaskTypes,
-			TokensUsed: projectTokensUsed,
-			Status:     projectStatus,
-			Branch:     p.branch,
-		})
+		runnableProjects = append(runnableProjects, pp)
 	}
+
+	counts, err := executeProjects(ctx, runnableProjects, plan.projectParallel, func(projectCtx context.Context, project preflightProject) (projectRunCounts, error) {
+		return executeProject(projectCtx, p, project)
+	})
+	if err != nil {
+		p.log.Info("run cancelled")
+		return err
+	}
+
+	tasksRun := counts.tasksRun
+	tasksCompleted := counts.tasksCompleted
+	tasksFailed := counts.tasksFailed
 
 	// Summary
 	duration := time.Since(start)
-	if isInteractive() {
+	if isInteractive() && !plan.projectParallel {
 		displayRunSummaryColored(duration, tasksRun, tasksCompleted, tasksFailed, skipReasons)
 	} else {
 		fmt.Printf("\n=== Run Complete ===\n")
@@ -873,6 +729,271 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 	}
 
 	return nil
+}
+
+func withOutputLock(mu *sync.Mutex, fn func()) {
+	if mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	fn()
+}
+
+func executeProjects(ctx context.Context, projects []preflightProject, parallel bool, runProject func(context.Context, preflightProject) (projectRunCounts, error)) (projectRunCounts, error) {
+	totals := projectRunCounts{}
+	if len(projects) == 0 {
+		return totals, nil
+	}
+
+	if !parallel || len(projects) == 1 {
+		for _, pp := range projects {
+			select {
+			case <-ctx.Done():
+				return totals, ctx.Err()
+			default:
+			}
+
+			counts, err := runProject(ctx, pp)
+			if err != nil {
+				return totals, err
+			}
+			totals.tasksRun += counts.tasksRun
+			totals.tasksCompleted += counts.tasksCompleted
+			totals.tasksFailed += counts.tasksFailed
+		}
+		return totals, nil
+	}
+
+	type projectResult struct {
+		counts projectRunCounts
+		err    error
+	}
+
+	resultCh := make(chan projectResult, len(projects))
+
+	var wg sync.WaitGroup
+	for _, pp := range projects {
+		wg.Add(1)
+		go func(project preflightProject) {
+			defer wg.Done()
+			if ctx.Err() != nil {
+				resultCh <- projectResult{err: ctx.Err()}
+				return
+			}
+			counts, err := runProject(ctx, project)
+			resultCh <- projectResult{counts: counts, err: err}
+		}(pp)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	var firstErr error
+	for result := range resultCh {
+		totals.tasksRun += result.counts.tasksRun
+		totals.tasksCompleted += result.counts.tasksCompleted
+		totals.tasksFailed += result.counts.tasksFailed
+		if firstErr == nil && result.err != nil {
+			firstErr = result.err
+		}
+	}
+
+	return totals, firstErr
+}
+
+func executeProject(ctx context.Context, p executeRunParams, pp preflightProject) (projectRunCounts, error) {
+	counts := projectRunCounts{}
+	choice := pp.provider
+	projectPath := pp.path
+	interactive := isInteractive() && !p.projectParallel
+
+	if interactive {
+		displayProjectHeaderColored(projectPath, choice.name, choice.allowance, len(pp.tasks), pp.tasks)
+	} else {
+		withOutputLock(p.outputMu, func() {
+			fmt.Printf("\n=== Project: %s ===\n", projectPath)
+			fmt.Printf("Provider: %s\n", choice.name)
+			fmt.Printf("Budget: %d tokens available (%.1f%% used, mode=%s)\n",
+				choice.allowance.Allowance, choice.allowance.UsedPercent, choice.allowance.Mode)
+
+			fmt.Printf("Selected %d task(s):\n", len(pp.tasks))
+			for i, st := range pp.tasks {
+				minTok, maxTok := st.Definition.EstimatedTokens()
+				fmt.Printf("  %d. %s (score=%.1f, cost=%s, tokens=%d-%d)\n",
+					i+1, st.Definition.Name, st.Score, st.Definition.CostTier, minTok, maxTok)
+			}
+		})
+	}
+
+	var renderer *liveRenderer
+	if interactive {
+		renderer = newLiveRenderer()
+		defer renderer.cleanup()
+	}
+
+	orchOpts := []orchestrator.Option{
+		orchestrator.WithAgent(choice.agent),
+		orchestrator.WithConfig(orchestrator.Config{
+			MaxIterations: 3,
+			AgentTimeout:  p.agentTimeout,
+		}),
+		orchestrator.WithLogger(logging.Component("orchestrator")),
+	}
+	if renderer != nil {
+		orchOpts = append(orchOpts, orchestrator.WithEventHandler(renderer.HandleEvent))
+	}
+	orch := orchestrator.New(orchOpts...)
+
+	projectStart := time.Now()
+	projectTaskTypes := make([]string, 0, len(pp.tasks))
+	projectTokensUsed := 0
+	projectCompleted := 0
+	projectFailed := 0
+
+	for _, scoredTask := range pp.tasks {
+		select {
+		case <-ctx.Done():
+			return counts, ctx.Err()
+		default:
+		}
+
+		counts.tasksRun++
+		if !interactive {
+			withOutputLock(p.outputMu, func() {
+				fmt.Printf("\n--- Running: %s (via %s) ---\n", scoredTask.Definition.Name, choice.name)
+			})
+		}
+		projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
+
+		taskInstance := &tasks.Task{
+			ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
+			Title:       scoredTask.Definition.Name,
+			Description: scoredTask.Definition.Description,
+			Priority:    int(scoredTask.Score),
+			Type:        scoredTask.Definition.Type,
+		}
+
+		p.st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))
+
+		orch.SetRunMetadata(&orchestrator.RunMetadata{
+			Provider:  choice.name,
+			TaskType:  string(scoredTask.Definition.Type),
+			TaskScore: scoredTask.Score,
+			CostTier:  scoredTask.Definition.CostTier.String(),
+			RunStart:  projectStart,
+			Branch:    p.branch,
+		})
+
+		result, err := orch.RunTask(ctx, taskInstance, projectPath)
+		p.st.ClearAssigned(taskInstance.ID)
+
+		if err != nil {
+			counts.tasksFailed++
+			projectFailed++
+			if !interactive {
+				withOutputLock(p.outputMu, func() {
+					fmt.Printf("  FAILED: %v\n", err)
+				})
+			}
+			p.log.Errorf("task %s failed: %v", taskInstance.ID, err)
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					TokensUsed: 0,
+					Duration:   result.Duration,
+				})
+			}
+			continue
+		}
+
+		switch result.Status {
+		case orchestrator.StatusCompleted:
+			counts.tasksCompleted++
+			projectCompleted++
+			if !interactive {
+				withOutputLock(p.outputMu, func() {
+					fmt.Printf("  COMPLETED in %d iteration(s) (%s)\n", result.Iterations, result.Duration)
+				})
+			}
+			p.st.RecordTaskRun(projectPath, string(scoredTask.Definition.Type))
+			_, maxTok := scoredTask.Definition.EstimatedTokens()
+			projectTokensUsed += maxTok
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "completed",
+					OutputType: result.OutputType,
+					OutputRef:  result.OutputRef,
+					TokensUsed: maxTok,
+					Duration:   result.Duration,
+				})
+			}
+		case orchestrator.StatusAbandoned:
+			counts.tasksFailed++
+			projectFailed++
+			if !interactive {
+				withOutputLock(p.outputMu, func() {
+					fmt.Printf("  ABANDONED after %d iteration(s): %s\n", result.Iterations, result.Error)
+				})
+			}
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		default:
+			counts.tasksFailed++
+			projectFailed++
+			if !interactive {
+				withOutputLock(p.outputMu, func() {
+					fmt.Printf("  FAILED: %s\n", result.Error)
+				})
+			}
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    projectPath,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		}
+	}
+
+	p.st.RecordProjectRun(projectPath)
+	projectStatus := "partial"
+	if projectFailed == 0 && projectCompleted > 0 {
+		projectStatus = "success"
+	}
+	if projectCompleted == 0 && projectFailed > 0 {
+		projectStatus = "failed"
+	}
+	p.st.AddRunRecord(state.RunRecord{
+		StartTime:  projectStart,
+		EndTime:    time.Now(),
+		Provider:   choice.name,
+		Project:    projectPath,
+		Tasks:      projectTaskTypes,
+		TokensUsed: projectTokensUsed,
+		Status:     projectStatus,
+		Branch:     p.branch,
+	})
+
+	return counts, nil
 }
 
 // loadConfig loads configuration from the appropriate paths.

--- a/cmd/nightshift/commands/run_output.go
+++ b/cmd/nightshift/commands/run_output.go
@@ -213,6 +213,13 @@ func displayPreflightColored(plan *preflightPlan) {
 			s.Label.Render("Branch:"),
 			s.Value.Render(plan.branch))
 	}
+	parallelMode := "disabled"
+	if plan.projectParallel {
+		parallelMode = "enabled"
+	}
+	fmt.Printf("  %s %s\n",
+		s.Label.Render("Project Parallelism:"),
+		s.Value.Render(parallelMode))
 
 	// Show provider info from first project that has one
 	for _, pp := range plan.projects {

--- a/cmd/nightshift/commands/run_reporting.go
+++ b/cmd/nightshift/commands/run_reporting.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/marcus/nightshift/internal/budget"
@@ -14,6 +15,7 @@ import (
 type runReport struct {
 	results    *reporting.RunResults
 	usedBudget int
+	mu         sync.Mutex
 }
 
 func newRunReport(start time.Time, startBudget int) *runReport {
@@ -30,6 +32,8 @@ func newRunReport(start time.Time, startBudget int) *runReport {
 }
 
 func (r *runReport) addTask(task reporting.TaskResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.results.Tasks = append(r.results.Tasks, task)
 	r.usedBudget += task.TokensUsed
 }
@@ -38,6 +42,8 @@ func (r *runReport) finalize(cfg *config.Config, log *logging.Logger) {
 	if r == nil || r.results == nil || cfg == nil {
 		return
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	r.results.EndTime = time.Now()
 	r.results.UsedBudget = r.usedBudget

--- a/cmd/nightshift/commands/run_test.go
+++ b/cmd/nightshift/commands/run_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1306,4 +1307,167 @@ func TestScheduleMaxProjectsCLIOverridesConfig(t *testing.T) {
 	if maxProjects != 2 {
 		t.Fatalf("maxProjects = %d, want 2 (CLI should win over config)", maxProjects)
 	}
+}
+
+func TestBuildPreflight_ProjectParallelIgnoresMaxProjects(t *testing.T) {
+	p0 := t.TempDir()
+	p1 := t.TempDir()
+	p2 := t.TempDir()
+
+	params := newPreflightParams(t, []string{p0, p1, p2})
+	params.maxProjects = 1
+	params.projectParallel = true
+
+	plan, err := buildPreflight(params)
+	if err != nil {
+		t.Fatalf("buildPreflight: %v", err)
+	}
+
+	if len(plan.projects) != 3 {
+		t.Fatalf("plan.projects len = %d, want 3 (maxProjects ignored in parallel mode)", len(plan.projects))
+	}
+
+	eligible := 0
+	for _, pp := range plan.projects {
+		if pp.skipReason == "" {
+			eligible++
+		}
+	}
+	if eligible != 3 {
+		t.Fatalf("eligible projects = %d, want 3", eligible)
+	}
+}
+
+func TestExecuteProjects_RunsProjectsInParallel(t *testing.T) {
+	projects := makeTestExecutionProjects(3)
+	gate := make(chan struct{})
+	started := make(chan struct{}, len(projects))
+
+	var mu sync.Mutex
+	running := 0
+	maxRunning := 0
+
+	runProject := func(ctx context.Context, pp preflightProject) (projectRunCounts, error) {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+
+		started <- struct{}{}
+
+		select {
+		case <-ctx.Done():
+			return projectRunCounts{}, ctx.Err()
+		case <-gate:
+		}
+
+		mu.Lock()
+		running--
+		mu.Unlock()
+
+		return projectRunCounts{
+			tasksRun:       1,
+			tasksCompleted: 1,
+		}, nil
+	}
+
+	var (
+		counts projectRunCounts
+		err    error
+	)
+	done := make(chan struct{})
+	go func() {
+		counts, err = executeProjects(context.Background(), projects, true, runProject)
+		close(done)
+	}()
+
+	for i := 0; i < len(projects); i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for project %d to start", i+1)
+		}
+	}
+
+	close(gate)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("executeProjects did not complete")
+	}
+
+	if err != nil {
+		t.Fatalf("executeProjects: %v", err)
+	}
+	if maxRunning < 2 {
+		t.Fatalf("maxRunning = %d, want >= 2 for parallel execution", maxRunning)
+	}
+	if counts.tasksRun != len(projects) {
+		t.Fatalf("tasksRun = %d, want %d", counts.tasksRun, len(projects))
+	}
+	if counts.tasksCompleted != len(projects) {
+		t.Fatalf("tasksCompleted = %d, want %d", counts.tasksCompleted, len(projects))
+	}
+}
+
+func TestExecuteProjects_SerialWhenParallelismDisabled(t *testing.T) {
+	projects := makeTestExecutionProjects(4)
+
+	var mu sync.Mutex
+	running := 0
+	maxRunning := 0
+
+	runProject := func(ctx context.Context, pp preflightProject) (projectRunCounts, error) {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+
+		time.Sleep(25 * time.Millisecond)
+
+		mu.Lock()
+		running--
+		mu.Unlock()
+
+		return projectRunCounts{
+			tasksRun:       1,
+			tasksCompleted: 1,
+		}, nil
+	}
+
+	counts, err := executeProjects(context.Background(), projects, false, runProject)
+	if err != nil {
+		t.Fatalf("executeProjects: %v", err)
+	}
+
+	if maxRunning != 1 {
+		t.Fatalf("maxRunning = %d, want 1", maxRunning)
+	}
+	if counts.tasksRun != len(projects) {
+		t.Fatalf("tasksRun = %d, want %d", counts.tasksRun, len(projects))
+	}
+}
+
+func makeTestExecutionProjects(n int) []preflightProject {
+	out := make([]preflightProject, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, preflightProject{
+			path: fmt.Sprintf("/tmp/project-%d", i),
+			tasks: []tasks.ScoredTask{
+				{
+					Definition: tasks.TaskDefinition{
+						Type: tasks.TaskLintFix,
+						Name: "Lint Fixes",
+					},
+					Score: float64(i + 1),
+				},
+			},
+		})
+	}
+	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,11 +29,12 @@ type Config struct {
 
 // ScheduleConfig defines when nightshift runs.
 type ScheduleConfig struct {
-	Cron        string        `mapstructure:"cron"`         // Cron expression (e.g., "0 2 * * *")
-	Interval    string        `mapstructure:"interval"`     // Alternative: duration (e.g., "1h")
-	Window      *WindowConfig `mapstructure:"window"`       // Optional time window constraint
-	MaxProjects int           `mapstructure:"max_projects"` // Default max projects per run (0 = unlimited)
-	MaxTasks    int           `mapstructure:"max_tasks"`    // Default max tasks per project (0 = 1)
+	Cron            string        `mapstructure:"cron"`                // Cron expression (e.g., "0 2 * * *")
+	Interval        string        `mapstructure:"interval"`            // Alternative: duration (e.g., "1h")
+	Window          *WindowConfig `mapstructure:"window"`              // Optional time window constraint
+	MaxProjects     int           `mapstructure:"max_projects"`        // Default max projects per run (0 = unlimited)
+	MaxTasks        int           `mapstructure:"max_tasks"`           // Default max tasks per project (0 = 1)
+	ProjectParallel bool          `mapstructure:"project_parallelism"` // Run all projects concurrently when true
 }
 
 // WindowConfig defines a time window for execution.
@@ -265,6 +266,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("logging.level", DefaultLogLevel)
 	v.SetDefault("logging.path", DefaultLogPath())
 	v.SetDefault("logging.format", DefaultLogFormat)
+
+	// Schedule defaults
+	v.SetDefault("schedule.project_parallelism", false)
 
 	// Reporting defaults
 	v.SetDefault("reporting.morning_summary", true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,7 +97,8 @@ func TestValidate_InvalidLogFormat(t *testing.T) {
 func TestValidate_ValidConfig(t *testing.T) {
 	cfg := &Config{
 		Schedule: ScheduleConfig{
-			Cron: "0 2 * * *",
+			Cron:            "0 2 * * *",
+			ProjectParallel: true,
 		},
 		Budget: BudgetConfig{
 			Mode:           "daily",
@@ -257,6 +258,7 @@ func TestLoadFromPaths_WithYAML(t *testing.T) {
 	configContent := `
 schedule:
   cron: "0 3 * * *"
+  project_parallelism: true
 budget:
   mode: weekly
   max_percent: 20
@@ -275,6 +277,9 @@ logging:
 
 	if cfg.Schedule.Cron != "0 3 * * *" {
 		t.Errorf("Schedule.Cron = %q, want %q", cfg.Schedule.Cron, "0 3 * * *")
+	}
+	if !cfg.Schedule.ProjectParallel {
+		t.Errorf("Schedule.ProjectParallel = %v, want true", cfg.Schedule.ProjectParallel)
 	}
 	if cfg.Budget.Mode != "weekly" {
 		t.Errorf("Budget.Mode = %q, want %q", cfg.Budget.Mode, "weekly")


### PR DESCRIPTION
This is for people with lots of projects and _lots_ of tokens.

- Add schedule.project_parallelism config support and preflight mode display
- Execute all eligible projects concurrently in run mode and daemon scheduled runs
- Preserve per-project serial task execution, daily skip guard, and reporting behavior
- Ignore max_projects in project parallel mode