### PR TITLE
docs: add missing package doc comments to 20 internal files

### DIFF
--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -1,3 +1,5 @@
+// Package agents provides interfaces and implementations for spawning AI agents.
+//
 // claude.go implements the Agent interface for Claude Code CLI.
 package agents
 

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -1,3 +1,5 @@
+// Package agents provides interfaces and implementations for spawning AI agents.
+//
 // codex.go implements the Agent interface for OpenAI Codex CLI.
 package agents
 

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -1,3 +1,5 @@
+// Package agents provides interfaces and implementations for spawning AI agents.
+//
 // copilot.go implements the Agent interface for GitHub Copilot CLI.
 package agents
 

--- a/internal/analysis/db.go
+++ b/internal/analysis/db.go
@@ -1,3 +1,4 @@
+// Package analysis provides code ownership and bus-factor analysis tools.
 package analysis
 
 import (

--- a/internal/analysis/metrics.go
+++ b/internal/analysis/metrics.go
@@ -1,3 +1,4 @@
+// Package analysis provides code ownership and bus-factor analysis tools.
 package analysis
 
 import (

--- a/internal/analysis/report.go
+++ b/internal/analysis/report.go
@@ -1,3 +1,4 @@
+// Package analysis provides code ownership and bus-factor analysis tools.
 package analysis
 
 import (

--- a/internal/db/import.go
+++ b/internal/db/import.go
@@ -1,3 +1,4 @@
+// Package db provides SQLite-backed storage for nightshift state and snapshots.
 package db
 
 import (

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,3 +1,4 @@
+// Package db provides SQLite-backed storage for nightshift state and snapshots.
 package db
 
 import (

--- a/internal/integrations/agentsmd.go
+++ b/internal/integrations/agentsmd.go
@@ -1,3 +1,4 @@
+// Package integrations provides readers for external configuration and task sources.
 package integrations
 
 import (

--- a/internal/integrations/claudemd.go
+++ b/internal/integrations/claudemd.go
@@ -1,3 +1,4 @@
+// Package integrations provides readers for external configuration and task sources.
 package integrations
 
 import (

--- a/internal/integrations/github.go
+++ b/internal/integrations/github.go
@@ -1,3 +1,4 @@
+// Package integrations provides readers for external configuration and task sources.
 package integrations
 
 import (

--- a/internal/integrations/td.go
+++ b/internal/integrations/td.go
@@ -1,3 +1,4 @@
+// Package integrations provides readers for external configuration and task sources.
 package integrations
 
 import (

--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -1,3 +1,4 @@
+// Package orchestrator coordinates AI agents working on tasks.
 package orchestrator
 
 import "time"

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -1,3 +1,5 @@
+// Package providers defines interfaces and implementations for AI coding agents.
+//
 // claude.go implements the Provider interface for Claude Code CLI.
 package providers
 

--- a/internal/providers/codex.go
+++ b/internal/providers/codex.go
@@ -1,3 +1,5 @@
+// Package providers defines interfaces and implementations for AI coding agents.
+//
 // codex.go implements the Provider interface for OpenAI Codex CLI.
 package providers
 

--- a/internal/providers/copilot.go
+++ b/internal/providers/copilot.go
@@ -1,3 +1,5 @@
+// Package providers defines interfaces and implementations for AI coding agents.
+//
 // copilot.go implements the Provider interface for GitHub Copilot CLI.
 package providers
 

--- a/internal/reporting/run_report.go
+++ b/internal/reporting/run_report.go
@@ -1,3 +1,4 @@
+// Package reporting generates morning summary reports for nightshift runs.
 package reporting
 
 import (

--- a/internal/reporting/run_results.go
+++ b/internal/reporting/run_results.go
@@ -1,3 +1,4 @@
+// Package reporting generates morning summary reports for nightshift runs.
 package reporting
 
 import (

--- a/internal/tasks/register.go
+++ b/internal/tasks/register.go
@@ -1,3 +1,4 @@
+// Package tasks defines task structures and loading from various sources.
 package tasks
 
 import (

--- a/internal/tmux/scraper.go
+++ b/internal/tmux/scraper.go
@@ -1,3 +1,4 @@
+// Package tmux scrapes tmux sessions to detect running AI agent processes and their usage.
 package tmux
 
 import (


### PR DESCRIPTION
Add `// Package <name> ...` doc comments to all 20 internal Go source files that were missing them. Comments reuse the canonical description from each package's primary file, following the existing project convention.

### Files modified
- `internal/agents/{claude,codex,copilot}.go`
- `internal/analysis/{db,metrics,report}.go`
- `internal/db/{import,migrations}.go`
- `internal/integrations/{agentsmd,claudemd,github,td}.go`
- `internal/orchestrator/events.go`
- `internal/providers/{claude,codex,copilot}.go`
- `internal/reporting/{run_report,run_results}.go`
- `internal/tasks/register.go`
- `internal/tmux/scraper.go`

`go build ./...` and `go vet ./...` pass.

Nightshift-Task: docs-backfill
Nightshift-Ref: https://github.com/marcus/nightshift