### PR TITLE
Add compile-time interface contract assertions

### DIFF
--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction checks.
+var (
+	_ Agent         = (*ClaudeAgent)(nil)
+	_ CommandRunner = (*ExecRunner)(nil)
+)
+
 // CommandRunner executes shell commands. Allows mocking in tests.
 type CommandRunner interface {
 	Run(ctx context.Context, name string, args []string, dir string, stdin string) (stdout, stderr string, exitCode int, err error)

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -12,6 +12,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ Agent = (*CodexAgent)(nil)
+
 // CodexAgent spawns Codex CLI for task execution.
 type CodexAgent struct {
 	binaryPath string        // Path to codex binary (default: "codex")

--- a/internal/agents/codex_test.go
+++ b/internal/agents/codex_test.go
@@ -396,11 +396,6 @@ func TestCodexAgent_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestCodexAgent_ImplementsAgentInterface(t *testing.T) {
-	// Verify CodexAgent implements the Agent interface
-	var _ Agent = (*CodexAgent)(nil)
-}
-
 // TestCodexAgentDefaultsBypassFlag verifies that a CodexAgent created with no
 // options includes --dangerously-bypass-approvals-and-sandbox (required for
 // non-interactive execution). This guards against Bug #19 fix 3, where

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -12,6 +12,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ Agent = (*CopilotAgent)(nil)
+
 // CopilotAgent spawns GitHub Copilot CLI for task execution.
 //
 // GitHub Copilot CLI implementation notes:

--- a/internal/integrations/agentsmd.go
+++ b/internal/integrations/agentsmd.go
@@ -11,6 +11,9 @@ import (
 	"github.com/marcus/nightshift/internal/config"
 )
 
+// Compile-time interface satisfaction check.
+var _ Reader = (*AgentsMDReader)(nil)
+
 // AgentsMDReader reads agents.md files for agent behavior configuration.
 type AgentsMDReader struct {
 	enabled bool

--- a/internal/integrations/claudemd.go
+++ b/internal/integrations/claudemd.go
@@ -11,6 +11,9 @@ import (
 	"github.com/marcus/nightshift/internal/config"
 )
 
+// Compile-time interface satisfaction check.
+var _ Reader = (*ClaudeMDReader)(nil)
+
 // ClaudeMDReader reads claude.md files for project context.
 type ClaudeMDReader struct {
 	enabled bool

--- a/internal/integrations/github.go
+++ b/internal/integrations/github.go
@@ -11,6 +11,9 @@ import (
 	"github.com/marcus/nightshift/internal/config"
 )
 
+// Compile-time interface satisfaction check.
+var _ Reader = (*GitHubReader)(nil)
+
 // GitHubReader integrates with GitHub issues via gh CLI.
 type GitHubReader struct {
 	enabled bool

--- a/internal/integrations/td.go
+++ b/internal/integrations/td.go
@@ -10,6 +10,9 @@ import (
 	"github.com/marcus/nightshift/internal/config"
 )
 
+// Compile-time interface satisfaction check.
+var _ Reader = (*TDReader)(nil)
+
 // TDReader integrates with the td task management CLI.
 type TDReader struct {
 	enabled    bool

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -15,6 +15,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ Provider = (*Claude)(nil)
+
 // StatsCache represents the stats-cache.json structure from Claude Code.
 // The file uses two arrays: dailyActivity (message/session/tool counts)
 // and dailyModelTokens (per-model token counts keyed by date).

--- a/internal/providers/codex.go
+++ b/internal/providers/codex.go
@@ -15,6 +15,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ Provider = (*Codex)(nil)
+
 // CodexRateLimits represents the rate_limits object in Codex session JSONL.
 type CodexRateLimits struct {
 	Primary   *CodexRateLimit `json:"primary"`

--- a/internal/providers/contracts_test.go
+++ b/internal/providers/contracts_test.go
@@ -1,0 +1,30 @@
+package providers_test
+
+import (
+	"github.com/marcus/nightshift/internal/budget"
+	"github.com/marcus/nightshift/internal/providers"
+	"github.com/marcus/nightshift/internal/snapshots"
+)
+
+// Compile-time interface satisfaction assertions for cross-package contracts.
+// These live in a _test.go file to avoid circular imports between providers,
+// budget, and snapshots packages.
+
+// Claude implements budget and snapshot interfaces.
+var (
+	_ budget.ClaudeUsageProvider       = (*providers.Claude)(nil)
+	_ budget.UsedPercentSourceProvider = (*providers.Claude)(nil)
+	_ snapshots.ClaudeUsage            = (*providers.Claude)(nil)
+)
+
+// Codex implements budget and snapshot interfaces.
+var (
+	_ budget.CodexUsageProvider = (*providers.Codex)(nil)
+	_ snapshots.CodexUsage      = (*providers.Codex)(nil)
+)
+
+// Copilot implements budget and snapshot interfaces.
+var (
+	_ budget.CopilotUsageProvider = (*providers.Copilot)(nil)
+	_ snapshots.CopilotUsage      = (*providers.Copilot)(nil)
+)

--- a/internal/providers/copilot.go
+++ b/internal/providers/copilot.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ Provider = (*Copilot)(nil)
+
 // Copilot wraps the GitHub Copilot CLI as a provider.
 //
 // Usage tracking approach:

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// Compile-time interface satisfaction check.
+var _ CommandRunner = (*ExecRunner)(nil)
+
 // CommandRunner executes commands for tmux interactions.
 type CommandRunner interface {
 	Run(ctx context.Context, name string, args ...string) ([]byte, error)


### PR DESCRIPTION
## Summary
- Add `var _ Interface = (*Type)(nil)` compile-time assertions across 13 files covering all 13 interfaces and 17 implementations
- Same-package assertions in source files: Agent (3 impls), Provider (3 impls), Reader (4 impls), CommandRunner (2 impls in agents + tmux)
- Cross-package assertions in `providers/contracts_test.go`: Claude/Codex/Copilot implementing `budget.*` and `snapshots.*` interfaces (7 assertions)
- Remove redundant runtime test `TestCodexAgent_ImplementsAgentInterface` now covered by compile-time check

## Test plan
- [x] `go build ./...` passes — all assertions compile
- [x] `go test ./internal/providers/ ./internal/agents/ ./internal/integrations/ ./internal/tmux/` — all tests pass
- [x] Pre-commit hooks (gofmt, vet, build) pass

Nightshift-Task: api-contract-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: api-contract-verify:/Users/marcus/code/nightshift
task-type: api-contract-verify
task-title: API Contract Verification
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
branch: main
iterations: 1
duration: 12m23s
run-started: 2026-03-27T03:34:29-07:00
nightshift:metadata -->
