### PR TITLE
fix: prefer Claude subscription auth and isolate dirty runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,9 @@ go test ./...
 - **Style**: Standard Go (gofmt, govet). No magic, explicit is better.
 - **Errors**: Wrap with context, don't swallow.
 - **Tests**: Table-driven, in `_test.go` files alongside code.
+
+## Git Remote Safety
+
+- Never push to the `marcus/nightshift` GitHub remote from this repo.
+- If a push is needed, stop after local commit(s) unless the configured remote is a user-writable fork.
+- Before any push, verify the target remote owner is not `marcus`.

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -416,6 +416,7 @@ type preflightProject struct {
 	path       string
 	tasks      []tasks.ScoredTask
 	provider   *providerChoice
+	baseBranch string
 	skipReason string // non-empty if project was skipped
 }
 
@@ -659,11 +660,24 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 
 		choice := pp.provider
 		projectPath := pp.path
+		target, err := prepareExecutionTarget(ctx, projectPath)
+		if err != nil {
+			tasksFailed += len(pp.tasks)
+			projectFailed := len(pp.tasks)
+			_ = projectFailed
+			skipReasons = append(skipReasons, fmt.Sprintf("%s: prepare execution target failed: %v", filepath.Base(projectPath), err))
+			p.log.Errorf("prepare execution target for %s failed: %v", projectPath, err)
+			continue
+		}
+		execProjectPath := target.WorkDir
 
 		if isInteractive() {
 			displayProjectHeaderColored(projectPath, choice.name, choice.allowance, len(pp.tasks), pp.tasks)
 		} else {
 			fmt.Printf("\n=== Project: %s ===\n", projectPath)
+			if target.Isolated {
+				fmt.Printf("Worktree: %s\n", execProjectPath)
+			}
 			fmt.Printf("Provider: %s\n", choice.name)
 			fmt.Printf("Budget: %d tokens available (%.1f%% used, mode=%s)\n",
 				choice.allowance.Allowance, choice.allowance.UsedPercent, choice.allowance.Mode)
@@ -735,11 +749,11 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 				TaskScore: scoredTask.Score,
 				CostTier:  scoredTask.Definition.CostTier.String(),
 				RunStart:  projectStart,
-				Branch:    p.branch,
+				Branch:    target.BaseBranch,
 			})
 
 			// Execute via orchestrator
-			result, err := orch.RunTask(ctx, taskInstance, projectPath)
+			result, err := orch.RunTask(ctx, taskInstance, execProjectPath)
 
 			// Clear assignment
 			p.st.ClearAssigned(taskInstance.ID)

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -203,12 +203,19 @@ func runTaskRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve branch: use flag value or detect current branch
+	// Resolve execution directory. Dirty repos are isolated into a clean
+	// worktree from origin/main when available so Nightshift changes do not
+	// mix with the user's in-progress work.
 	ctx := context.Background()
+	target, err := prepareExecutionTarget(ctx, projectPath)
+	if err != nil {
+		return fmt.Errorf("prepare execution target: %w", err)
+	}
+	execProjectPath := target.WorkDir
+
+	// Resolve branch metadata used in prompts.
 	if branch == "" {
-		if detected, err := orchestrator.CurrentBranch(ctx, projectPath); err == nil {
-			branch = detected
-		}
+		branch = target.BaseBranch
 	}
 
 	// Build the task
@@ -246,6 +253,9 @@ func runTaskRun(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Task:     %s (%s)\n", def.Name, def.Type)
 	fmt.Printf("Provider: %s\n", provider)
 	fmt.Printf("Project:  %s\n", projectPath)
+	if target.Isolated {
+		fmt.Printf("Worktree: %s\n", execProjectPath)
+	}
 	if branch != "" {
 		fmt.Printf("Branch:   %s\n", branch)
 	}
@@ -276,7 +286,7 @@ func runTaskRun(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
-	result, err := orch.RunTask(ctx, taskInstance, projectPath)
+	result, err := orch.RunTask(ctx, taskInstance, execProjectPath)
 	if err != nil {
 		return fmt.Errorf("task failed: %w", err)
 	}

--- a/cmd/nightshift/commands/worktree.go
+++ b/cmd/nightshift/commands/worktree.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type executionTarget struct {
+	ProjectPath string
+	WorkDir     string
+	BaseBranch  string
+	Isolated    bool
+}
+
+func prepareExecutionTarget(ctx context.Context, projectPath string) (executionTarget, error) {
+	abs, err := filepath.Abs(projectPath)
+	if err != nil {
+		return executionTarget{}, fmt.Errorf("abs project path: %w", err)
+	}
+
+	branch, _ := orchestratorCurrentBranch(ctx, abs)
+	target := executionTarget{ProjectPath: abs, WorkDir: abs, BaseBranch: branch}
+
+	dirty, err := gitDirty(ctx, abs)
+	if err != nil || !dirty {
+		return target, nil
+	}
+
+	hasOriginMain, err := gitHasOriginMain(ctx, abs)
+	if err != nil || !hasOriginMain {
+		return target, nil
+	}
+
+	if err := gitFetchOriginMain(ctx, abs); err != nil {
+		return target, nil
+	}
+
+	root := filepath.Join(abs, ".nightshift", "worktrees")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return executionTarget{}, fmt.Errorf("create worktree root: %w", err)
+	}
+
+	name := fmt.Sprintf("run-%s", time.Now().Format("20060102-150405"))
+	workDir := filepath.Join(root, name)
+	cmd := exec.CommandContext(ctx, "git", "-C", abs, "worktree", "add", "--detach", workDir, "origin/main")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return executionTarget{}, fmt.Errorf("git worktree add: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	target.WorkDir = workDir
+	target.BaseBranch = ""
+	target.Isolated = true
+	return target, nil
+}
+
+func gitDirty(ctx context.Context, repo string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func gitHasOriginMain(ctx context.Context, repo string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "rev-parse", "--verify", "refs/remotes/origin/main")
+	if err := cmd.Run(); err == nil {
+		return true, nil
+	}
+	cmd = exec.CommandContext(ctx, "git", "-C", repo, "rev-parse", "--verify", "refs/remotes/origin/master")
+	if err := cmd.Run(); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+func gitFetchOriginMain(ctx context.Context, repo string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "fetch", "origin", "main")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("fetch origin main: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func orchestratorCurrentBranch(ctx context.Context, repo string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "branch", "--show-current")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cmd/nightshift/commands/worktree_test.go
+++ b/cmd/nightshift/commands/worktree_test.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareExecutionTarget_CleanRepoUsesOriginalPath(t *testing.T) {
+	repo := initRepoWithOriginMain(t)
+
+	target, err := prepareExecutionTarget(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("prepareExecutionTarget: %v", err)
+	}
+	if target.WorkDir != repo {
+		t.Fatalf("WorkDir = %q, want %q", target.WorkDir, repo)
+	}
+	if target.Isolated {
+		t.Fatal("expected non-isolated target for clean repo")
+	}
+	if target.BaseBranch != "main" {
+		t.Fatalf("BaseBranch = %q, want main", target.BaseBranch)
+	}
+}
+
+func TestPrepareExecutionTarget_DirtyRepoUsesOriginMainWorktree(t *testing.T) {
+	repo := initRepoWithOriginMain(t)
+	readme := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(readme, []byte("dirty local change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scratch.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target, err := prepareExecutionTarget(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("prepareExecutionTarget: %v", err)
+	}
+	if !target.Isolated {
+		t.Fatal("expected isolated target for dirty repo")
+	}
+	if target.WorkDir == repo {
+		t.Fatal("expected worktree path to differ from original repo")
+	}
+	if target.BaseBranch != "" {
+		t.Fatalf("BaseBranch = %q, want empty for isolated worktree", target.BaseBranch)
+	}
+
+	content, err := os.ReadFile(filepath.Join(target.WorkDir, "README.md"))
+	if err != nil {
+		t.Fatalf("read worktree README: %v", err)
+	}
+	if strings.Contains(string(content), "dirty local change") {
+		t.Fatalf("worktree README contains dirty local changes: %q", string(content))
+	}
+	if _, err := os.Stat(filepath.Join(target.WorkDir, "scratch.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected untracked scratch.txt to be absent in isolated worktree, got err=%v", err)
+	}
+}
+
+func initRepoWithOriginMain(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	remote := filepath.Join(base, "remote.git")
+	repo := filepath.Join(base, "repo")
+	runGit(t, base, "init", "--bare", remote)
+	runGit(t, base, "clone", remote, repo)
+	runGit(t, repo, "config", "user.name", "Nightshift Test")
+	runGit(t, repo, "config", "user.email", "nightshift@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello from main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "feat: initial commit")
+	runGit(t, repo, "branch", "-M", "main")
+	runGit(t, repo, "push", "-u", "origin", "main")
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return string(out)
+}

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- 2026-03-08: In `nightshift`, never push to the upstream `marcus/nightshift` remote. Verify the remote owner before pushing; default to local commits only unless pushing to a user-writable fork.

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -151,8 +151,13 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 		}
 	}
 
+	// Prefer Claude Code subscription auth when an OAuth token or saved
+	// claude.ai session is available. Claude CLI prioritizes ANTHROPIC_API_KEY
+	// if both are set, which breaks subscription-backed headless runs.
+	cmdName, cmdArgs := a.commandSpec(ctx, args)
+
 	// Run command
-	stdout, stderr, exitCode, err := a.runner.Run(ctx, a.binaryPath, args, opts.WorkDir, stdinContent)
+	stdout, stderr, exitCode, err := a.runner.Run(ctx, cmdName, cmdArgs, opts.WorkDir, stdinContent)
 
 	result := &ExecuteResult{
 		Output:   stdout,
@@ -200,6 +205,48 @@ func (a *ClaudeAgent) ExecuteWithFiles(ctx context.Context, prompt string, files
 		Files:   files,
 		WorkDir: workDir,
 	})
+}
+
+// commandSpec returns the executable/args for Claude CLI invocation.
+func (a *ClaudeAgent) commandSpec(ctx context.Context, args []string) (string, []string) {
+	if strings.TrimSpace(os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")) != "" || a.hasSavedClaudeAIAuth(ctx) {
+		wrapped := append([]string{"-u", "ANTHROPIC_API_KEY", a.binaryPath}, args...)
+		return "env", wrapped
+	}
+	return a.binaryPath, args
+}
+
+// hasSavedClaudeAIAuth reports whether Claude CLI has a usable first-party
+// claude.ai session on disk. When true, Nightshift should not let a stale
+// ANTHROPIC_API_KEY override the subscription-backed login.
+func (a *ClaudeAgent) hasSavedClaudeAIAuth(ctx context.Context) bool {
+	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) == "" {
+		return false
+	}
+
+	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	stdout, _, exitCode, err := a.runner.Run(authCtx, "env", []string{"-u", "ANTHROPIC_API_KEY", a.binaryPath, "auth", "status"}, "", "")
+	if err != nil || exitCode != 0 {
+		return false
+	}
+
+	candidate := a.extractJSON([]byte(stdout))
+	if len(candidate) == 0 {
+		candidate = []byte(stdout)
+	}
+
+	var status struct {
+		LoggedIn    bool   `json:"loggedIn"`
+		AuthMethod  string `json:"authMethod"`
+		APIProvider string `json:"apiProvider"`
+	}
+	if err := json.Unmarshal(candidate, &status); err != nil {
+		return false
+	}
+
+	return status.LoggedIn && (status.AuthMethod == "claude.ai" || status.APIProvider == "firstParty")
 }
 
 // buildFileContext reads files and formats them as context.

--- a/internal/agents/claude_test.go
+++ b/internal/agents/claude_test.go
@@ -17,6 +17,7 @@ type MockRunner struct {
 	ExitCode int
 	Err      error
 	Delay    time.Duration // Simulate slow command
+	RunFunc  func(ctx context.Context, name string, args []string, dir string, stdin string) (stdout, stderr string, exitCode int, err error)
 
 	// Captured values
 	CapturedName  string
@@ -30,6 +31,10 @@ func (m *MockRunner) Run(ctx context.Context, name string, args []string, dir st
 	m.CapturedArgs = args
 	m.CapturedDir = dir
 	m.CapturedStdin = stdin
+
+	if m.RunFunc != nil {
+		return m.RunFunc(ctx, name, args, dir, stdin)
+	}
 
 	if m.Delay > 0 {
 		select {
@@ -79,6 +84,122 @@ func TestClaudeAgent_Name(t *testing.T) {
 	agent := NewClaudeAgent()
 	if agent.Name() != "claude" {
 		t.Errorf("Name() = %q, want %q", agent.Name(), "claude")
+	}
+}
+
+func TestClaudeAgent_Execute_PrefersOAuthTokenOverAPIKey(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("ANTHROPIC_API_KEY", "api-key")
+
+	mock := &MockRunner{Stdout: "ok", ExitCode: 0}
+	agent := NewClaudeAgent(WithRunner(mock))
+
+	result, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test prompt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output != "ok" {
+		t.Fatalf("Output = %q, want ok", result.Output)
+	}
+	if mock.CapturedName != "env" {
+		t.Fatalf("binary = %q, want %q", mock.CapturedName, "env")
+	}
+	want := []string{"-u", "ANTHROPIC_API_KEY", "claude", "--print", "--dangerously-skip-permissions", "test prompt"}
+	if len(mock.CapturedArgs) != len(want) {
+		t.Fatalf("args length = %d, want %d (%v)", len(mock.CapturedArgs), len(want), mock.CapturedArgs)
+	}
+	for i, arg := range want {
+		if mock.CapturedArgs[i] != arg {
+			t.Fatalf("args[%d] = %q, want %q (all=%v)", i, mock.CapturedArgs[i], arg, mock.CapturedArgs)
+		}
+	}
+}
+
+func TestClaudeAgent_Execute_PrefersSavedClaudeAIAuthOverAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "api-key")
+
+	calls := 0
+	mock := &MockRunner{}
+	mock.RunFunc = func(ctx context.Context, name string, args []string, dir string, stdin string) (string, string, int, error) {
+		calls++
+		switch calls {
+		case 1:
+			want := []string{"-u", "ANTHROPIC_API_KEY", "claude", "auth", "status"}
+			if name != "env" {
+				t.Fatalf("auth check binary = %q, want env", name)
+			}
+			if len(args) != len(want) {
+				t.Fatalf("auth check args length = %d, want %d (%v)", len(args), len(want), args)
+			}
+			for i, arg := range want {
+				if args[i] != arg {
+					t.Fatalf("auth check args[%d] = %q, want %q (%v)", i, args[i], arg, args)
+				}
+			}
+			return `{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty"}`, "", 0, nil
+		case 2:
+			want := []string{"-u", "ANTHROPIC_API_KEY", "claude", "--print", "--dangerously-skip-permissions", "test prompt"}
+			if name != "env" {
+				t.Fatalf("execution binary = %q, want env", name)
+			}
+			if len(args) != len(want) {
+				t.Fatalf("execution args length = %d, want %d (%v)", len(args), len(want), args)
+			}
+			for i, arg := range want {
+				if args[i] != arg {
+					t.Fatalf("execution args[%d] = %q, want %q (%v)", i, args[i], arg, args)
+				}
+			}
+			return "saved-auth-ok", "", 0, nil
+		default:
+			t.Fatalf("unexpected extra runner call %d: %s %v", calls, name, args)
+			return "", "", 0, nil
+		}
+	}
+
+	agent := NewClaudeAgent(WithRunner(mock))
+	result, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test prompt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output != "saved-auth-ok" {
+		t.Fatalf("Output = %q, want saved-auth-ok", result.Output)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestClaudeAgent_Execute_PrefersSavedClaudeAIAuthWithExecRunner(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "api-key")
+
+	tmpDir := t.TempDir()
+	fakeClaude := filepath.Join(tmpDir, "fake-claude.sh")
+	script := `#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  printf '{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty"}\n'
+  exit 0
+fi
+if [ -n "$ANTHROPIC_API_KEY" ]; then
+  echo ANTHROPIC_API_KEY_was_set >&2
+  exit 9
+fi
+printf 'saved-auth-exec:%s\n' "$*"
+`
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := NewClaudeAgent(WithBinaryPath(fakeClaude))
+	result, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test prompt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v (result=%+v)", err, result)
+	}
+	if !result.IsSuccess() {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if !strings.Contains(result.Output, "saved-auth-exec:--print --dangerously-skip-permissions test prompt") {
+		t.Fatalf("unexpected output: %q", result.Output)
 	}
 }
 


### PR DESCRIPTION
## What changed
- prefer Claude Code subscription auth over a stale `ANTHROPIC_API_KEY` when `CLAUDE_CODE_OAUTH_TOKEN` or saved `claude.ai` auth is available
- isolate dirty repo Nightshift runs in clean worktrees created from `origin/main`
- add repo instruction forbidding pushes to `marcus/nightshift` and record the lesson

## Why
- Nightshift task runs were failing on Claude when an inherited `ANTHROPIC_API_KEY` overrode valid Claude Code subscription auth
- PR-oriented Nightshift runs in dirty repos were mixing with local in-progress changes, making monitoring noisy and unsafe
- This changes Nightshift to use subscription-backed Claude auth correctly and to run dirty repos from a clean detached worktree rooted at `origin/main`

## Verification
- `go test ./internal/agents -run 'TestClaudeAgent_Execute_(PrefersOAuthTokenOverAPIKey|PrefersSavedClaudeAIAuthOverAPIKey|PrefersSavedClaudeAIAuthWithExecRunner)$'`
- `go test ./cmd/nightshift/commands -run 'TestPrepareExecutionTarget|TestMaxProjects_SkipsProcessedBeforeCounting'`
- `go test ./...`
- live smoke: Claude-backed Nightshift task advanced past auth into planning/implementation
- live smoke: Codex-backed Nightshift task advanced through planning and implementation
- live smoke: dirty temp repo task run showed Nightshift using `.nightshift/worktrees/run-...` while leaving the original dirty checkout untouched

## Notes
- pushes for this local repo are now routed to the fork remote, not `origin`
