### PR TITLE
fix: handle 5 silent-error bugs

### DIFF
--- a/internal/analysis/analyzer.go
+++ b/internal/analysis/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -98,7 +99,7 @@ type ParseOptions struct {
 
 // RepositoryExists checks if a valid git repository exists at the given path.
 func RepositoryExists(path string) bool {
-	gitDir := strings.TrimSpace(path) + "/.git"
+	gitDir := filepath.Join(strings.TrimSpace(path), ".git")
 	_, err := os.Stat(gitDir)
 	return err == nil
 }

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -101,7 +101,10 @@ func ExpandGlobPatterns(patterns, excludes []string) ([]string, error) {
 	// Build exclude set (expanded)
 	for _, exc := range excludes {
 		excPath := expandPath(exc)
-		excPath, _ = filepath.Abs(excPath)
+		excPath, err := filepath.Abs(excPath)
+		if err != nil {
+			continue
+		}
 		excludeSet[excPath] = true
 	}
 
@@ -114,7 +117,10 @@ func ExpandGlobPatterns(patterns, excludes []string) ([]string, error) {
 		}
 
 		for _, match := range matches {
-			absMatch, _ := filepath.Abs(match)
+			absMatch, err := filepath.Abs(match)
+			if err != nil {
+				continue
+			}
 
 			// Check if excluded
 			if excludeSet[absMatch] {

--- a/internal/reporting/summary.go
+++ b/internal/reporting/summary.go
@@ -375,7 +375,8 @@ func (g *Generator) sendSlack(summary *Summary, webhookURL string) error {
 		return fmt.Errorf("marshaling slack payload: %w", err)
 	}
 
-	resp, err := http.Post(webhookURL, "application/json", bytes.NewReader(jsonPayload))
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(webhookURL, "application/json", bytes.NewReader(jsonPayload))
 	if err != nil {
 		return fmt.Errorf("posting to slack: %w", err)
 	}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -215,7 +215,10 @@ func ValidateProjectPath(path string) error {
 		return fmt.Errorf("resolving path: %w", err)
 	}
 
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
 
 	blocked := []string{
 		"/",
@@ -223,9 +226,7 @@ func ValidateProjectPath(path string) error {
 		"/var",
 		"/etc",
 		"/usr",
-	}
-	if home != "" {
-		blocked = append(blocked, home)
+		home,
 	}
 
 	for _, b := range blocked {

--- a/internal/snapshots/collector.go
+++ b/internal/snapshots/collector.go
@@ -195,7 +195,10 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 		return Snapshot{}, fmt.Errorf("insert snapshot: %w", err)
 	}
 
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("get snapshot id: %w", err)
+	}
 
 	return Snapshot{
 		ID:               id,


### PR DESCRIPTION
## Summary
- **Snapshot ID=0**: Propagate `LastInsertId()` error instead of discarding it with `_`, which silently produces ID=0
- **Slack webhook hang**: Replace default `http.Post` (no timeout) with `http.Client{Timeout: 30s}` to prevent indefinite hangs
- **Cross-platform path**: Use `filepath.Join` instead of string concatenation for `.git` path in `RepositoryExists`
- **Broken exclude matching**: Check `filepath.Abs` errors in glob expansion instead of silently using empty strings
- **Security bypass**: Return error from `ValidateProjectPath` when `os.UserHomeDir()` fails, preventing home-directory block from being silently skipped

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All tests pass for affected packages (`snapshots`, `reporting`, `analysis`, `projects`, `security`)

Nightshift-Task: bug-finder
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: bug-finder:/Users/marcus/code/nightshift
task-type: bug-finder
task-title: Bug Finder & Fixer
provider: claude
score: 3.0
cost-tier: High (150-500k)
branch: designer
iterations: 1
duration: 7m38s
run-started: 2026-03-23T02:53:32-07:00
nightshift:metadata -->
