### PR TITLE
docs: backfill godoc comments across codebase

### DIFF
--- a/cmd/nightshift/commands/budget.go
+++ b/cmd/nightshift/commands/budget.go
@@ -1,3 +1,5 @@
+// budget.go implements the budget command for displaying provider budget status.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/budget_helpers.go
+++ b/cmd/nightshift/commands/budget_helpers.go
@@ -1,3 +1,5 @@
+// budget_helpers.go provides shared utilities for budget-related commands.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/busfactor.go
+++ b/cmd/nightshift/commands/busfactor.go
@@ -1,3 +1,5 @@
+// busfactor.go implements the busfactor command for code ownership analysis.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -1,3 +1,5 @@
+// config.go implements the config command for viewing and modifying configuration.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -1,3 +1,5 @@
+// daemon.go implements the daemon command for managing the background scheduler.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/doctor.go
+++ b/cmd/nightshift/commands/doctor.go
@@ -1,3 +1,5 @@
+// doctor.go implements the doctor command for diagnosing configuration issues.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -1,3 +1,5 @@
+// helpers.go provides shared utilities for creating provider agents.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/init.go
+++ b/cmd/nightshift/commands/init.go
@@ -1,3 +1,5 @@
+// init.go implements the init command for creating configuration files.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/install.go
+++ b/cmd/nightshift/commands/install.go
@@ -1,3 +1,5 @@
+// install.go implements the install and uninstall commands for system services.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/logs.go
+++ b/cmd/nightshift/commands/logs.go
@@ -1,3 +1,5 @@
+// logs.go implements the logs command for viewing and following log output.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/preview.go
+++ b/cmd/nightshift/commands/preview.go
@@ -1,3 +1,5 @@
+// preview.go implements the preview command for previewing scheduled runs.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/preview_output.go
+++ b/cmd/nightshift/commands/preview_output.go
@@ -1,3 +1,5 @@
+// preview_output.go renders preview results as text, JSON, or paged output.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/report.go
+++ b/cmd/nightshift/commands/report.go
@@ -1,3 +1,5 @@
+// report.go implements the report command for viewing run history and reports.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -1,3 +1,5 @@
+// run.go implements the run command for executing tasks immediately.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/run_output.go
+++ b/cmd/nightshift/commands/run_output.go
@@ -1,3 +1,5 @@
+// run_output.go renders colored run progress and preflight summaries.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/run_reporting.go
+++ b/cmd/nightshift/commands/run_reporting.go
@@ -1,3 +1,5 @@
+// run_reporting.go collects run results and generates post-run reports.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -1,3 +1,5 @@
+// setup.go implements the interactive onboarding wizard.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/snapshot.go
+++ b/cmd/nightshift/commands/snapshot.go
@@ -1,3 +1,5 @@
+// snapshot.go implements budget snapshot, history, and calibrate subcommands.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/stats.go
+++ b/cmd/nightshift/commands/stats.go
@@ -1,3 +1,5 @@
+// stats.go implements the stats command for displaying aggregate statistics.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/status.go
+++ b/cmd/nightshift/commands/status.go
@@ -1,3 +1,5 @@
+// status.go implements the status command for showing run history.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -1,3 +1,5 @@
+// task.go implements task list, show, and run subcommands.
+
 package commands
 
 import (

--- a/cmd/nightshift/commands/time_parse.go
+++ b/cmd/nightshift/commands/time_parse.go
@@ -1,3 +1,5 @@
+// time_parse.go provides flexible time and clock parsing for CLI flags.
+
 package commands
 
 import (

--- a/cmd/provider-calibration/main.go
+++ b/cmd/provider-calibration/main.go
@@ -1,3 +1,5 @@
+// Command provider-calibration compares token usage between Codex and Claude
+// sessions to derive budget multipliers for cross-provider cost normalization.
 package main
 
 import (

--- a/internal/analysis/db.go
+++ b/internal/analysis/db.go
@@ -1,3 +1,5 @@
+// db.go persists and queries bus-factor analysis results in SQLite.
+
 package analysis
 
 import (

--- a/internal/analysis/metrics.go
+++ b/internal/analysis/metrics.go
@@ -1,3 +1,5 @@
+// metrics.go computes ownership concentration metrics for bus-factor analysis.
+
 package analysis
 
 import (

--- a/internal/analysis/report.go
+++ b/internal/analysis/report.go
@@ -1,3 +1,5 @@
+// report.go generates formatted bus-factor analysis reports.
+
 package analysis
 
 import (

--- a/internal/db/import.go
+++ b/internal/db/import.go
@@ -1,3 +1,5 @@
+// import.go migrates legacy state.json data into SQLite.
+
 package db
 
 import (

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,3 +1,5 @@
+// migrations.go defines and applies database schema migrations.
+
 package db
 
 import (

--- a/internal/integrations/agentsmd.go
+++ b/internal/integrations/agentsmd.go
@@ -1,3 +1,5 @@
+// agentsmd.go reads agents.md files for agent behavior configuration.
+
 package integrations
 
 import (

--- a/internal/integrations/claudemd.go
+++ b/internal/integrations/claudemd.go
@@ -1,3 +1,5 @@
+// claudemd.go reads claude.md files for project context.
+
 package integrations
 
 import (

--- a/internal/integrations/github.go
+++ b/internal/integrations/github.go
@@ -1,3 +1,5 @@
+// github.go integrates with GitHub issues via the gh CLI.
+
 package integrations
 
 import (

--- a/internal/integrations/td.go
+++ b/internal/integrations/td.go
@@ -1,3 +1,5 @@
+// td.go integrates with the td task management CLI.
+
 package integrations
 
 import (

--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -1,3 +1,5 @@
+// events.go defines event types and handlers for orchestrator lifecycle notifications.
+
 package orchestrator
 
 import "time"

--- a/internal/reporting/run_report.go
+++ b/internal/reporting/run_report.go
@@ -1,3 +1,5 @@
+// run_report.go renders and persists per-run markdown reports.
+
 package reporting
 
 import (

--- a/internal/reporting/run_results.go
+++ b/internal/reporting/run_results.go
@@ -1,3 +1,5 @@
+// run_results.go handles JSON serialization of structured run results.
+
 package reporting
 
 import (

--- a/internal/tasks/register.go
+++ b/internal/tasks/register.go
@@ -1,3 +1,5 @@
+// register.go converts custom task configs into TaskDefinitions and registers them.
+
 package tasks
 
 import (

--- a/internal/tmux/scraper.go
+++ b/internal/tmux/scraper.go
@@ -1,3 +1,5 @@
+// scraper.go scrapes Claude and Codex CLI usage data via tmux sessions.
+
 package tmux
 
 import (


### PR DESCRIPTION
## Summary
- Add file-level godoc comments to 37 undocumented Go files across the codebase
- Covers all 22 command files in `cmd/nightshift/commands/`, the `cmd/provider-calibration/main.go` tool, and 14 internal package files (`analysis`, `db`, `integrations`, `orchestrator`, `reporting`, `tasks`, `tmux`)
- Uses the `// filename.go description` convention with a blank line before the package clause to avoid conflicting with existing `// Package ...` docs

## Approach
- File-level comments (blank line before `package`) for files in packages that already have a `// Package X` doc in another file
- Package-level doc (no blank line before `package main`) for `cmd/provider-calibration/main.go` which had no existing package doc

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Pre-commit hooks (gofmt, vet, build) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/marcus/code/nightshift
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 3.0
cost-tier: Low (10-50k)
branch: main
iterations: 2
duration: 15m40s
run-started: 2026-03-29T02:58:44-07:00
nightshift:metadata -->
