### PR TITLE
feat: add release-notes command for drafting changelog entries

### DIFF
--- a/cmd/nightshift/commands/release_notes.go
+++ b/cmd/nightshift/commands/release_notes.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marcus/nightshift/internal/releasenotes"
+	"github.com/spf13/cobra"
+)
+
+var releaseNotesCmd = &cobra.Command{
+	Use:   "release-notes",
+	Short: "Draft release notes from git history",
+	Long: `Generate release notes from conventional commits between two git refs.
+
+Collects commits between --from (default: latest tag) and --to (default: HEAD),
+parses conventional commit messages, groups them by type (Features, Bug Fixes,
+Other), and renders formatted markdown matching the CHANGELOG.md style.
+
+Examples:
+  nightshift release-notes
+  nightshift release-notes --from v0.3.3 --to v0.3.4
+  nightshift release-notes --version v0.4.0 --output RELEASE.md`,
+	RunE: runReleaseNotes,
+}
+
+func init() {
+	releaseNotesCmd.Flags().String("from", "", "Start ref (tag or commit); default: latest tag")
+	releaseNotesCmd.Flags().String("to", "", "End ref (tag, commit, or branch); default: HEAD")
+	releaseNotesCmd.Flags().String("version", "", "Version string for the header; default: Unreleased")
+	releaseNotesCmd.Flags().StringP("output", "o", "", "Write output to file instead of stdout")
+	rootCmd.AddCommand(releaseNotesCmd)
+}
+
+func runReleaseNotes(cmd *cobra.Command, args []string) error {
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	version, _ := cmd.Flags().GetString("version")
+	output, _ := cmd.Flags().GetString("output")
+
+	opts := releasenotes.Options{
+		From:    from,
+		To:      to,
+		Version: version,
+	}
+
+	md, err := releasenotes.Generate(opts)
+	if err != nil {
+		return fmt.Errorf("generate release notes: %w", err)
+	}
+
+	if output != "" {
+		if err := os.WriteFile(output, []byte(md), 0644); err != nil {
+			return fmt.Errorf("write output file: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Release notes written to %s\n", output)
+		return nil
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), md)
+	return nil
+}

--- a/internal/releasenotes/releasenotes.go
+++ b/internal/releasenotes/releasenotes.go
@@ -1,0 +1,279 @@
+// Package releasenotes collects git commits between two refs, parses
+// conventional commit messages, groups them by type, and renders
+// formatted markdown release notes matching the CHANGELOG.md style.
+package releasenotes
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// CommitType represents the conventional commit type.
+type CommitType int
+
+const (
+	TypeFeature CommitType = iota
+	TypeFix
+	TypeOther
+)
+
+// Commit holds a parsed conventional commit.
+type Commit struct {
+	Hash        string
+	Type        CommitType
+	RawType     string
+	Scope       string
+	Description string
+	PRNumber    string
+	IssueRefs   []string
+	Author      string
+	Breaking    bool
+}
+
+// Group is a labeled set of commits for rendering.
+type Group struct {
+	Title   string
+	Commits []Commit
+}
+
+// Options configures the release notes generation.
+type Options struct {
+	From    string // start ref (tag or sha), default: latest tag
+	To      string // end ref, default: HEAD
+	Version string // version label for the header
+	RepoDir string // git working directory (empty = cwd)
+}
+
+// commitDelimiter separates fields in the git log format string.
+const commitDelimiter = "---FIELD---"
+
+// logFormat is the git log --format string we use.
+var logFormat = strings.Join([]string{"%H", "%s", "%an"}, commitDelimiter)
+
+// conventionalRe matches a conventional commit subject line.
+// Groups: 1=type, 2=scope (optional, with parens), 3=breaking marker, 4=description
+var conventionalRe = regexp.MustCompile(`^(\w+)(?:\(([^)]*)\))?(!)?\s*:\s*(.+)$`)
+
+// prRefRe matches a trailing (#123) PR reference.
+var prRefRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// issueRefRe matches "fixes #N" or "closes #N" references in the description.
+var issueRefRe = regexp.MustCompile(`(?i)(?:fix(?:es)?|close(?:s)?|resolve(?:s)?)\s+#(\d+)`)
+
+// Generate produces the full release notes markdown string.
+func Generate(opts Options) (string, error) {
+	raw, err := collectCommits(opts)
+	if err != nil {
+		return "", err
+	}
+	commits := ParseCommits(raw)
+	if len(commits) == 0 {
+		return "", fmt.Errorf("no commits found between %s and %s", opts.From, opts.To)
+	}
+	groups := GroupCommits(commits)
+	return Render(opts.Version, groups), nil
+}
+
+// collectCommits shells out to git log and returns the raw output lines.
+func collectCommits(opts Options) ([]string, error) {
+	from := opts.From
+	if from == "" {
+		tag, err := latestTag(opts.RepoDir)
+		if err != nil {
+			return nil, fmt.Errorf("determine latest tag: %w", err)
+		}
+		from = tag
+	}
+	to := opts.To
+	if to == "" {
+		to = "HEAD"
+	}
+
+	rangeArg := from + ".." + to
+	args := []string{"log", "--format=" + logFormat, rangeArg}
+	cmd := exec.Command("git", args...)
+	if opts.RepoDir != "" {
+		cmd.Dir = opts.RepoDir
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log %s: %w", rangeArg, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil, nil
+	}
+	return lines, nil
+}
+
+// latestTag returns the most recent reachable tag.
+func latestTag(dir string) (string, error) {
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("no tags found: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ParseCommits parses raw git log lines into structured Commits.
+func ParseCommits(lines []string) []Commit {
+	var commits []Commit
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		c := parseLine(line)
+		commits = append(commits, c)
+	}
+	return commits
+}
+
+func parseLine(line string) Commit {
+	parts := strings.SplitN(line, commitDelimiter, 3)
+	var hash, subject, author string
+	if len(parts) >= 1 {
+		hash = parts[0]
+	}
+	if len(parts) >= 2 {
+		subject = parts[1]
+	}
+	if len(parts) >= 3 {
+		author = parts[2]
+	}
+
+	c := Commit{
+		Hash:   hash,
+		Author: author,
+	}
+
+	// Try to extract PR number from subject
+	if m := prRefRe.FindStringSubmatch(subject); m != nil {
+		c.PRNumber = m[1]
+		subject = strings.TrimSpace(prRefRe.ReplaceAllString(subject, ""))
+	}
+
+	// Try conventional commit format
+	if m := conventionalRe.FindStringSubmatch(subject); m != nil {
+		c.RawType = strings.ToLower(m[1])
+		c.Scope = m[2]
+		c.Breaking = m[3] == "!"
+		c.Description = m[4]
+		c.Type = classifyType(c.RawType)
+	} else {
+		// Not a conventional commit — goes into Other
+		c.RawType = ""
+		c.Description = subject
+		c.Type = TypeOther
+	}
+
+	// Extract issue references from description
+	if matches := issueRefRe.FindAllStringSubmatch(c.Description, -1); matches != nil {
+		for _, m := range matches {
+			c.IssueRefs = append(c.IssueRefs, m[1])
+		}
+	}
+
+	return c
+}
+
+func classifyType(t string) CommitType {
+	switch t {
+	case "feat":
+		return TypeFeature
+	case "fix":
+		return TypeFix
+	default:
+		return TypeOther
+	}
+}
+
+// GroupCommits buckets commits by type into ordered groups.
+// Empty groups are omitted.
+func GroupCommits(commits []Commit) []Group {
+	buckets := map[CommitType][]Commit{}
+	for _, c := range commits {
+		buckets[c.Type] = append(buckets[c.Type], c)
+	}
+
+	order := []struct {
+		t     CommitType
+		title string
+	}{
+		{TypeFeature, "Features"},
+		{TypeFix, "Bug Fixes"},
+		{TypeOther, "Other"},
+	}
+
+	var groups []Group
+	for _, o := range order {
+		if cs, ok := buckets[o.t]; ok && len(cs) > 0 {
+			groups = append(groups, Group{Title: o.title, Commits: cs})
+		}
+	}
+	return groups
+}
+
+// Render formats grouped commits as markdown release notes.
+func Render(version string, groups []Group) string {
+	var b strings.Builder
+
+	if version == "" {
+		version = "Unreleased"
+	}
+
+	// Version header
+	date := time.Now().Format("2006-01-02")
+	if version == "Unreleased" {
+		fmt.Fprintf(&b, "## [%s]\n", version)
+	} else {
+		fmt.Fprintf(&b, "## [%s] - %s\n", version, date)
+	}
+
+	for _, g := range groups {
+		fmt.Fprintf(&b, "\n### %s\n", g.Title)
+		for _, c := range g.Commits {
+			b.WriteString(renderCommit(c))
+		}
+	}
+
+	return b.String()
+}
+
+func renderCommit(c Commit) string {
+	var b strings.Builder
+	b.WriteString("- ")
+
+	// Bold title from scope or first phrase
+	title := c.Description
+	if c.Scope != "" {
+		title = c.Scope
+	}
+	fmt.Fprintf(&b, "**%s**", title)
+
+	// Description after scope
+	if c.Scope != "" {
+		fmt.Fprintf(&b, " — %s", c.Description)
+	}
+
+	// PR link
+	if c.PRNumber != "" {
+		fmt.Fprintf(&b, " (#%s)", c.PRNumber)
+	}
+
+	// Breaking change marker
+	if c.Breaking {
+		b.WriteString(" **BREAKING**")
+	}
+
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/releasenotes/releasenotes_test.go
+++ b/internal/releasenotes/releasenotes_test.go
@@ -1,0 +1,299 @@
+package releasenotes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLine_ConventionalFeat(t *testing.T) {
+	t.Parallel()
+	line := "abc123" + commitDelimiter + "feat(auth): add OAuth2 support (#42)" + commitDelimiter + "alice"
+	c := parseLine(line)
+
+	if c.Hash != "abc123" {
+		t.Errorf("Hash = %q, want %q", c.Hash, "abc123")
+	}
+	if c.Type != TypeFeature {
+		t.Errorf("Type = %v, want TypeFeature", c.Type)
+	}
+	if c.RawType != "feat" {
+		t.Errorf("RawType = %q, want %q", c.RawType, "feat")
+	}
+	if c.Scope != "auth" {
+		t.Errorf("Scope = %q, want %q", c.Scope, "auth")
+	}
+	if c.Description != "add OAuth2 support" {
+		t.Errorf("Description = %q, want %q", c.Description, "add OAuth2 support")
+	}
+	if c.PRNumber != "42" {
+		t.Errorf("PRNumber = %q, want %q", c.PRNumber, "42")
+	}
+	if c.Author != "alice" {
+		t.Errorf("Author = %q, want %q", c.Author, "alice")
+	}
+	if c.Breaking {
+		t.Error("Breaking = true, want false")
+	}
+}
+
+func TestParseLine_ConventionalFix(t *testing.T) {
+	t.Parallel()
+	line := "def456" + commitDelimiter + "fix: correct nil pointer in scheduler" + commitDelimiter + "bob"
+	c := parseLine(line)
+
+	if c.Type != TypeFix {
+		t.Errorf("Type = %v, want TypeFix", c.Type)
+	}
+	if c.Scope != "" {
+		t.Errorf("Scope = %q, want empty", c.Scope)
+	}
+	if c.Description != "correct nil pointer in scheduler" {
+		t.Errorf("Description = %q, want %q", c.Description, "correct nil pointer in scheduler")
+	}
+	if c.PRNumber != "" {
+		t.Errorf("PRNumber = %q, want empty", c.PRNumber)
+	}
+}
+
+func TestParseLine_BreakingChange(t *testing.T) {
+	t.Parallel()
+	line := "aaa111" + commitDelimiter + "feat!: remove deprecated API (#10)" + commitDelimiter + "carol"
+	c := parseLine(line)
+
+	if c.Type != TypeFeature {
+		t.Errorf("Type = %v, want TypeFeature", c.Type)
+	}
+	if !c.Breaking {
+		t.Error("Breaking = false, want true")
+	}
+	if c.PRNumber != "10" {
+		t.Errorf("PRNumber = %q, want %q", c.PRNumber, "10")
+	}
+}
+
+func TestParseLine_BreakingWithScope(t *testing.T) {
+	t.Parallel()
+	line := "bbb222" + commitDelimiter + "feat(config)!: change default format" + commitDelimiter + "dave"
+	c := parseLine(line)
+
+	if c.Type != TypeFeature {
+		t.Errorf("Type = %v, want TypeFeature", c.Type)
+	}
+	if c.Scope != "config" {
+		t.Errorf("Scope = %q, want %q", c.Scope, "config")
+	}
+	if !c.Breaking {
+		t.Error("Breaking = false, want true")
+	}
+}
+
+func TestParseLine_NonConventional(t *testing.T) {
+	t.Parallel()
+	line := "ghi789" + commitDelimiter + "Update README with examples" + commitDelimiter + "eve"
+	c := parseLine(line)
+
+	if c.Type != TypeOther {
+		t.Errorf("Type = %v, want TypeOther", c.Type)
+	}
+	if c.Description != "Update README with examples" {
+		t.Errorf("Description = %q, want %q", c.Description, "Update README with examples")
+	}
+	if c.RawType != "" {
+		t.Errorf("RawType = %q, want empty", c.RawType)
+	}
+}
+
+func TestParseLine_OtherType(t *testing.T) {
+	t.Parallel()
+	line := "ccc333" + commitDelimiter + "chore: update deps (#55)" + commitDelimiter + "frank"
+	c := parseLine(line)
+
+	if c.Type != TypeOther {
+		t.Errorf("Type = %v, want TypeOther", c.Type)
+	}
+	if c.RawType != "chore" {
+		t.Errorf("RawType = %q, want %q", c.RawType, "chore")
+	}
+	if c.PRNumber != "55" {
+		t.Errorf("PRNumber = %q, want %q", c.PRNumber, "55")
+	}
+}
+
+func TestParseLine_IssueRefs(t *testing.T) {
+	t.Parallel()
+	line := "ddd444" + commitDelimiter + "fix: handle edge case fixes #7 and closes #8" + commitDelimiter + "grace"
+	c := parseLine(line)
+
+	if len(c.IssueRefs) != 2 {
+		t.Fatalf("IssueRefs len = %d, want 2", len(c.IssueRefs))
+	}
+	if c.IssueRefs[0] != "7" || c.IssueRefs[1] != "8" {
+		t.Errorf("IssueRefs = %v, want [7 8]", c.IssueRefs)
+	}
+}
+
+func TestParseCommits_SkipsEmpty(t *testing.T) {
+	t.Parallel()
+	lines := []string{
+		"abc" + commitDelimiter + "feat: first" + commitDelimiter + "a",
+		"",
+		"def" + commitDelimiter + "fix: second" + commitDelimiter + "b",
+	}
+	commits := ParseCommits(lines)
+	if len(commits) != 2 {
+		t.Errorf("len = %d, want 2", len(commits))
+	}
+}
+
+func TestGroupCommits_Order(t *testing.T) {
+	t.Parallel()
+	commits := []Commit{
+		{Type: TypeOther, Description: "chore"},
+		{Type: TypeFix, Description: "bugfix"},
+		{Type: TypeFeature, Description: "new thing"},
+		{Type: TypeFix, Description: "another fix"},
+	}
+
+	groups := GroupCommits(commits)
+
+	if len(groups) != 3 {
+		t.Fatalf("groups len = %d, want 3", len(groups))
+	}
+	if groups[0].Title != "Features" {
+		t.Errorf("groups[0].Title = %q, want %q", groups[0].Title, "Features")
+	}
+	if groups[1].Title != "Bug Fixes" {
+		t.Errorf("groups[1].Title = %q, want %q", groups[1].Title, "Bug Fixes")
+	}
+	if groups[2].Title != "Other" {
+		t.Errorf("groups[2].Title = %q, want %q", groups[2].Title, "Other")
+	}
+	if len(groups[1].Commits) != 2 {
+		t.Errorf("Bug Fixes commits = %d, want 2", len(groups[1].Commits))
+	}
+}
+
+func TestGroupCommits_OmitsEmpty(t *testing.T) {
+	t.Parallel()
+	commits := []Commit{
+		{Type: TypeFeature, Description: "feat only"},
+	}
+	groups := GroupCommits(commits)
+	if len(groups) != 1 {
+		t.Fatalf("groups len = %d, want 1", len(groups))
+	}
+	if groups[0].Title != "Features" {
+		t.Errorf("Title = %q, want %q", groups[0].Title, "Features")
+	}
+}
+
+func TestRender_Unreleased(t *testing.T) {
+	t.Parallel()
+	groups := []Group{
+		{
+			Title: "Features",
+			Commits: []Commit{
+				{Scope: "auth", Description: "add login flow", PRNumber: "42"},
+			},
+		},
+		{
+			Title: "Bug Fixes",
+			Commits: []Commit{
+				{Description: "fix crash on startup"},
+			},
+		},
+	}
+
+	out := Render("", groups)
+
+	if !strings.HasPrefix(out, "## [Unreleased]\n") {
+		t.Errorf("header missing, got: %s", out)
+	}
+	if !strings.Contains(out, "### Features\n") {
+		t.Error("missing Features section")
+	}
+	if !strings.Contains(out, "- **auth** — add login flow (#42)\n") {
+		t.Errorf("missing formatted feature commit, got:\n%s", out)
+	}
+	if !strings.Contains(out, "### Bug Fixes\n") {
+		t.Error("missing Bug Fixes section")
+	}
+	if !strings.Contains(out, "- **fix crash on startup**\n") {
+		t.Errorf("missing formatted fix commit, got:\n%s", out)
+	}
+}
+
+func TestRender_WithVersion(t *testing.T) {
+	t.Parallel()
+	groups := []Group{
+		{
+			Title:   "Other",
+			Commits: []Commit{{Description: "update deps"}},
+		},
+	}
+
+	out := Render("v1.0.0", groups)
+
+	if !strings.Contains(out, "## [v1.0.0] - ") {
+		t.Errorf("version header missing, got: %s", out)
+	}
+}
+
+func TestRender_BreakingMarker(t *testing.T) {
+	t.Parallel()
+	groups := []Group{
+		{
+			Title: "Features",
+			Commits: []Commit{
+				{Description: "new API", Breaking: true, PRNumber: "5"},
+			},
+		},
+	}
+
+	out := Render("v2.0.0", groups)
+
+	if !strings.Contains(out, "**BREAKING**") {
+		t.Errorf("missing BREAKING marker, got:\n%s", out)
+	}
+}
+
+func TestRenderCommit_NoScope(t *testing.T) {
+	t.Parallel()
+	c := Commit{Description: "simple change", PRNumber: "99"}
+	got := renderCommit(c)
+	want := "- **simple change** (#99)\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderCommit_WithScope(t *testing.T) {
+	t.Parallel()
+	c := Commit{Scope: "cli", Description: "add verbose flag", PRNumber: "10"}
+	got := renderCommit(c)
+	want := "- **cli** — add verbose flag (#10)\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestClassifyType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  CommitType
+	}{
+		{"feat", TypeFeature},
+		{"fix", TypeFix},
+		{"chore", TypeOther},
+		{"docs", TypeOther},
+		{"refactor", TypeOther},
+		{"ci", TypeOther},
+		{"test", TypeOther},
+	}
+	for _, tt := range tests {
+		if got := classifyType(tt.input); got != tt.want {
+			t.Errorf("classifyType(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `nightshift release-notes` CLI command that collects git commits between two refs (default: latest-tag..HEAD), parses conventional commit messages, groups by type (Features, Bug Fixes, Other), and renders markdown matching the CHANGELOG.md style
- Core logic in `internal/releasenotes/` package with 16 unit tests covering commit parsing, grouping, and rendering
- Cobra command exposes `--from`, `--to`, `--version`, and `--output` flags

## Usage
```bash
# Draft notes from latest tag to HEAD
nightshift release-notes

# Between specific refs with a version header
nightshift release-notes --from v0.3.3 --to v0.3.4 --version v0.3.4

# Write to file
nightshift release-notes --version v0.4.0 --output RELEASE.md
```

## Test plan
- [x] All 16 unit tests pass (`go test ./internal/releasenotes/`)
- [x] `go build ./...` succeeds
- [x] `gofmt` and `go vet` clean
- [ ] Manual: run `nightshift release-notes` in the repo and verify output matches CHANGELOG.md style
- [ ] Manual: run with `--from` / `--to` flags to verify custom ranges
- [ ] Manual: run with `--output` flag to verify file writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/marcus/code/nightshift
task-type: release-notes
task-title: Release Note Drafter
provider: claude
score: 3.0
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 7m16s
run-started: 2026-03-29T02:58:44-07:00
nightshift:metadata -->
