### PR TITLE
feat: add ownership boundary suggester

### DIFF
--- a/cmd/nightshift/commands/ownership.go
+++ b/cmd/nightshift/commands/ownership.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/analysis"
+	"github.com/marcus/nightshift/internal/logging"
+)
+
+var ownershipCmd = &cobra.Command{
+	Use:   "ownership [path]",
+	Short: "Analyze code ownership boundaries per directory",
+	Long: `Analyze git history to identify code ownership boundaries per directory.
+
+Parses commit history to find dominant contributors per directory, detects
+co-change cohesion between directories, and suggests ownership boundaries.
+Can output a GitHub CODEOWNERS file or a human-readable markdown report.
+
+Flags:
+  --depth      Directory depth to analyze (default 2)
+  --min-commits  Minimum commits for a directory to be included (default 10)
+  --codeowners   Output in GitHub CODEOWNERS format
+  --json         Output as JSON
+  --since/--until  Filter by date range`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := cmd.Flags().GetString("path")
+		if err != nil {
+			return err
+		}
+
+		if path == "" && len(args) > 0 {
+			path = args[0]
+		}
+		if path == "" {
+			path, err = os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current directory: %w", err)
+			}
+		}
+
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		since, _ := cmd.Flags().GetString("since")
+		until, _ := cmd.Flags().GetString("until")
+		depth, _ := cmd.Flags().GetInt("depth")
+		minCommits, _ := cmd.Flags().GetInt("min-commits")
+		codeowners, _ := cmd.Flags().GetBool("codeowners")
+
+		return runOwnership(path, jsonOutput, since, until, depth, minCommits, codeowners)
+	},
+}
+
+func init() {
+	ownershipCmd.Flags().StringP("path", "p", "", "Repository path")
+	ownershipCmd.Flags().Bool("json", false, "Output as JSON")
+	ownershipCmd.Flags().String("since", "", "Start date (RFC3339 or YYYY-MM-DD)")
+	ownershipCmd.Flags().String("until", "", "End date (RFC3339 or YYYY-MM-DD)")
+	ownershipCmd.Flags().Int("depth", 2, "Directory depth to analyze")
+	ownershipCmd.Flags().Int("min-commits", 10, "Minimum commits threshold per directory")
+	ownershipCmd.Flags().Bool("codeowners", false, "Output in GitHub CODEOWNERS format")
+	rootCmd.AddCommand(ownershipCmd)
+}
+
+func runOwnership(path string, jsonOutput bool, since, until string, depth, minCommits int, codeowners bool) error {
+	logger := logging.Component("ownership")
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolving path: %w", err)
+	}
+
+	if !analysis.RepositoryExists(absPath) {
+		return fmt.Errorf("not a git repository: %s", absPath)
+	}
+
+	var sinceTime, untilTime time.Time
+	if since != "" {
+		t, err := parseDate(since)
+		if err != nil {
+			return fmt.Errorf("parsing since date: %w", err)
+		}
+		sinceTime = t
+	}
+	if until != "" {
+		t, err := parseDate(until)
+		if err != nil {
+			return fmt.Errorf("parsing until date: %w", err)
+		}
+		untilTime = t
+	}
+
+	opts := analysis.ParseOptions{
+		Since: sinceTime,
+		Until: untilTime,
+	}
+
+	parser := analysis.NewGitParser(absPath)
+
+	dirs, err := parser.ParseDirectoryOwnership(opts, depth, minCommits)
+	if err != nil {
+		return fmt.Errorf("parsing directory ownership: %w", err)
+	}
+
+	if len(dirs) == 0 {
+		logger.Warnf("no directories with sufficient commits found in %s", absPath)
+		return nil
+	}
+
+	boundaries := analysis.SuggestBoundaries(dirs)
+	unclear := analysis.FindUnclearOwnership(dirs, 0.5)
+
+	cohesion, err := parser.DetectCohesion(opts, depth, 3)
+	if err != nil {
+		logger.Warnf("could not detect cohesion: %v", err)
+	}
+
+	report := &analysis.OwnershipReport{
+		Timestamp:   time.Now(),
+		RepoPath:    absPath,
+		Directories: dirs,
+		Boundaries:  boundaries,
+		Cohesion:    cohesion,
+		Unclear:     unclear,
+	}
+
+	if codeowners {
+		fmt.Print(analysis.GenerateCODEOWNERS(boundaries))
+		return nil
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	fmt.Print(analysis.RenderOwnershipMarkdown(report))
+	return nil
+}

--- a/internal/analysis/ownership.go
+++ b/internal/analysis/ownership.go
@@ -1,0 +1,417 @@
+package analysis
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DirectoryOwnership represents ownership statistics for a single directory.
+type DirectoryOwnership struct {
+	Dir           string                  `json:"dir"`
+	Authors       map[string]*AuthorStats `json:"authors"`
+	DominantOwner string                  `json:"dominant_owner"`
+	Confidence    float64                 `json:"confidence"` // 0-1, how dominant the top owner is
+	TotalCommits  int                     `json:"total_commits"`
+}
+
+// AuthorStats tracks an author's contribution to a directory.
+type AuthorStats struct {
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Commits int    `json:"commits"`
+}
+
+// OwnershipBoundary groups directories by their dominant owner.
+type OwnershipBoundary struct {
+	Owner       string   `json:"owner"`
+	Email       string   `json:"email"`
+	Directories []string `json:"directories"`
+	TotalCommit int      `json:"total_commits"`
+}
+
+// CohesionPair represents two directories frequently co-changed.
+type CohesionPair struct {
+	DirA      string  `json:"dir_a"`
+	DirB      string  `json:"dir_b"`
+	CoChanges int     `json:"co_changes"`
+	Strength  float64 `json:"strength"` // 0-1, ratio of co-changes to total changes
+}
+
+// OwnershipReport is the complete output of an ownership boundary analysis.
+type OwnershipReport struct {
+	Timestamp   time.Time            `json:"timestamp"`
+	RepoPath    string               `json:"repo_path"`
+	Directories []DirectoryOwnership `json:"directories"`
+	Boundaries  []OwnershipBoundary  `json:"boundaries"`
+	Cohesion    []CohesionPair       `json:"cohesion"`
+	Unclear     []DirectoryOwnership `json:"unclear"` // directories with no clear dominant owner
+}
+
+// ParseDirectoryOwnership runs git log to aggregate per-directory author commit counts.
+func (gp *GitParser) ParseDirectoryOwnership(opts ParseOptions, depth int, minCommits int) ([]DirectoryOwnership, error) {
+	args := []string{"log", "--format=%an|%ae", "--name-only"}
+
+	if !opts.Since.IsZero() {
+		args = append(args, fmt.Sprintf("--since=%s", opts.Since.Format(time.RFC3339)))
+	}
+	if !opts.Until.IsZero() {
+		args = append(args, fmt.Sprintf("--until=%s", opts.Until.Format(time.RFC3339)))
+	}
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = gp.repoPath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running git log: %w", err)
+	}
+
+	// Parse the output. git log --format=%an|%ae --name-only produces:
+	//   author|email
+	//                    <-- blank line between format and filenames
+	//   file1
+	//   file2
+	//   author|email
+	//                    <-- blank
+	//   file3
+	//
+	// Author lines contain "|" with an email (containing "@").
+	// Blank lines are ignored. File lines are attributed to the most recent author.
+	dirAuthors := make(map[string]map[string]*AuthorStats) // dir -> email -> stats
+
+	lines := strings.Split(string(output), "\n")
+	var currentAuthor, currentEmail string
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Detect author lines: contain "|" and the second part has "@"
+		if parts := strings.SplitN(line, "|", 2); len(parts) == 2 && strings.Contains(parts[1], "@") {
+			currentAuthor = parts[0]
+			currentEmail = parts[1]
+			continue
+		}
+
+		if currentAuthor == "" {
+			continue
+		}
+
+		// This is a file path — extract the directory at the given depth
+		dir := directoryAtDepth(line, depth)
+		if dir == "" {
+			continue
+		}
+
+		emailKey := strings.ToLower(currentEmail)
+		if dirAuthors[dir] == nil {
+			dirAuthors[dir] = make(map[string]*AuthorStats)
+		}
+		if dirAuthors[dir][emailKey] == nil {
+			dirAuthors[dir][emailKey] = &AuthorStats{
+				Name:  currentAuthor,
+				Email: currentEmail,
+			}
+		}
+		dirAuthors[dir][emailKey].Commits++
+	}
+
+	// Build DirectoryOwnership entries
+	var results []DirectoryOwnership
+	for dir, authors := range dirAuthors {
+		total := 0
+		for _, a := range authors {
+			total += a.Commits
+		}
+		if total < minCommits {
+			continue
+		}
+
+		// Find dominant owner
+		var dominant *AuthorStats
+		for _, a := range authors {
+			if dominant == nil || a.Commits > dominant.Commits {
+				dominant = a
+			}
+		}
+
+		confidence := 0.0
+		if dominant != nil && total > 0 {
+			confidence = float64(dominant.Commits) / float64(total)
+		}
+
+		dominantName := ""
+		if dominant != nil {
+			dominantName = dominant.Name
+		}
+
+		results = append(results, DirectoryOwnership{
+			Dir:           dir,
+			Authors:       authors,
+			DominantOwner: dominantName,
+			Confidence:    confidence,
+			TotalCommits:  total,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Dir < results[j].Dir
+	})
+
+	return results, nil
+}
+
+// directoryAtDepth returns the directory path truncated to the given depth.
+// depth=1 returns just the top-level dir, depth=2 returns two levels, etc.
+func directoryAtDepth(filePath string, depth int) string {
+	dir := filepath.Dir(filePath)
+	if dir == "." {
+		return ""
+	}
+
+	parts := strings.Split(filepath.ToSlash(dir), "/")
+	if len(parts) > depth {
+		parts = parts[:depth]
+	}
+	return strings.Join(parts, "/")
+}
+
+// DetectCohesion analyzes git history to find directories frequently co-changed in the same commit.
+func (gp *GitParser) DetectCohesion(opts ParseOptions, depth int, minCoChanges int) ([]CohesionPair, error) {
+	args := []string{"log", "--name-only", "--pretty=format:COMMIT_SEP"}
+
+	if !opts.Since.IsZero() {
+		args = append(args, fmt.Sprintf("--since=%s", opts.Since.Format(time.RFC3339)))
+	}
+	if !opts.Until.IsZero() {
+		args = append(args, fmt.Sprintf("--until=%s", opts.Until.Format(time.RFC3339)))
+	}
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = gp.repoPath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running git log: %w", err)
+	}
+
+	// Build co-change matrix
+	type pairKey struct{ a, b string }
+	coChangeCount := make(map[pairKey]int)
+	dirChangeCount := make(map[string]int)
+
+	commits := strings.Split(string(output), "COMMIT_SEP")
+	for _, commit := range commits {
+		// Collect unique directories in this commit
+		dirSet := make(map[string]bool)
+		for _, line := range strings.Split(commit, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			dir := directoryAtDepth(line, depth)
+			if dir != "" {
+				dirSet[dir] = true
+			}
+		}
+
+		dirs := make([]string, 0, len(dirSet))
+		for d := range dirSet {
+			dirs = append(dirs, d)
+		}
+		sort.Strings(dirs)
+
+		for _, d := range dirs {
+			dirChangeCount[d]++
+		}
+
+		// Count pairwise co-changes
+		for i := 0; i < len(dirs); i++ {
+			for j := i + 1; j < len(dirs); j++ {
+				key := pairKey{dirs[i], dirs[j]}
+				coChangeCount[key]++
+			}
+		}
+	}
+
+	// Build result pairs
+	var pairs []CohesionPair
+	for key, count := range coChangeCount {
+		if count < minCoChanges {
+			continue
+		}
+		// Strength = co-changes / min(changes_a, changes_b)
+		minChanges := dirChangeCount[key.a]
+		if dirChangeCount[key.b] < minChanges {
+			minChanges = dirChangeCount[key.b]
+		}
+		strength := 0.0
+		if minChanges > 0 {
+			strength = float64(count) / float64(minChanges)
+		}
+
+		pairs = append(pairs, CohesionPair{
+			DirA:      key.a,
+			DirB:      key.b,
+			CoChanges: count,
+			Strength:  strength,
+		})
+	}
+
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].CoChanges > pairs[j].CoChanges
+	})
+
+	return pairs, nil
+}
+
+// SuggestBoundaries groups directories by their dominant owner to suggest ownership boundaries.
+func SuggestBoundaries(dirs []DirectoryOwnership) []OwnershipBoundary {
+	ownerDirs := make(map[string]*OwnershipBoundary) // email -> boundary
+
+	for _, d := range dirs {
+		if d.DominantOwner == "" {
+			continue
+		}
+
+		// Find the email for the dominant owner
+		var email string
+		for _, a := range d.Authors {
+			if a.Name == d.DominantOwner {
+				email = strings.ToLower(a.Email)
+				break
+			}
+		}
+		if email == "" {
+			continue
+		}
+
+		if ownerDirs[email] == nil {
+			ownerDirs[email] = &OwnershipBoundary{
+				Owner: d.DominantOwner,
+				Email: email,
+			}
+		}
+		ownerDirs[email].Directories = append(ownerDirs[email].Directories, d.Dir)
+		ownerDirs[email].TotalCommit += d.TotalCommits
+	}
+
+	boundaries := make([]OwnershipBoundary, 0, len(ownerDirs))
+	for _, b := range ownerDirs {
+		sort.Strings(b.Directories)
+		boundaries = append(boundaries, *b)
+	}
+
+	// Sort by total commits descending
+	sort.Slice(boundaries, func(i, j int) bool {
+		return boundaries[i].TotalCommit > boundaries[j].TotalCommit
+	})
+
+	return boundaries
+}
+
+// FindUnclearOwnership returns directories where no single author dominates.
+func FindUnclearOwnership(dirs []DirectoryOwnership, threshold float64) []DirectoryOwnership {
+	var unclear []DirectoryOwnership
+	for _, d := range dirs {
+		if d.Confidence < threshold {
+			unclear = append(unclear, d)
+		}
+	}
+	return unclear
+}
+
+// GenerateCODEOWNERS renders a GitHub-style CODEOWNERS file from ownership boundaries.
+func GenerateCODEOWNERS(boundaries []OwnershipBoundary) string {
+	var buf bytes.Buffer
+	buf.WriteString("# CODEOWNERS - Generated by nightshift ownership analysis\n")
+	buf.WriteString("# Review and adjust before committing\n\n")
+
+	for _, b := range boundaries {
+		for _, dir := range b.Directories {
+			fmt.Fprintf(&buf, "/%s/ %s\n", dir, b.Email)
+		}
+	}
+
+	return buf.String()
+}
+
+// RenderOwnershipMarkdown generates a human-readable markdown report.
+func RenderOwnershipMarkdown(report *OwnershipReport) string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "# Ownership Boundary Analysis\n\n")
+	fmt.Fprintf(&buf, "*Generated: %s*\n\n", report.Timestamp.Format("2006-01-02 15:04:05"))
+
+	// Summary
+	fmt.Fprintf(&buf, "## Summary\n\n")
+	fmt.Fprintf(&buf, "- **Directories analyzed**: %d\n", len(report.Directories))
+	fmt.Fprintf(&buf, "- **Ownership boundaries**: %d owners\n", len(report.Boundaries))
+	fmt.Fprintf(&buf, "- **Unclear ownership**: %d directories\n", len(report.Unclear))
+	fmt.Fprintf(&buf, "- **Co-change pairs**: %d\n\n", len(report.Cohesion))
+
+	// Ownership boundaries
+	if len(report.Boundaries) > 0 {
+		buf.WriteString("## Ownership Boundaries\n\n")
+		for _, b := range report.Boundaries {
+			fmt.Fprintf(&buf, "### %s (%s)\n\n", b.Owner, b.Email)
+			fmt.Fprintf(&buf, "Total commits: %d\n\n", b.TotalCommit)
+			for _, dir := range b.Directories {
+				fmt.Fprintf(&buf, "- `%s/`\n", dir)
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	// Directory details
+	if len(report.Directories) > 0 {
+		buf.WriteString("## Directory Ownership Details\n\n")
+		buf.WriteString("| Directory | Dominant Owner | Confidence | Commits | Contributors |\n")
+		buf.WriteString("|-----------|---------------|------------|---------|-------------|\n")
+		for _, d := range report.Directories {
+			fmt.Fprintf(&buf, "| `%s/` | %s | %.0f%% | %d | %d |\n",
+				d.Dir, d.DominantOwner, d.Confidence*100, d.TotalCommits, len(d.Authors))
+		}
+		buf.WriteString("\n")
+	}
+
+	// Unclear ownership
+	if len(report.Unclear) > 0 {
+		buf.WriteString("## Unclear Ownership\n\n")
+		buf.WriteString("These directories have no dominant contributor (confidence < 50%):\n\n")
+		for _, d := range report.Unclear {
+			fmt.Fprintf(&buf, "- **`%s/`** — %d commits across %d contributors (top: %s at %.0f%%)\n",
+				d.Dir, d.TotalCommits, len(d.Authors), d.DominantOwner, d.Confidence*100)
+		}
+		buf.WriteString("\n")
+	}
+
+	// Cohesion
+	if len(report.Cohesion) > 0 {
+		buf.WriteString("## Co-Change Cohesion\n\n")
+		buf.WriteString("Directories frequently modified in the same commits:\n\n")
+		buf.WriteString("| Dir A | Dir B | Co-Changes | Strength |\n")
+		buf.WriteString("|-------|-------|------------|----------|\n")
+		limit := len(report.Cohesion)
+		if limit > 20 {
+			limit = 20
+		}
+		for _, c := range report.Cohesion[:limit] {
+			fmt.Fprintf(&buf, "| `%s/` | `%s/` | %d | %.0f%% |\n",
+				c.DirA, c.DirB, c.CoChanges, c.Strength*100)
+		}
+		if len(report.Cohesion) > 20 {
+			fmt.Fprintf(&buf, "\n*... and %d more pairs*\n", len(report.Cohesion)-20)
+		}
+		buf.WriteString("\n")
+	}
+
+	return buf.String()
+}

--- a/internal/analysis/ownership_test.go
+++ b/internal/analysis/ownership_test.go
@@ -1,0 +1,265 @@
+package analysis
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDirectoryAtDepth(t *testing.T) {
+	tests := []struct {
+		path  string
+		depth int
+		want  string
+	}{
+		{"cmd/nightshift/main.go", 1, "cmd"},
+		{"cmd/nightshift/main.go", 2, "cmd/nightshift"},
+		{"cmd/nightshift/main.go", 3, "cmd/nightshift"},
+		{"internal/analysis/ownership.go", 1, "internal"},
+		{"internal/analysis/ownership.go", 2, "internal/analysis"},
+		{"main.go", 1, ""}, // root-level file, no directory
+		{"main.go", 2, ""}, // root-level file, no directory
+		{"a/b.go", 1, "a"},
+		{"a/b/c/d.go", 2, "a/b"},
+	}
+
+	for _, tt := range tests {
+		got := directoryAtDepth(tt.path, tt.depth)
+		if got != tt.want {
+			t.Errorf("directoryAtDepth(%q, %d) = %q, want %q", tt.path, tt.depth, got, tt.want)
+		}
+	}
+}
+
+func TestSuggestBoundaries(t *testing.T) {
+	dirs := []DirectoryOwnership{
+		{
+			Dir:           "cmd",
+			DominantOwner: "Alice",
+			Confidence:    0.8,
+			TotalCommits:  40,
+			Authors: map[string]*AuthorStats{
+				"alice@example.com": {Name: "Alice", Email: "alice@example.com", Commits: 32},
+				"bob@example.com":   {Name: "Bob", Email: "bob@example.com", Commits: 8},
+			},
+		},
+		{
+			Dir:           "internal/analysis",
+			DominantOwner: "Alice",
+			Confidence:    0.6,
+			TotalCommits:  30,
+			Authors: map[string]*AuthorStats{
+				"alice@example.com": {Name: "Alice", Email: "alice@example.com", Commits: 18},
+				"bob@example.com":   {Name: "Bob", Email: "bob@example.com", Commits: 12},
+			},
+		},
+		{
+			Dir:           "internal/db",
+			DominantOwner: "Bob",
+			Confidence:    0.7,
+			TotalCommits:  20,
+			Authors: map[string]*AuthorStats{
+				"alice@example.com": {Name: "Alice", Email: "alice@example.com", Commits: 6},
+				"bob@example.com":   {Name: "Bob", Email: "bob@example.com", Commits: 14},
+			},
+		},
+	}
+
+	boundaries := SuggestBoundaries(dirs)
+
+	if len(boundaries) != 2 {
+		t.Fatalf("expected 2 boundaries, got %d", len(boundaries))
+	}
+
+	// Alice should be first (more total commits)
+	if boundaries[0].Owner != "Alice" {
+		t.Errorf("expected first boundary owner to be Alice, got %s", boundaries[0].Owner)
+	}
+	if len(boundaries[0].Directories) != 2 {
+		t.Errorf("expected Alice to own 2 directories, got %d", len(boundaries[0].Directories))
+	}
+
+	if boundaries[1].Owner != "Bob" {
+		t.Errorf("expected second boundary owner to be Bob, got %s", boundaries[1].Owner)
+	}
+	if len(boundaries[1].Directories) != 1 {
+		t.Errorf("expected Bob to own 1 directory, got %d", len(boundaries[1].Directories))
+	}
+}
+
+func TestSuggestBoundariesEmpty(t *testing.T) {
+	boundaries := SuggestBoundaries(nil)
+	if len(boundaries) != 0 {
+		t.Errorf("expected 0 boundaries for nil input, got %d", len(boundaries))
+	}
+}
+
+func TestSuggestBoundariesSingleOwner(t *testing.T) {
+	dirs := []DirectoryOwnership{
+		{
+			Dir:           "src",
+			DominantOwner: "Alice",
+			Confidence:    1.0,
+			TotalCommits:  100,
+			Authors: map[string]*AuthorStats{
+				"alice@example.com": {Name: "Alice", Email: "alice@example.com", Commits: 100},
+			},
+		},
+	}
+
+	boundaries := SuggestBoundaries(dirs)
+	if len(boundaries) != 1 {
+		t.Fatalf("expected 1 boundary, got %d", len(boundaries))
+	}
+	if boundaries[0].TotalCommit != 100 {
+		t.Errorf("expected total commits 100, got %d", boundaries[0].TotalCommit)
+	}
+}
+
+func TestFindUnclearOwnership(t *testing.T) {
+	dirs := []DirectoryOwnership{
+		{Dir: "clear", Confidence: 0.8},
+		{Dir: "unclear1", Confidence: 0.3},
+		{Dir: "borderline", Confidence: 0.5},
+		{Dir: "unclear2", Confidence: 0.1},
+	}
+
+	unclear := FindUnclearOwnership(dirs, 0.5)
+	if len(unclear) != 2 {
+		t.Fatalf("expected 2 unclear directories, got %d", len(unclear))
+	}
+	if unclear[0].Dir != "unclear1" {
+		t.Errorf("expected first unclear dir to be 'unclear1', got %s", unclear[0].Dir)
+	}
+	if unclear[1].Dir != "unclear2" {
+		t.Errorf("expected second unclear dir to be 'unclear2', got %s", unclear[1].Dir)
+	}
+}
+
+func TestFindUnclearOwnershipAllClear(t *testing.T) {
+	dirs := []DirectoryOwnership{
+		{Dir: "a", Confidence: 0.9},
+		{Dir: "b", Confidence: 0.7},
+	}
+
+	unclear := FindUnclearOwnership(dirs, 0.5)
+	if len(unclear) != 0 {
+		t.Errorf("expected 0 unclear directories, got %d", len(unclear))
+	}
+}
+
+func TestGenerateCODEOWNERS(t *testing.T) {
+	boundaries := []OwnershipBoundary{
+		{
+			Owner:       "Alice",
+			Email:       "alice@example.com",
+			Directories: []string{"cmd", "internal/analysis"},
+		},
+		{
+			Owner:       "Bob",
+			Email:       "bob@example.com",
+			Directories: []string{"internal/db"},
+		},
+	}
+
+	output := GenerateCODEOWNERS(boundaries)
+
+	if !strings.Contains(output, "CODEOWNERS") {
+		t.Error("output should contain CODEOWNERS header")
+	}
+	if !strings.Contains(output, "/cmd/ alice@example.com") {
+		t.Error("output should contain /cmd/ alice@example.com")
+	}
+	if !strings.Contains(output, "/internal/analysis/ alice@example.com") {
+		t.Error("output should contain /internal/analysis/ alice@example.com")
+	}
+	if !strings.Contains(output, "/internal/db/ bob@example.com") {
+		t.Error("output should contain /internal/db/ bob@example.com")
+	}
+}
+
+func TestGenerateCODEOWNERSEmpty(t *testing.T) {
+	output := GenerateCODEOWNERS(nil)
+	if !strings.Contains(output, "CODEOWNERS") {
+		t.Error("even empty output should contain header")
+	}
+	// Should not contain any path entries
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "/") {
+			t.Errorf("empty boundaries should not produce path entries, got: %s", line)
+		}
+	}
+}
+
+func TestRenderOwnershipMarkdown(t *testing.T) {
+	report := &OwnershipReport{
+		Timestamp: time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC),
+		RepoPath:  "/test/repo",
+		Directories: []DirectoryOwnership{
+			{
+				Dir:           "cmd",
+				DominantOwner: "Alice",
+				Confidence:    0.8,
+				TotalCommits:  40,
+				Authors: map[string]*AuthorStats{
+					"alice@example.com": {Name: "Alice", Email: "alice@example.com", Commits: 32},
+					"bob@example.com":   {Name: "Bob", Email: "bob@example.com", Commits: 8},
+				},
+			},
+		},
+		Boundaries: []OwnershipBoundary{
+			{Owner: "Alice", Email: "alice@example.com", Directories: []string{"cmd"}, TotalCommit: 40},
+		},
+		Cohesion: []CohesionPair{
+			{DirA: "cmd", DirB: "internal", CoChanges: 15, Strength: 0.6},
+		},
+		Unclear: []DirectoryOwnership{
+			{Dir: "docs", DominantOwner: "Carol", Confidence: 0.3, TotalCommits: 10,
+				Authors: map[string]*AuthorStats{
+					"carol@example.com": {Name: "Carol", Email: "carol@example.com", Commits: 3},
+				}},
+		},
+	}
+
+	md := RenderOwnershipMarkdown(report)
+
+	sections := []string{
+		"# Ownership Boundary Analysis",
+		"## Summary",
+		"## Ownership Boundaries",
+		"## Directory Ownership Details",
+		"## Unclear Ownership",
+		"## Co-Change Cohesion",
+	}
+	for _, s := range sections {
+		if !strings.Contains(md, s) {
+			t.Errorf("markdown should contain section %q", s)
+		}
+	}
+
+	if !strings.Contains(md, "Alice") {
+		t.Error("markdown should mention Alice")
+	}
+	if !strings.Contains(md, "cmd") {
+		t.Error("markdown should mention cmd directory")
+	}
+	if !strings.Contains(md, "2026-03-25") {
+		t.Error("markdown should contain timestamp")
+	}
+}
+
+func TestRenderOwnershipMarkdownEmpty(t *testing.T) {
+	report := &OwnershipReport{
+		Timestamp: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+
+	md := RenderOwnershipMarkdown(report)
+	if !strings.Contains(md, "# Ownership Boundary Analysis") {
+		t.Error("empty report should still have title")
+	}
+	if !strings.Contains(md, "Directories analyzed**: 0") {
+		t.Error("empty report should show 0 directories")
+	}
+}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -686,10 +686,25 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		DefaultInterval: 168 * time.Hour,
 	},
 	TaskOwnershipBoundary: {
-		Type:            TaskOwnershipBoundary,
-		Category:        CategoryOptions,
-		Name:            "Ownership Boundary Suggester",
-		Description:     "Suggest code ownership boundaries",
+		Type:     TaskOwnershipBoundary,
+		Category: CategoryOptions,
+		Name:     "Ownership Boundary Suggester",
+		Description: `Analyze git history per directory to identify code ownership boundaries and suggest team structures.
+
+Steps:
+1. Run 'nightshift ownership --json' on the repository to get per-directory ownership data.
+2. Review the dominant contributors for each directory — flag directories where no single
+   contributor owns more than 50% of commits (unclear ownership).
+3. Detect co-change patterns: directories frequently modified in the same commit suggest
+   shared ownership or tight coupling that should be owned by the same team.
+4. Identify natural ownership clusters — groups of directories consistently maintained by
+   the same person or team.
+5. Flag directories with unclear ownership where no contributor dominates, as these may
+   need an explicit owner assigned.
+6. Suggest team boundaries based on the natural clusters found.
+7. Output a CODEOWNERS file mapping directories to their dominant contributors.
+8. Output a markdown report summarizing ownership distribution, unclear areas, and
+   co-change cohesion patterns with actionable recommendations.`,
 		CostTier:        CostMedium,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 168 * time.Hour,


### PR DESCRIPTION
## Summary

- Add `nightshift ownership` CLI command that analyzes git history per directory to identify dominant code owners, detect co-change cohesion, and suggest ownership boundaries
- New `internal/analysis/ownership.go` module with `ParseDirectoryOwnership`, `DetectCohesion`, `SuggestBoundaries`, `FindUnclearOwnership`, `GenerateCODEOWNERS`, and `RenderOwnershipMarkdown`
- Enhanced `TaskOwnershipBoundary` description with detailed agent instructions for autonomous execution

## CLI Flags

- `--depth` (default 2): directory depth to analyze
- `--min-commits` (default 10): minimum commit threshold per directory
- `--codeowners`: output GitHub CODEOWNERS format
- `--json`: JSON output
- `--since` / `--until`: date range filtering

## Test plan

- [x] Unit tests for `directoryAtDepth`, `SuggestBoundaries`, `FindUnclearOwnership`, `GenerateCODEOWNERS`, `RenderOwnershipMarkdown`
- [x] `go build ./...` passes
- [x] `go test ./internal/analysis/... ./cmd/nightshift/...` passes
- [x] Smoke tested `nightshift ownership`, `--codeowners`, `--json` on this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: ownership-boundary:/Users/marcus/code/nightshift
task-type: ownership-boundary
task-title: Ownership Boundary Suggester
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
branch: main
iterations: 1
duration: 10m47s
run-started: 2026-03-25T02:42:44-07:00
nightshift:metadata -->
