### PR TITLE
feat: add service-advisor for package boundary analysis

### DIFF
--- a/cmd/nightshift/commands/serviceadvisor.go
+++ b/cmd/nightshift/commands/serviceadvisor.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/analysis"
+	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/db"
+	"github.com/marcus/nightshift/internal/logging"
+)
+
+var serviceAdvisorCmd = &cobra.Command{
+	Use:   "service-advisor [path]",
+	Short: "Analyze Go package structure for service boundary opportunities",
+	Long: `Analyze Go package structure to identify service boundary opportunities.
+
+Examines packages by coupling (afferent/efferent import ratios), cohesion
+(internal vs cross-package references), size (LOC/file count), and change
+coupling (git co-change frequency) to produce a ranked list of packages
+with extract/merge/keep recommendations.
+
+Metrics:
+  - Coupling: Import dependency connections (afferent + efferent)
+  - Cohesion: Internal references vs exported API surface
+  - Size: Lines of code relative to project total
+  - Churn: Co-change frequency from git history
+  - Extract-Worthiness: Composite score for service extraction potential`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := cmd.Flags().GetString("path")
+		if err != nil {
+			return err
+		}
+
+		if path == "" && len(args) > 0 {
+			path = args[0]
+		}
+		if path == "" {
+			path, err = os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current directory: %w", err)
+			}
+		}
+
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		saveReport, _ := cmd.Flags().GetBool("save")
+		dbPath, _ := cmd.Flags().GetString("db")
+		minLOC, _ := cmd.Flags().GetInt("min-loc")
+
+		return runServiceAdvisor(path, jsonOutput, saveReport, dbPath, minLOC)
+	},
+}
+
+func init() {
+	serviceAdvisorCmd.Flags().StringP("path", "p", "", "Repository or directory path")
+	serviceAdvisorCmd.Flags().Bool("json", false, "Output as JSON")
+	serviceAdvisorCmd.Flags().Bool("save", false, "Save results to database")
+	serviceAdvisorCmd.Flags().String("db", "", "Database path (uses config if not set)")
+	serviceAdvisorCmd.Flags().Int("min-loc", 10, "Minimum LOC threshold for package analysis")
+	rootCmd.AddCommand(serviceAdvisorCmd)
+}
+
+func runServiceAdvisor(path string, jsonOutput, saveReport bool, dbPath string, minLOC int) error {
+	logger := logging.Component("service-advisor")
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolving path: %w", err)
+	}
+
+	if !analysis.RepositoryExists(absPath) {
+		return fmt.Errorf("not a git repository: %s", absPath)
+	}
+
+	// Analyze packages
+	analyzer := analysis.NewServiceAnalyzer(absPath)
+	pkgs, err := analyzer.Analyze(minLOC)
+	if err != nil {
+		return fmt.Errorf("analyzing packages: %w", err)
+	}
+
+	if len(pkgs) == 0 {
+		logger.Warnf("no Go packages found in %s (above %d LOC threshold)", absPath, minLOC)
+		return nil
+	}
+
+	// Calculate metrics
+	analyses := analysis.CalculateServiceMetrics(pkgs)
+
+	// Generate report
+	gen := analysis.NewServiceReportGenerator()
+	component := filepath.Base(absPath)
+	report := gen.Generate(component, analyses)
+
+	// Output
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	markdown := gen.RenderMarkdown(report)
+	fmt.Println(markdown)
+
+	// Save if requested
+	if saveReport {
+		if dbPath == "" {
+			cfg, err := config.Load()
+			if err != nil {
+				logger.Warnf("could not load config for db path: %v", err)
+			} else {
+				dbPath = cfg.ExpandedDBPath()
+			}
+		}
+
+		if dbPath != "" {
+			database, err := db.Open(dbPath)
+			if err != nil {
+				logger.Errorf("opening database: %v", err)
+			} else {
+				defer func() { _ = database.Close() }()
+
+				metrics := make([]analysis.ServiceMetrics, len(analyses))
+				for i, a := range analyses {
+					metrics[i] = a.Metrics
+				}
+
+				result := &analysis.ServiceAdvisorResult{
+					Component:       component,
+					Timestamp:       time.Now(),
+					Packages:        analyses,
+					Metrics:         metrics,
+					Recommendations: report.Recommendations,
+				}
+
+				if err := result.Store(database.SQL()); err != nil {
+					logger.Errorf("storing result: %v", err)
+				} else {
+					logger.Infof("results saved (ID: %d)", result.ID)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/analysis/service.go
+++ b/internal/analysis/service.go
@@ -1,0 +1,321 @@
+package analysis
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PackageInfo holds parsed data about a Go package.
+type PackageInfo struct {
+	Name         string   `json:"name"`
+	Path         string   `json:"path"`          // relative path from repo root
+	Files        int      `json:"files"`         // number of .go files
+	LOC          int      `json:"loc"`           // lines of code
+	Imports      []string `json:"imports"`       // cross-package imports (within module)
+	ImportedBy   []string `json:"imported_by"`   // packages that import this one
+	ExportedSyms int      `json:"exported_syms"` // exported functions/types/vars
+	InternalRefs int      `json:"internal_refs"` // references between files within package
+	CoChanges    []string `json:"co_changes"`    // packages frequently changed together
+}
+
+// ServiceAnalyzer parses Go package structure and git history to extract
+// service boundary data.
+type ServiceAnalyzer struct {
+	repoPath   string
+	modulePath string
+}
+
+// NewServiceAnalyzer creates a new analyzer for the given repository path.
+func NewServiceAnalyzer(repoPath string) *ServiceAnalyzer {
+	return &ServiceAnalyzer{repoPath: repoPath}
+}
+
+// Analyze scans the repository for Go packages and builds package-level data
+// including imports, sizes, exported API surface, and change coupling.
+func (sa *ServiceAnalyzer) Analyze(minLOC int) ([]PackageInfo, error) {
+	// Detect Go module path
+	modPath, err := sa.detectModule()
+	if err != nil {
+		return nil, fmt.Errorf("detecting module: %w", err)
+	}
+	sa.modulePath = modPath
+
+	// Find all Go packages
+	pkgs, err := sa.parsePackages()
+	if err != nil {
+		return nil, fmt.Errorf("parsing packages: %w", err)
+	}
+
+	// Build import graph (imported_by)
+	sa.buildImportGraph(pkgs)
+
+	// Compute co-change data from git history
+	if err := sa.computeCoChanges(pkgs); err != nil {
+		// Non-fatal: git data is supplementary
+		_ = err
+	}
+
+	// Filter by minimum LOC
+	var filtered []PackageInfo
+	for _, pkg := range pkgs {
+		if pkg.LOC >= minLOC {
+			filtered = append(filtered, pkg)
+		}
+	}
+
+	// Sort by LOC descending for consistent output
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].LOC > filtered[j].LOC
+	})
+
+	return filtered, nil
+}
+
+// detectModule reads the module path from go.mod.
+func (sa *ServiceAnalyzer) detectModule() (string, error) {
+	modFile := filepath.Join(sa.repoPath, "go.mod")
+	data, err := os.ReadFile(modFile)
+	if err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimPrefix(line, "module "), nil
+		}
+	}
+	return "", fmt.Errorf("module directive not found in go.mod")
+}
+
+// parsePackages walks the repo tree, parses Go files, and collects package info.
+func (sa *ServiceAnalyzer) parsePackages() ([]PackageInfo, error) {
+	pkgMap := make(map[string]*PackageInfo) // keyed by relative dir path
+
+	err := filepath.Walk(sa.repoPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		// Skip hidden dirs, vendor, testdata
+		if info.IsDir() {
+			base := filepath.Base(path)
+			if strings.HasPrefix(base, ".") || base == "vendor" || base == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		relDir, err := filepath.Rel(sa.repoPath, filepath.Dir(path))
+		if err != nil {
+			return nil
+		}
+
+		pkg, exists := pkgMap[relDir]
+		if !exists {
+			pkg = &PackageInfo{Path: relDir}
+			pkgMap[relDir] = pkg
+		}
+		pkg.Files++
+
+		// Count LOC
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		loc := 0
+		for _, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "//") {
+				loc++
+			}
+		}
+		pkg.LOC += loc
+
+		// Parse AST for imports and exported symbols
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, data, parser.ImportsOnly|parser.ParseComments)
+		if err != nil {
+			return nil // skip unparseable files
+		}
+
+		if pkg.Name == "" {
+			pkg.Name = f.Name.Name
+		}
+
+		for _, imp := range f.Imports {
+			impPath := strings.Trim(imp.Path.Value, `"`)
+			if strings.HasPrefix(impPath, sa.modulePath) {
+				// Convert module import to relative path
+				relImport := strings.TrimPrefix(impPath, sa.modulePath+"/")
+				if relImport != relDir {
+					pkg.Imports = appendUnique(pkg.Imports, relImport)
+				}
+			}
+		}
+
+		// Count exported symbols (re-parse with full AST for declarations)
+		full, err := parser.ParseFile(fset, path, data, 0)
+		if err != nil {
+			return nil
+		}
+		for _, decl := range full.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Name.IsExported() {
+					pkg.ExportedSyms++
+				}
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						if s.Name.IsExported() {
+							pkg.ExportedSyms++
+						}
+					case *ast.ValueSpec:
+						for _, name := range s.Names {
+							if name.IsExported() {
+								pkg.ExportedSyms++
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Count internal references (identifiers referencing other files' symbols)
+		for _, decl := range full.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok {
+				if fn.Body != nil {
+					ast.Inspect(fn.Body, func(n ast.Node) bool {
+						if sel, ok := n.(*ast.SelectorExpr); ok {
+							_ = sel
+							pkg.InternalRefs++
+						}
+						return true
+					})
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking repository: %w", err)
+	}
+
+	result := make([]PackageInfo, 0, len(pkgMap))
+	for _, pkg := range pkgMap {
+		result = append(result, *pkg)
+	}
+	return result, nil
+}
+
+// buildImportGraph populates ImportedBy for each package.
+func (sa *ServiceAnalyzer) buildImportGraph(pkgs []PackageInfo) {
+	byPath := make(map[string]int)
+	for i := range pkgs {
+		byPath[pkgs[i].Path] = i
+	}
+
+	for i := range pkgs {
+		for _, imp := range pkgs[i].Imports {
+			if idx, ok := byPath[imp]; ok {
+				pkgs[idx].ImportedBy = appendUnique(pkgs[idx].ImportedBy, pkgs[i].Path)
+			}
+		}
+	}
+}
+
+// computeCoChanges uses git log to find packages that frequently change together.
+func (sa *ServiceAnalyzer) computeCoChanges(pkgs []PackageInfo) error {
+	// Get recent commits with changed files
+	cmd := exec.Command("git", "log", "--name-only", "--format=COMMIT", "-n", "200")
+	cmd.Dir = sa.repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running git log: %w", err)
+	}
+
+	// Parse commits into sets of changed package dirs
+	var commits []map[string]bool
+	var current map[string]bool
+
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "COMMIT" {
+			if current != nil && len(current) > 0 {
+				commits = append(commits, current)
+			}
+			current = make(map[string]bool)
+			continue
+		}
+		if line == "" || current == nil {
+			continue
+		}
+		dir := filepath.Dir(line)
+		current[dir] = true
+	}
+	if current != nil && len(current) > 0 {
+		commits = append(commits, current)
+	}
+
+	// Build co-change matrix: count how often each pair of packages appears in same commit
+	byPath := make(map[string]int)
+	for i := range pkgs {
+		byPath[pkgs[i].Path] = i
+	}
+
+	type pair struct{ a, b string }
+	coCount := make(map[pair]int)
+
+	for _, commit := range commits {
+		dirs := make([]string, 0, len(commit))
+		for d := range commit {
+			if _, ok := byPath[d]; ok {
+				dirs = append(dirs, d)
+			}
+		}
+		for i := 0; i < len(dirs); i++ {
+			for j := i + 1; j < len(dirs); j++ {
+				a, b := dirs[i], dirs[j]
+				if a > b {
+					a, b = b, a
+				}
+				coCount[pair{a, b}]++
+			}
+		}
+	}
+
+	// Assign co-changes where count >= 3 (meaningful frequency)
+	threshold := 3
+	for p, count := range coCount {
+		if count >= threshold {
+			if idx, ok := byPath[p.a]; ok {
+				pkgs[idx].CoChanges = appendUnique(pkgs[idx].CoChanges, p.b)
+			}
+			if idx, ok := byPath[p.b]; ok {
+				pkgs[idx].CoChanges = appendUnique(pkgs[idx].CoChanges, p.a)
+			}
+		}
+	}
+
+	return nil
+}
+
+func appendUnique(slice []string, val string) []string {
+	for _, s := range slice {
+		if s == val {
+			return slice
+		}
+	}
+	return append(slice, val)
+}

--- a/internal/analysis/service_db.go
+++ b/internal/analysis/service_db.go
@@ -1,0 +1,182 @@
+package analysis
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ServiceAdvisorResult represents a stored service boundary analysis result.
+type ServiceAdvisorResult struct {
+	ID              int64             `json:"id"`
+	Component       string            `json:"component"`
+	Timestamp       time.Time         `json:"timestamp"`
+	Packages        []PackageAnalysis `json:"packages"`
+	Metrics         []ServiceMetrics  `json:"metrics"`
+	Recommendations []string          `json:"recommendations"`
+	ReportPath      string            `json:"report_path,omitempty"`
+}
+
+// StoreServiceResult saves a service advisor result to the database.
+func (result *ServiceAdvisorResult) Store(db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("database is nil")
+	}
+
+	packagesJSON, err := json.Marshal(result.Packages)
+	if err != nil {
+		return fmt.Errorf("marshaling packages: %w", err)
+	}
+
+	metricsJSON, err := json.Marshal(result.Metrics)
+	if err != nil {
+		return fmt.Errorf("marshaling metrics: %w", err)
+	}
+
+	recsJSON, err := json.Marshal(result.Recommendations)
+	if err != nil {
+		return fmt.Errorf("marshaling recommendations: %w", err)
+	}
+
+	query := `
+		INSERT INTO service_advisor_results (component, timestamp, packages, metrics, recommendations, report_path)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`
+
+	res, err := db.Exec(query,
+		result.Component,
+		result.Timestamp,
+		string(packagesJSON),
+		string(metricsJSON),
+		string(recsJSON),
+		result.ReportPath,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting service advisor result: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("getting insert id: %w", err)
+	}
+	result.ID = id
+
+	return nil
+}
+
+// LoadLatestServiceResult loads the most recent service advisor result for a component.
+func LoadLatestServiceResult(db *sql.DB, component string) (*ServiceAdvisorResult, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+
+	query := `
+		SELECT id, component, timestamp, packages, metrics, recommendations, report_path
+		FROM service_advisor_results
+		WHERE component = ?
+		ORDER BY timestamp DESC
+		LIMIT 1
+	`
+
+	row := db.QueryRow(query, component)
+
+	result := &ServiceAdvisorResult{}
+	var packagesJSON, metricsJSON, recsJSON string
+
+	err := row.Scan(
+		&result.ID,
+		&result.Component,
+		&result.Timestamp,
+		&packagesJSON,
+		&metricsJSON,
+		&recsJSON,
+		&result.ReportPath,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("querying service advisor result: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(packagesJSON), &result.Packages); err != nil {
+		return nil, fmt.Errorf("unmarshaling packages: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(metricsJSON), &result.Metrics); err != nil {
+		return nil, fmt.Errorf("unmarshaling metrics: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(recsJSON), &result.Recommendations); err != nil {
+		return nil, fmt.Errorf("unmarshaling recommendations: %w", err)
+	}
+
+	return result, nil
+}
+
+// LoadAllServiceResults loads all service advisor results for a component.
+func LoadAllServiceResults(db *sql.DB, component string, since time.Time) ([]ServiceAdvisorResult, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+
+	query := `
+		SELECT id, component, timestamp, packages, metrics, recommendations, report_path
+		FROM service_advisor_results
+		WHERE component = ?
+	`
+	args := []any{component}
+
+	if !since.IsZero() {
+		query += " AND timestamp >= ?"
+		args = append(args, since)
+	}
+
+	query += " ORDER BY timestamp DESC"
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying service advisor results: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ServiceAdvisorResult
+	for rows.Next() {
+		result := ServiceAdvisorResult{}
+		var packagesJSON, metricsJSON, recsJSON string
+
+		err := rows.Scan(
+			&result.ID,
+			&result.Component,
+			&result.Timestamp,
+			&packagesJSON,
+			&metricsJSON,
+			&recsJSON,
+			&result.ReportPath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning service advisor result: %w", err)
+		}
+
+		if err := json.Unmarshal([]byte(packagesJSON), &result.Packages); err != nil {
+			return nil, fmt.Errorf("unmarshaling packages: %w", err)
+		}
+
+		if err := json.Unmarshal([]byte(metricsJSON), &result.Metrics); err != nil {
+			return nil, fmt.Errorf("unmarshaling metrics: %w", err)
+		}
+
+		if err := json.Unmarshal([]byte(recsJSON), &result.Recommendations); err != nil {
+			return nil, fmt.Errorf("unmarshaling recommendations: %w", err)
+		}
+
+		results = append(results, result)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating service advisor results: %w", err)
+	}
+
+	return results, nil
+}

--- a/internal/analysis/service_db_test.go
+++ b/internal/analysis/service_db_test.go
@@ -1,0 +1,156 @@
+package analysis
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE service_advisor_results (
+			id              INTEGER PRIMARY KEY AUTOINCREMENT,
+			component       TEXT NOT NULL,
+			timestamp       DATETIME NOT NULL,
+			packages        TEXT NOT NULL,
+			metrics         TEXT NOT NULL,
+			recommendations TEXT NOT NULL,
+			report_path     TEXT
+		);
+		CREATE INDEX idx_service_advisor_component_time ON service_advisor_results(component, timestamp DESC);
+	`)
+	if err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+
+	return db
+}
+
+func TestServiceAdvisorResultStoreAndLoad(t *testing.T) {
+	db := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	result := &ServiceAdvisorResult{
+		Component: "test-project",
+		Timestamp: time.Now().Truncate(time.Second),
+		Packages: []PackageAnalysis{
+			{
+				Package: PackageInfo{Name: "api", Path: "internal/api", Files: 5, LOC: 500},
+				Metrics: ServiceMetrics{CouplingScore: 0.3, CohesionScore: 0.8, Recommendation: "extract"},
+			},
+		},
+		Metrics: []ServiceMetrics{
+			{CouplingScore: 0.3, CohesionScore: 0.8, Recommendation: "extract"},
+		},
+		Recommendations: []string{"Extract internal/api"},
+	}
+
+	// Store
+	if err := result.Store(db); err != nil {
+		t.Fatalf("storing result: %v", err)
+	}
+	if result.ID == 0 {
+		t.Errorf("expected non-zero ID after store")
+	}
+
+	// Load latest
+	loaded, err := LoadLatestServiceResult(db, "test-project")
+	if err != nil {
+		t.Fatalf("loading latest: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if loaded.Component != "test-project" {
+		t.Errorf("expected component 'test-project', got %s", loaded.Component)
+	}
+	if len(loaded.Packages) != 1 {
+		t.Errorf("expected 1 package, got %d", len(loaded.Packages))
+	}
+	if loaded.Packages[0].Package.Path != "internal/api" {
+		t.Errorf("expected package path 'internal/api', got %s", loaded.Packages[0].Package.Path)
+	}
+	if len(loaded.Recommendations) != 1 {
+		t.Errorf("expected 1 recommendation, got %d", len(loaded.Recommendations))
+	}
+}
+
+func TestServiceAdvisorResultStoreNilDB(t *testing.T) {
+	result := &ServiceAdvisorResult{}
+	if err := result.Store(nil); err == nil {
+		t.Errorf("expected error for nil db")
+	}
+}
+
+func TestLoadLatestServiceResultNilDB(t *testing.T) {
+	_, err := LoadLatestServiceResult(nil, "test")
+	if err == nil {
+		t.Errorf("expected error for nil db")
+	}
+}
+
+func TestLoadLatestServiceResultNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	result, err := LoadLatestServiceResult(db, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil for nonexistent component")
+	}
+}
+
+func TestLoadAllServiceResults(t *testing.T) {
+	db := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Store two results
+	for i := 0; i < 2; i++ {
+		result := &ServiceAdvisorResult{
+			Component:       "test-project",
+			Timestamp:       time.Now().Add(time.Duration(i) * time.Hour),
+			Packages:        []PackageAnalysis{},
+			Metrics:         []ServiceMetrics{},
+			Recommendations: []string{"rec"},
+		}
+		if err := result.Store(db); err != nil {
+			t.Fatalf("storing result %d: %v", i, err)
+		}
+	}
+
+	// Load all
+	results, err := LoadAllServiceResults(db, "test-project", time.Time{})
+	if err != nil {
+		t.Fatalf("loading all: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+
+	// Load with since filter
+	future := time.Now().Add(24 * time.Hour)
+	results2, err := LoadAllServiceResults(db, "test-project", future)
+	if err != nil {
+		t.Fatalf("loading with since: %v", err)
+	}
+	if len(results2) != 0 {
+		t.Errorf("expected 0 results with future since, got %d", len(results2))
+	}
+}
+
+func TestLoadAllServiceResultsNilDB(t *testing.T) {
+	_, err := LoadAllServiceResults(nil, "test", time.Time{})
+	if err == nil {
+		t.Errorf("expected error for nil db")
+	}
+}

--- a/internal/analysis/service_metrics.go
+++ b/internal/analysis/service_metrics.go
@@ -1,0 +1,166 @@
+package analysis
+
+import (
+	"fmt"
+	"math"
+)
+
+// ServiceMetrics holds computed metrics for a single package's service boundary potential.
+type ServiceMetrics struct {
+	// CouplingScore measures afferent/efferent coupling ratio (0=isolated, 1=highly coupled)
+	CouplingScore float64 `json:"coupling_score"`
+	// CohesionScore measures internal vs external references (0=low cohesion, 1=high cohesion)
+	CohesionScore float64 `json:"cohesion_score"`
+	// SizeScore measures relative LOC size (0=small, 1=very large relative to project)
+	SizeScore float64 `json:"size_score"`
+	// ChurnCorrelation measures co-change frequency with other packages (0=independent, 1=always co-changed)
+	ChurnCorrelation float64 `json:"churn_correlation"`
+	// ExtractWorthiness is a composite score (0=keep as-is, 1=strong extraction candidate)
+	ExtractWorthiness float64 `json:"extract_worthiness"`
+	// AfferentCoupling is the number of packages that depend on this package
+	AfferentCoupling int `json:"afferent_coupling"`
+	// EfferentCoupling is the number of packages this package depends on
+	EfferentCoupling int `json:"efferent_coupling"`
+	// Recommendation is the suggested action: "extract", "merge", or "keep"
+	Recommendation string `json:"recommendation"`
+}
+
+// PackageAnalysis pairs a package with its computed metrics.
+type PackageAnalysis struct {
+	Package PackageInfo    `json:"package"`
+	Metrics ServiceMetrics `json:"metrics"`
+}
+
+// CalculateServiceMetrics computes service boundary metrics for each package.
+func CalculateServiceMetrics(pkgs []PackageInfo) []PackageAnalysis {
+	if len(pkgs) == 0 {
+		return nil
+	}
+
+	// Compute total LOC across all packages for relative size
+	totalLOC := 0
+	for _, pkg := range pkgs {
+		totalLOC += pkg.LOC
+	}
+
+	results := make([]PackageAnalysis, len(pkgs))
+	for i, pkg := range pkgs {
+		m := computeMetrics(pkg, totalLOC, len(pkgs))
+		results[i] = PackageAnalysis{
+			Package: pkg,
+			Metrics: m,
+		}
+	}
+
+	return results
+}
+
+func computeMetrics(pkg PackageInfo, totalLOC, totalPkgs int) ServiceMetrics {
+	afferent := len(pkg.ImportedBy)
+	efferent := len(pkg.Imports)
+
+	coupling := computeCouplingScore(afferent, efferent)
+	cohesion := computeCohesionScore(pkg)
+	size := computeSizeScore(pkg.LOC, totalLOC)
+	churn := computeChurnCorrelation(pkg, totalPkgs)
+	extract := computeExtractWorthiness(coupling, cohesion, size, churn)
+	rec := recommendAction(extract, coupling, cohesion, size, pkg)
+
+	return ServiceMetrics{
+		CouplingScore:     coupling,
+		CohesionScore:     cohesion,
+		SizeScore:         size,
+		ChurnCorrelation:  churn,
+		ExtractWorthiness: extract,
+		AfferentCoupling:  afferent,
+		EfferentCoupling:  efferent,
+		Recommendation:    rec,
+	}
+}
+
+// computeCouplingScore calculates instability: Ce / (Ca + Ce).
+// High instability (close to 1) = depends on many, depended on by few.
+// Low instability (close to 0) = stable, depended on by many.
+// We return coupling as the ratio of total connections relative to a reasonable max.
+func computeCouplingScore(afferent, efferent int) float64 {
+	total := afferent + efferent
+	if total == 0 {
+		return 0
+	}
+	// Normalize: assume > 10 total connections is highly coupled
+	score := float64(total) / 10.0
+	return math.Min(score, 1.0)
+}
+
+// computeCohesionScore estimates internal cohesion.
+// High exported symbols with few internal references suggests low cohesion (grab bag).
+// Many internal references relative to exports suggests high cohesion (tightly related).
+func computeCohesionScore(pkg PackageInfo) float64 {
+	if pkg.ExportedSyms == 0 {
+		return 1.0 // No exports = internally cohesive by default
+	}
+	// Ratio of internal references to exported symbols
+	ratio := float64(pkg.InternalRefs) / float64(pkg.ExportedSyms)
+	// Normalize: ratio of 5+ internal refs per export = high cohesion
+	score := math.Min(ratio/5.0, 1.0)
+	return score
+}
+
+// computeSizeScore returns how large this package is relative to the project.
+func computeSizeScore(pkgLOC, totalLOC int) float64 {
+	if totalLOC == 0 {
+		return 0
+	}
+	// A package with > 20% of total LOC is very large
+	ratio := float64(pkgLOC) / float64(totalLOC)
+	score := ratio / 0.20
+	return math.Min(score, 1.0)
+}
+
+// computeChurnCorrelation measures how frequently this package co-changes with others.
+func computeChurnCorrelation(pkg PackageInfo, totalPkgs int) float64 {
+	if totalPkgs <= 1 {
+		return 0
+	}
+	// Fraction of other packages this one co-changes with
+	ratio := float64(len(pkg.CoChanges)) / float64(totalPkgs-1)
+	return math.Min(ratio, 1.0)
+}
+
+// computeExtractWorthiness combines metrics into a single score.
+// Higher = stronger candidate for extraction into its own service.
+func computeExtractWorthiness(coupling, cohesion, size, churn float64) float64 {
+	// Weights: size and cohesion matter most for extraction decisions
+	// High cohesion + large size + low coupling + low churn = good extraction candidate
+	// We want: high cohesion (good), large size (indicates complexity), low coupling (clean boundary), low churn (stable)
+	score := (cohesion*0.30 + size*0.30 + (1-coupling)*0.20 + (1-churn)*0.20)
+	return math.Round(score*1000) / 1000
+}
+
+// recommendAction suggests what to do with the package.
+func recommendAction(extract, coupling, cohesion, size float64, pkg PackageInfo) string {
+	// Small packages with low cohesion: merge candidates
+	if size < 0.1 && pkg.Files <= 2 && pkg.LOC < 100 {
+		return "merge"
+	}
+
+	// High extract-worthiness: extraction candidates
+	if extract >= 0.6 && cohesion >= 0.4 && size >= 0.2 {
+		return "extract"
+	}
+
+	return "keep"
+}
+
+// String returns a human-readable summary of service metrics.
+func (sm *ServiceMetrics) String() string {
+	return fmt.Sprintf(
+		"Coupling: %.2f | Cohesion: %.2f | Size: %.2f | Churn: %.2f | Extract: %.3f | Rec: %s",
+		sm.CouplingScore,
+		sm.CohesionScore,
+		sm.SizeScore,
+		sm.ChurnCorrelation,
+		sm.ExtractWorthiness,
+		sm.Recommendation,
+	)
+}

--- a/internal/analysis/service_report.go
+++ b/internal/analysis/service_report.go
@@ -1,0 +1,208 @@
+package analysis
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ServiceReport represents a service boundary analysis report.
+type ServiceReport struct {
+	Timestamp       time.Time         `json:"timestamp"`
+	Component       string            `json:"component"`
+	Packages        []PackageAnalysis `json:"packages"`
+	Recommendations []string          `json:"recommendations"`
+	ReportedAt      string            `json:"reported_at"`
+	TotalPackages   int               `json:"total_packages"`
+	TotalLOC        int               `json:"total_loc"`
+}
+
+// ServiceReportGenerator creates formatted service boundary reports.
+type ServiceReportGenerator struct{}
+
+// NewServiceReportGenerator creates a new report generator.
+func NewServiceReportGenerator() *ServiceReportGenerator {
+	return &ServiceReportGenerator{}
+}
+
+// Generate creates a service report from package analysis results.
+func (rg *ServiceReportGenerator) Generate(component string, analyses []PackageAnalysis) *ServiceReport {
+	// Sort by extract-worthiness descending
+	sorted := make([]PackageAnalysis, len(analyses))
+	copy(sorted, analyses)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Metrics.ExtractWorthiness > sorted[j].Metrics.ExtractWorthiness
+	})
+
+	totalLOC := 0
+	for _, a := range sorted {
+		totalLOC += a.Package.LOC
+	}
+
+	report := &ServiceReport{
+		Timestamp:       time.Now(),
+		Component:       component,
+		Packages:        sorted,
+		ReportedAt:      time.Now().Format("2006-01-02 15:04:05"),
+		TotalPackages:   len(sorted),
+		TotalLOC:        totalLOC,
+		Recommendations: rg.generateRecommendations(sorted),
+	}
+
+	return report
+}
+
+func (rg *ServiceReportGenerator) generateRecommendations(analyses []PackageAnalysis) []string {
+	var recs []string
+
+	var extractCount, mergeCount int
+	for _, a := range analyses {
+		switch a.Metrics.Recommendation {
+		case "extract":
+			extractCount++
+		case "merge":
+			mergeCount++
+		}
+	}
+
+	if extractCount > 0 {
+		recs = append(recs, fmt.Sprintf("Found %d package(s) that are strong candidates for service extraction.", extractCount))
+		for _, a := range analyses {
+			if a.Metrics.Recommendation == "extract" {
+				recs = append(recs, fmt.Sprintf("  - %s (%d LOC, %.0f%% cohesion, extract score: %.3f)",
+					a.Package.Path, a.Package.LOC, a.Metrics.CohesionScore*100, a.Metrics.ExtractWorthiness))
+			}
+		}
+	}
+
+	if mergeCount > 0 {
+		recs = append(recs, fmt.Sprintf("Found %d package(s) that may benefit from merging into a neighbor.", mergeCount))
+		for _, a := range analyses {
+			if a.Metrics.Recommendation == "merge" {
+				target := "a related package"
+				if len(a.Package.Imports) > 0 {
+					target = a.Package.Imports[0]
+				}
+				recs = append(recs, fmt.Sprintf("  - %s (%d LOC, %d files) could merge into %s",
+					a.Package.Path, a.Package.LOC, a.Package.Files, target))
+			}
+		}
+	}
+
+	if extractCount == 0 && mergeCount == 0 {
+		recs = append(recs, "Package structure looks healthy. No strong extraction or merge candidates found.")
+	}
+
+	// Look for high coupling packages
+	for _, a := range analyses {
+		if a.Metrics.CouplingScore > 0.7 {
+			recs = append(recs, fmt.Sprintf("High coupling: %s has %d afferent + %d efferent dependencies. Consider interface boundaries.",
+				a.Package.Path, a.Metrics.AfferentCoupling, a.Metrics.EfferentCoupling))
+		}
+	}
+
+	// Look for high churn correlation
+	for _, a := range analyses {
+		if a.Metrics.ChurnCorrelation > 0.5 {
+			recs = append(recs, fmt.Sprintf("High change coupling: %s frequently co-changes with %d other packages. This suggests hidden dependencies.",
+				a.Package.Path, len(a.Package.CoChanges)))
+		}
+	}
+
+	return recs
+}
+
+// RenderMarkdown generates a markdown representation of the service report.
+func (rg *ServiceReportGenerator) RenderMarkdown(report *ServiceReport) string {
+	var buf bytes.Buffer
+
+	// Header
+	fmt.Fprintf(&buf, "# Service Boundary Analysis - %s\n\n", report.Component)
+	fmt.Fprintf(&buf, "*Generated: %s*\n\n", report.ReportedAt)
+
+	// Summary
+	buf.WriteString("## Summary\n\n")
+	buf.WriteString("| Metric | Value |\n")
+	buf.WriteString("|--------|-------|\n")
+	fmt.Fprintf(&buf, "| Total Packages | %d |\n", report.TotalPackages)
+	fmt.Fprintf(&buf, "| Total LOC | %d |\n\n", report.TotalLOC)
+
+	// Package details table
+	if len(report.Packages) > 0 {
+		buf.WriteString("## Packages by Extract-Worthiness\n\n")
+		buf.WriteString("| Package | LOC | Files | Coupling | Cohesion | Size | Churn | Score | Rec |\n")
+		buf.WriteString("|---------|-----|-------|----------|----------|------|-------|-------|-----|\n")
+
+		for _, a := range report.Packages {
+			fmt.Fprintf(&buf, "| %s | %d | %d | %.2f | %.2f | %.2f | %.2f | %.3f | **%s** |\n",
+				a.Package.Path,
+				a.Package.LOC,
+				a.Package.Files,
+				a.Metrics.CouplingScore,
+				a.Metrics.CohesionScore,
+				a.Metrics.SizeScore,
+				a.Metrics.ChurnCorrelation,
+				a.Metrics.ExtractWorthiness,
+				a.Metrics.Recommendation,
+			)
+		}
+		buf.WriteString("\n")
+	}
+
+	// Import graph
+	hasImports := false
+	for _, a := range report.Packages {
+		if len(a.Package.Imports) > 0 || len(a.Package.ImportedBy) > 0 {
+			hasImports = true
+			break
+		}
+	}
+	if hasImports {
+		buf.WriteString("## Import Graph\n\n")
+		for _, a := range report.Packages {
+			if len(a.Package.Imports) == 0 && len(a.Package.ImportedBy) == 0 {
+				continue
+			}
+			fmt.Fprintf(&buf, "### %s\n", a.Package.Path)
+			if len(a.Package.Imports) > 0 {
+				fmt.Fprintf(&buf, "- **Depends on**: %s\n", joinPaths(a.Package.Imports))
+			}
+			if len(a.Package.ImportedBy) > 0 {
+				fmt.Fprintf(&buf, "- **Used by**: %s\n", joinPaths(a.Package.ImportedBy))
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	// Recommendations
+	if len(report.Recommendations) > 0 {
+		buf.WriteString("## Recommendations\n\n")
+		for _, rec := range report.Recommendations {
+			fmt.Fprintf(&buf, "- %s\n", rec)
+		}
+		buf.WriteString("\n")
+	}
+
+	// Scoring explanation
+	buf.WriteString("## Scoring Guide\n\n")
+	buf.WriteString("- **Coupling**: Total import connections relative to max (0=isolated, 1=highly coupled)\n")
+	buf.WriteString("- **Cohesion**: Internal references vs exports (0=low cohesion, 1=high cohesion)\n")
+	buf.WriteString("- **Size**: LOC relative to project (0=tiny, 1=very large)\n")
+	buf.WriteString("- **Churn**: Co-change frequency with other packages (0=independent, 1=always co-changed)\n")
+	buf.WriteString("- **Score**: Composite extract-worthiness (higher = stronger extraction candidate)\n")
+	buf.WriteString("- **Rec**: extract (good service candidate), merge (too small), keep (fine as-is)\n")
+
+	return buf.String()
+}
+
+func joinPaths(paths []string) string {
+	var buf bytes.Buffer
+	for i, p := range paths {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "`%s`", p)
+	}
+	return buf.String()
+}

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -1,0 +1,322 @@
+package analysis
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCalculateServiceMetricsEmpty(t *testing.T) {
+	results := CalculateServiceMetrics(nil)
+	if results != nil {
+		t.Errorf("expected nil for empty input, got %v", results)
+	}
+}
+
+func TestCalculateServiceMetricsSinglePackage(t *testing.T) {
+	pkgs := []PackageInfo{
+		{Name: "main", Path: "cmd/app", Files: 3, LOC: 500, ExportedSyms: 5, InternalRefs: 20},
+	}
+
+	results := CalculateServiceMetrics(pkgs)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	m := results[0].Metrics
+	// Single package with no imports = 0 coupling
+	if m.CouplingScore != 0 {
+		t.Errorf("expected 0 coupling for isolated package, got %.2f", m.CouplingScore)
+	}
+	// 500 LOC is 100% of project = size score should be 1.0
+	if m.SizeScore != 1.0 {
+		t.Errorf("expected size score 1.0 for only package, got %.2f", m.SizeScore)
+	}
+	// Large, cohesive, isolated package = extract candidate
+	if m.Recommendation != "extract" {
+		t.Errorf("expected 'extract' recommendation for large cohesive package, got %s", m.Recommendation)
+	}
+}
+
+func TestCalculateServiceMetricsMultiplePackages(t *testing.T) {
+	pkgs := []PackageInfo{
+		{
+			Name: "api", Path: "internal/api", Files: 10, LOC: 2000,
+			Imports:      []string{"internal/db", "internal/auth"},
+			ExportedSyms: 30, InternalRefs: 100,
+		},
+		{
+			Name: "db", Path: "internal/db", Files: 5, LOC: 800,
+			ImportedBy:   []string{"internal/api"},
+			ExportedSyms: 15, InternalRefs: 40,
+		},
+		{
+			Name: "auth", Path: "internal/auth", Files: 3, LOC: 300,
+			ImportedBy:   []string{"internal/api"},
+			ExportedSyms: 8, InternalRefs: 25,
+		},
+		{
+			Name: "util", Path: "internal/util", Files: 1, LOC: 50,
+			ExportedSyms: 3, InternalRefs: 0,
+		},
+	}
+
+	results := CalculateServiceMetrics(pkgs)
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	// api package has 2 efferent deps = some coupling
+	for _, r := range results {
+		if r.Package.Path == "internal/api" {
+			if r.Metrics.EfferentCoupling != 2 {
+				t.Errorf("expected api efferent=2, got %d", r.Metrics.EfferentCoupling)
+			}
+		}
+		if r.Package.Path == "internal/db" {
+			if r.Metrics.AfferentCoupling != 1 {
+				t.Errorf("expected db afferent=1, got %d", r.Metrics.AfferentCoupling)
+			}
+		}
+	}
+}
+
+func TestComputeCouplingScore(t *testing.T) {
+	tests := []struct {
+		afferent int
+		efferent int
+		wantZero bool
+		wantMax  bool
+	}{
+		{0, 0, true, false},
+		{5, 5, false, true},  // 10 total = 1.0
+		{2, 1, false, false}, // 3 total = 0.3
+	}
+
+	for _, tt := range tests {
+		score := computeCouplingScore(tt.afferent, tt.efferent)
+		if tt.wantZero && score != 0 {
+			t.Errorf("coupling(%d,%d) = %.2f, want 0", tt.afferent, tt.efferent, score)
+		}
+		if tt.wantMax && score != 1.0 {
+			t.Errorf("coupling(%d,%d) = %.2f, want 1.0", tt.afferent, tt.efferent, score)
+		}
+		if score < 0 || score > 1 {
+			t.Errorf("coupling(%d,%d) = %.2f, out of [0,1] range", tt.afferent, tt.efferent, score)
+		}
+	}
+}
+
+func TestComputeCohesionScore(t *testing.T) {
+	// No exports = high cohesion (1.0)
+	pkg1 := PackageInfo{ExportedSyms: 0, InternalRefs: 10}
+	if s := computeCohesionScore(pkg1); s != 1.0 {
+		t.Errorf("no exports should give cohesion 1.0, got %.2f", s)
+	}
+
+	// Many refs per export = high cohesion
+	pkg2 := PackageInfo{ExportedSyms: 5, InternalRefs: 50}
+	s2 := computeCohesionScore(pkg2)
+	if s2 < 0.9 {
+		t.Errorf("10 refs/export should give high cohesion, got %.2f", s2)
+	}
+
+	// Few refs per export = low cohesion
+	pkg3 := PackageInfo{ExportedSyms: 20, InternalRefs: 5}
+	s3 := computeCohesionScore(pkg3)
+	if s3 > 0.1 {
+		t.Errorf("0.25 refs/export should give low cohesion, got %.2f", s3)
+	}
+}
+
+func TestComputeSizeScore(t *testing.T) {
+	// 0 total LOC
+	if s := computeSizeScore(100, 0); s != 0 {
+		t.Errorf("size with 0 total should be 0, got %.2f", s)
+	}
+
+	// Package is 20% of project = score 1.0
+	if s := computeSizeScore(200, 1000); s != 1.0 {
+		t.Errorf("20%% of project should be 1.0, got %.2f", s)
+	}
+
+	// Package is 10% of project = score 0.5
+	s := computeSizeScore(100, 1000)
+	if s < 0.49 || s > 0.51 {
+		t.Errorf("10%% of project should be ~0.5, got %.2f", s)
+	}
+}
+
+func TestComputeChurnCorrelation(t *testing.T) {
+	// No co-changes
+	pkg1 := PackageInfo{}
+	if s := computeChurnCorrelation(pkg1, 5); s != 0 {
+		t.Errorf("no co-changes should be 0, got %.2f", s)
+	}
+
+	// Single package in project
+	if s := computeChurnCorrelation(pkg1, 1); s != 0 {
+		t.Errorf("single package should be 0, got %.2f", s)
+	}
+
+	// Co-changes with all other packages
+	pkg2 := PackageInfo{CoChanges: []string{"a", "b", "c", "d"}}
+	if s := computeChurnCorrelation(pkg2, 5); s != 1.0 {
+		t.Errorf("co-change with all should be 1.0, got %.2f", s)
+	}
+}
+
+func TestComputeExtractWorthiness(t *testing.T) {
+	// Perfect extraction candidate: high cohesion, large, low coupling, low churn
+	score := computeExtractWorthiness(0, 1.0, 1.0, 0)
+	if score < 0.9 {
+		t.Errorf("ideal candidate should score >0.9, got %.3f", score)
+	}
+
+	// Poor candidate: high coupling, low cohesion, small, high churn
+	score2 := computeExtractWorthiness(1.0, 0, 0, 1.0)
+	if score2 > 0.1 {
+		t.Errorf("poor candidate should score <0.1, got %.3f", score2)
+	}
+}
+
+func TestRecommendAction(t *testing.T) {
+	// Small package = merge
+	rec := recommendAction(0.3, 0.1, 0.1, 0.05, PackageInfo{Files: 1, LOC: 50})
+	if rec != "merge" {
+		t.Errorf("small package should get 'merge', got %s", rec)
+	}
+
+	// High extract score with good metrics = extract
+	rec2 := recommendAction(0.7, 0.2, 0.8, 0.3, PackageInfo{Files: 10, LOC: 1000})
+	if rec2 != "extract" {
+		t.Errorf("large cohesive package should get 'extract', got %s", rec2)
+	}
+
+	// Default = keep
+	rec3 := recommendAction(0.4, 0.5, 0.3, 0.15, PackageInfo{Files: 5, LOC: 300})
+	if rec3 != "keep" {
+		t.Errorf("average package should get 'keep', got %s", rec3)
+	}
+}
+
+func TestServiceMetricsString(t *testing.T) {
+	m := ServiceMetrics{
+		CouplingScore:     0.3,
+		CohesionScore:     0.8,
+		SizeScore:         0.5,
+		ChurnCorrelation:  0.1,
+		ExtractWorthiness: 0.650,
+		Recommendation:    "extract",
+	}
+
+	str := m.String()
+	if !strings.Contains(str, "Coupling: 0.30") {
+		t.Errorf("string should contain coupling, got %s", str)
+	}
+	if !strings.Contains(str, "Rec: extract") {
+		t.Errorf("string should contain recommendation, got %s", str)
+	}
+}
+
+func TestServiceReportGenerate(t *testing.T) {
+	analyses := []PackageAnalysis{
+		{
+			Package: PackageInfo{Name: "api", Path: "internal/api", Files: 5, LOC: 500},
+			Metrics: ServiceMetrics{ExtractWorthiness: 0.7, Recommendation: "extract"},
+		},
+		{
+			Package: PackageInfo{Name: "util", Path: "internal/util", Files: 1, LOC: 30},
+			Metrics: ServiceMetrics{ExtractWorthiness: 0.2, Recommendation: "merge"},
+		},
+	}
+
+	gen := NewServiceReportGenerator()
+	report := gen.Generate("test-project", analyses)
+
+	if report.Component != "test-project" {
+		t.Errorf("expected component 'test-project', got %s", report.Component)
+	}
+	if report.TotalPackages != 2 {
+		t.Errorf("expected 2 packages, got %d", report.TotalPackages)
+	}
+	if report.TotalLOC != 530 {
+		t.Errorf("expected 530 total LOC, got %d", report.TotalLOC)
+	}
+	// Should be sorted by extract-worthiness descending
+	if report.Packages[0].Package.Path != "internal/api" {
+		t.Errorf("expected api first (higher score), got %s", report.Packages[0].Package.Path)
+	}
+	if len(report.Recommendations) == 0 {
+		t.Errorf("expected recommendations to be generated")
+	}
+}
+
+func TestServiceReportRenderMarkdown(t *testing.T) {
+	analyses := []PackageAnalysis{
+		{
+			Package: PackageInfo{
+				Name: "api", Path: "internal/api", Files: 5, LOC: 500,
+				Imports: []string{"internal/db"}, ImportedBy: []string{"cmd/app"},
+			},
+			Metrics: ServiceMetrics{
+				CouplingScore: 0.3, CohesionScore: 0.8, SizeScore: 0.5,
+				ExtractWorthiness: 0.7, Recommendation: "extract",
+			},
+		},
+	}
+
+	gen := NewServiceReportGenerator()
+	report := gen.Generate("test-project", analyses)
+	md := gen.RenderMarkdown(report)
+
+	if !strings.Contains(md, "# Service Boundary Analysis") {
+		t.Errorf("markdown should contain title")
+	}
+	if !strings.Contains(md, "## Packages by Extract-Worthiness") {
+		t.Errorf("markdown should contain packages section")
+	}
+	if !strings.Contains(md, "## Import Graph") {
+		t.Errorf("markdown should contain import graph")
+	}
+	if !strings.Contains(md, "## Recommendations") {
+		t.Errorf("markdown should contain recommendations")
+	}
+	if !strings.Contains(md, "internal/api") {
+		t.Errorf("markdown should contain package path")
+	}
+}
+
+func TestServiceReportNoExtractOrMerge(t *testing.T) {
+	analyses := []PackageAnalysis{
+		{
+			Package: PackageInfo{Name: "pkg", Path: "internal/pkg", Files: 3, LOC: 200},
+			Metrics: ServiceMetrics{ExtractWorthiness: 0.4, Recommendation: "keep"},
+		},
+	}
+
+	gen := NewServiceReportGenerator()
+	report := gen.Generate("test", analyses)
+
+	found := false
+	for _, rec := range report.Recommendations {
+		if strings.Contains(rec, "healthy") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected healthy message when no extract/merge candidates, got %v", report.Recommendations)
+	}
+}
+
+func TestAppendUnique(t *testing.T) {
+	s := []string{"a", "b"}
+	s = appendUnique(s, "b")
+	if len(s) != 2 {
+		t.Errorf("appendUnique should not duplicate, got %v", s)
+	}
+	s = appendUnique(s, "c")
+	if len(s) != 3 {
+		t.Errorf("appendUnique should add new, got %v", s)
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -40,6 +40,11 @@ var migrations = []Migration{
 		Description: "add branch column to run_history",
 		SQL:         migration005SQL,
 	},
+	{
+		Version:     6,
+		Description: "add service_advisor_results table for service boundary analysis",
+		SQL:         migration006SQL,
+	},
 }
 
 const migration002SQL = `
@@ -119,6 +124,20 @@ CREATE INDEX idx_run_history_time ON run_history(start_time DESC);
 
 const migration005SQL = `
 ALTER TABLE run_history ADD COLUMN branch TEXT NOT NULL DEFAULT '';
+`
+
+const migration006SQL = `
+CREATE TABLE IF NOT EXISTS service_advisor_results (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    component       TEXT NOT NULL,
+    timestamp       DATETIME NOT NULL,
+    packages        TEXT NOT NULL,
+    metrics         TEXT NOT NULL,
+    recommendations TEXT NOT NULL,
+    report_path     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_advisor_component_time ON service_advisor_results(component, timestamp DESC);
 `
 
 // Migrate runs all pending migrations inside transactions.


### PR DESCRIPTION
## Summary
- Adds `service-advisor` CLI command that analyzes Go package structure to identify service boundary opportunities
- Computes per-package metrics: coupling (afferent/efferent), cohesion (internal refs vs exports), size (relative LOC), and change coupling (git co-change frequency)
- Produces ranked recommendations (extract/merge/keep) with markdown and JSON output
- Includes SQLite persistence (migration 006) following the bus-factor pattern, with `--save` flag support
- Full unit test coverage for metrics, report generation, and DB round-trips

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [x] Pre-commit hooks pass (gofmt, go vet, go build)
- [ ] Manual: `nightshift service-advisor --path .` produces expected markdown output
- [ ] Manual: `nightshift service-advisor --json` produces valid JSON
- [ ] Manual: `nightshift service-advisor --save --db /tmp/test.db` persists results

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: service-advisor:/Users/marcus/code/nightshift
task-type: service-advisor
task-title: Should This Be a Service Advisor
provider: claude
score: 3.0
cost-tier: High (150-500k)
branch: designer
iterations: 1
duration: 11m55s
run-started: 2026-03-24T03:58:18-07:00
nightshift:metadata -->
