### PR TITLE
feat: add changelog command

### DIFF
--- a/cmd/nightshift/commands/changelog.go
+++ b/cmd/nightshift/commands/changelog.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/changelog"
+)
+
+var changelogCmd = &cobra.Command{
+	Use:   "changelog",
+	Short: "Synthesize a changelog from git commits",
+	Long: `Generate a changelog from git commits between two refs (tags or SHAs).
+
+Parses conventional commit prefixes (feat/fix/docs/refactor/chore/ci/test),
+groups them into human-readable categories (Features, Bug Fixes, Other),
+and renders output in markdown matching the existing CHANGELOG.md style.
+
+Examples:
+  nightshift changelog
+  nightshift changelog --from v0.3.3 --to v0.3.4 --version v0.3.4
+  nightshift changelog --format plain --output CHANGELOG.md`,
+	RunE: runChangelog,
+}
+
+func init() {
+	changelogCmd.Flags().String("from", "", "Start ref: tag or SHA (default: latest tag)")
+	changelogCmd.Flags().String("to", "HEAD", "End ref: tag or SHA")
+	changelogCmd.Flags().String("version", "", "Version label for the header (e.g. v1.0.0)")
+	changelogCmd.Flags().String("format", "markdown", "Output format: markdown or plain")
+	changelogCmd.Flags().StringP("output", "o", "", "Write output to file (default: stdout)")
+	rootCmd.AddCommand(changelogCmd)
+}
+
+func runChangelog(cmd *cobra.Command, args []string) error {
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	version, _ := cmd.Flags().GetString("version")
+	format, _ := cmd.Flags().GetString("format")
+	output, _ := cmd.Flags().GetString("output")
+
+	if format != "markdown" && format != "plain" {
+		return fmt.Errorf("unsupported format %q: use markdown or plain", format)
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	gen := changelog.NewGenerator(dir)
+
+	// Default --from to latest tag
+	if from == "" {
+		tag, err := gen.LatestTag()
+		if err != nil {
+			return fmt.Errorf("no --from specified and no tags found: %w", err)
+		}
+		from = tag
+	}
+
+	groups, err := gen.Generate(from, to)
+	if err != nil {
+		return fmt.Errorf("generating changelog: %w", err)
+	}
+
+	if len(groups) == 0 {
+		fmt.Fprintln(cmd.ErrOrStderr(), "No commits found in range", from+".."+to)
+		return nil
+	}
+
+	var rendered string
+	if format == "plain" {
+		rendered = changelog.RenderPlain(version, groups)
+	} else {
+		rendered = changelog.RenderMarkdown(version, groups)
+	}
+
+	if output != "" {
+		if err := os.WriteFile(output, []byte(rendered), 0644); err != nil {
+			return fmt.Errorf("writing output file: %w", err)
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "Changelog written to %s\n", output)
+		return nil
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), rendered)
+	return nil
+}

--- a/cmd/nightshift/commands/changelog_test.go
+++ b/cmd/nightshift/commands/changelog_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestChangelogCmd_Flags(t *testing.T) {
+	// Verify all expected flags are registered
+	flags := []string{"from", "to", "version", "format", "output"}
+	for _, name := range flags {
+		f := changelogCmd.Flags().Lookup(name)
+		if f == nil {
+			t.Errorf("flag %q not registered", name)
+		}
+	}
+}
+
+func TestChangelogCmd_FlagDefaults(t *testing.T) {
+	tests := []struct {
+		flag string
+		want string
+	}{
+		{"from", ""},
+		{"to", "HEAD"},
+		{"version", ""},
+		{"format", "markdown"},
+		{"output", ""},
+	}
+	for _, tc := range tests {
+		f := changelogCmd.Flags().Lookup(tc.flag)
+		if f == nil {
+			t.Fatalf("flag %q not found", tc.flag)
+		}
+		if f.DefValue != tc.want {
+			t.Errorf("flag %q default = %q, want %q", tc.flag, f.DefValue, tc.want)
+		}
+	}
+}
+
+func TestChangelogCmd_InvalidFormat(t *testing.T) {
+	cmd := changelogCmd
+	_ = cmd.Flags().Set("from", "v0.1.0")
+	_ = cmd.Flags().Set("format", "html")
+	defer func() {
+		_ = cmd.Flags().Set("from", "")
+		_ = cmd.Flags().Set("format", "markdown")
+	}()
+
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error for invalid format, got nil")
+	}
+}
+
+func TestChangelogCmd_Registration(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "changelog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("changelog command not registered on root")
+	}
+}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,230 @@
+// Package changelog synthesizes changelogs from git commit history.
+package changelog
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Category represents a changelog section.
+type Category string
+
+const (
+	CategoryFeatures Category = "Features"
+	CategoryFixes    Category = "Bug Fixes"
+	CategoryDocs     Category = "Documentation"
+	CategoryOther    Category = "Other"
+)
+
+// CommitInfo holds parsed data from a single git commit.
+type CommitInfo struct {
+	Hash    string
+	Subject string
+	Prefix  string
+	Scope   string
+	Title   string
+	PR      int
+}
+
+// CategoryGroup holds commits grouped under a changelog category.
+type CategoryGroup struct {
+	Category Category
+	Commits  []CommitInfo
+}
+
+// prefixToCategory maps conventional commit prefixes to changelog categories.
+var prefixToCategory = map[string]Category{
+	"feat":     CategoryFeatures,
+	"fix":      CategoryFixes,
+	"docs":     CategoryDocs,
+	"refactor": CategoryOther,
+	"chore":    CategoryOther,
+	"ci":       CategoryOther,
+	"test":     CategoryOther,
+}
+
+var (
+	// Matches: feat(scope): title  or  fix: title
+	conventionalRe = regexp.MustCompile(`^(\w+)(?:\(([^)]*)\))?:\s*(.+)$`)
+	// Matches: (#123) anywhere in the string
+	prNumberRe = regexp.MustCompile(`\(#(\d+)\)`)
+)
+
+// ParseCommit extracts structured info from a conventional commit subject line.
+func ParseCommit(hash, subject string) CommitInfo {
+	ci := CommitInfo{Hash: hash, Subject: subject}
+
+	// Extract PR number
+	if m := prNumberRe.FindStringSubmatch(subject); len(m) > 1 {
+		fmt.Sscanf(m[1], "%d", &ci.PR)
+	}
+
+	// Parse conventional commit prefix
+	if m := conventionalRe.FindStringSubmatch(subject); len(m) > 1 {
+		ci.Prefix = m[1]
+		ci.Scope = m[2]
+		ci.Title = m[3]
+	} else {
+		ci.Title = subject
+	}
+
+	return ci
+}
+
+// ClassifyCommit returns the changelog category for a commit prefix.
+func ClassifyCommit(prefix string) Category {
+	if cat, ok := prefixToCategory[strings.ToLower(prefix)]; ok {
+		return cat
+	}
+	return CategoryOther
+}
+
+// Generator produces changelogs from git history.
+type Generator struct {
+	RepoDir string
+}
+
+// NewGenerator creates a Generator for the given repository directory.
+func NewGenerator(repoDir string) *Generator {
+	return &Generator{RepoDir: repoDir}
+}
+
+// Generate reads commits between fromRef and toRef and returns grouped categories.
+func (g *Generator) Generate(fromRef, toRef string) ([]CategoryGroup, error) {
+	subjects, err := g.gitLog(fromRef, toRef)
+	if err != nil {
+		return nil, err
+	}
+	return GroupCommits(subjects), nil
+}
+
+// gitLog shells out to git log and returns hash+subject lines.
+func (g *Generator) gitLog(fromRef, toRef string) ([]string, error) {
+	rangeArg := fromRef + ".." + toRef
+	cmd := exec.Command("git", "log", "--pretty=format:%H %s", rangeArg)
+	cmd.Dir = g.RepoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log %s: %w", rangeArg, err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	return strings.Split(raw, "\n"), nil
+}
+
+// LatestTag returns the most recent reachable tag, or "" if none.
+func (g *Generator) LatestTag() (string, error) {
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	cmd.Dir = g.RepoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// GroupCommits parses raw "hash subject" lines and groups them by category.
+func GroupCommits(lines []string) []CategoryGroup {
+	groups := map[Category][]CommitInfo{}
+	for _, line := range lines {
+		hash, subject, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		ci := ParseCommit(hash, subject)
+		cat := ClassifyCommit(ci.Prefix)
+		groups[cat] = append(groups[cat], ci)
+	}
+	return sortedGroups(groups)
+}
+
+// sortedGroups returns categories in a stable display order.
+func sortedGroups(m map[Category][]CommitInfo) []CategoryGroup {
+	order := []Category{CategoryFeatures, CategoryFixes, CategoryDocs, CategoryOther}
+	var result []CategoryGroup
+	for _, cat := range order {
+		if commits, ok := m[cat]; ok {
+			result = append(result, CategoryGroup{Category: cat, Commits: commits})
+		}
+	}
+	// Any unknown categories (shouldn't happen, but be safe)
+	seen := map[Category]bool{}
+	for _, c := range order {
+		seen[c] = true
+	}
+	var extra []Category
+	for c := range m {
+		if !seen[c] {
+			extra = append(extra, c)
+		}
+	}
+	sort.Slice(extra, func(i, j int) bool { return extra[i] < extra[j] })
+	for _, c := range extra {
+		result = append(result, CategoryGroup{Category: c, Commits: m[c]})
+	}
+	return result
+}
+
+// RenderMarkdown formats grouped commits as markdown matching CHANGELOG.md style.
+func RenderMarkdown(version string, groups []CategoryGroup) string {
+	var sb strings.Builder
+	if version != "" {
+		date := time.Now().Format("2006-01-02")
+		fmt.Fprintf(&sb, "## [%s] - %s\n", version, date)
+	}
+	for _, g := range groups {
+		sb.WriteString("\n### ")
+		sb.WriteString(string(g.Category))
+		sb.WriteString("\n")
+		for _, c := range g.Commits {
+			sb.WriteString("- ")
+			title := strings.TrimSpace(c.Title)
+			// Strip trailing PR reference from title since we append it
+			title = prNumberRe.ReplaceAllString(title, "")
+			title = strings.TrimSpace(title)
+			sb.WriteString("**")
+			sb.WriteString(title)
+			sb.WriteString("**")
+			if c.PR > 0 {
+				fmt.Fprintf(&sb, " (#%d)", c.PR)
+			}
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// RenderPlain formats grouped commits as plain text.
+func RenderPlain(version string, groups []CategoryGroup) string {
+	var sb strings.Builder
+	if version != "" {
+		fmt.Fprintf(&sb, "%s\n", version)
+		sb.WriteString(strings.Repeat("=", len(version)))
+		sb.WriteString("\n")
+	}
+	for _, g := range groups {
+		sb.WriteString("\n")
+		sb.WriteString(string(g.Category))
+		sb.WriteString("\n")
+		sb.WriteString(strings.Repeat("-", len(string(g.Category))))
+		sb.WriteString("\n")
+		for _, c := range g.Commits {
+			title := strings.TrimSpace(c.Title)
+			title = prNumberRe.ReplaceAllString(title, "")
+			title = strings.TrimSpace(title)
+			sb.WriteString("- ")
+			sb.WriteString(title)
+			if c.PR > 0 {
+				fmt.Fprintf(&sb, " (#%d)", c.PR)
+			}
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,203 @@
+package changelog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCommit_ConventionalWithScope(t *testing.T) {
+	ci := ParseCommit("abc123", "feat(api): add new endpoint (#42)")
+	if ci.Prefix != "feat" {
+		t.Errorf("prefix = %q, want %q", ci.Prefix, "feat")
+	}
+	if ci.Scope != "api" {
+		t.Errorf("scope = %q, want %q", ci.Scope, "api")
+	}
+	if ci.Title != "add new endpoint (#42)" {
+		t.Errorf("title = %q, want %q", ci.Title, "add new endpoint (#42)")
+	}
+	if ci.PR != 42 {
+		t.Errorf("pr = %d, want %d", ci.PR, 42)
+	}
+	if ci.Hash != "abc123" {
+		t.Errorf("hash = %q, want %q", ci.Hash, "abc123")
+	}
+}
+
+func TestParseCommit_ConventionalWithoutScope(t *testing.T) {
+	ci := ParseCommit("def456", "fix: resolve crash on startup")
+	if ci.Prefix != "fix" {
+		t.Errorf("prefix = %q, want %q", ci.Prefix, "fix")
+	}
+	if ci.Scope != "" {
+		t.Errorf("scope = %q, want empty", ci.Scope)
+	}
+	if ci.Title != "resolve crash on startup" {
+		t.Errorf("title = %q, want %q", ci.Title, "resolve crash on startup")
+	}
+	if ci.PR != 0 {
+		t.Errorf("pr = %d, want 0", ci.PR)
+	}
+}
+
+func TestParseCommit_NonConventional(t *testing.T) {
+	ci := ParseCommit("789abc", "Update README (#10)")
+	if ci.Prefix != "" {
+		t.Errorf("prefix = %q, want empty", ci.Prefix)
+	}
+	if ci.Title != "Update README (#10)" {
+		t.Errorf("title = %q, want %q", ci.Title, "Update README (#10)")
+	}
+	if ci.PR != 10 {
+		t.Errorf("pr = %d, want 10", ci.PR)
+	}
+}
+
+func TestClassifyCommit(t *testing.T) {
+	tests := []struct {
+		prefix string
+		want   Category
+	}{
+		{"feat", CategoryFeatures},
+		{"fix", CategoryFixes},
+		{"docs", CategoryDocs},
+		{"refactor", CategoryOther},
+		{"chore", CategoryOther},
+		{"ci", CategoryOther},
+		{"test", CategoryOther},
+		{"", CategoryOther},
+		{"unknown", CategoryOther},
+	}
+	for _, tc := range tests {
+		got := ClassifyCommit(tc.prefix)
+		if got != tc.want {
+			t.Errorf("ClassifyCommit(%q) = %q, want %q", tc.prefix, got, tc.want)
+		}
+	}
+}
+
+func TestGroupCommits(t *testing.T) {
+	lines := []string{
+		"aaa111 feat: add user profiles (#1)",
+		"bbb222 fix: resolve login crash (#2)",
+		"ccc333 docs: update API reference",
+		"ddd444 chore: update dependencies",
+		"eee555 feat(ui): redesign dashboard (#3)",
+	}
+	groups := GroupCommits(lines)
+
+	// Should have Features first, then Bug Fixes, Documentation, Other
+	if len(groups) != 4 {
+		t.Fatalf("got %d groups, want 4", len(groups))
+	}
+	if groups[0].Category != CategoryFeatures {
+		t.Errorf("first group = %q, want Features", groups[0].Category)
+	}
+	if len(groups[0].Commits) != 2 {
+		t.Errorf("Features has %d commits, want 2", len(groups[0].Commits))
+	}
+	if groups[1].Category != CategoryFixes {
+		t.Errorf("second group = %q, want Bug Fixes", groups[1].Category)
+	}
+	if groups[2].Category != CategoryDocs {
+		t.Errorf("third group = %q, want Documentation", groups[2].Category)
+	}
+	if groups[3].Category != CategoryOther {
+		t.Errorf("fourth group = %q, want Other", groups[3].Category)
+	}
+}
+
+func TestGroupCommits_EmptyInput(t *testing.T) {
+	groups := GroupCommits(nil)
+	if len(groups) != 0 {
+		t.Errorf("got %d groups, want 0", len(groups))
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	groups := []CategoryGroup{
+		{
+			Category: CategoryFeatures,
+			Commits: []CommitInfo{
+				{Hash: "aaa", Title: "add user profiles (#1)", PR: 1},
+				{Hash: "bbb", Title: "redesign dashboard (#3)", PR: 3},
+			},
+		},
+		{
+			Category: CategoryFixes,
+			Commits: []CommitInfo{
+				{Hash: "ccc", Title: "resolve login crash (#2)", PR: 2},
+			},
+		},
+	}
+
+	out := RenderMarkdown("v1.0.0", groups)
+
+	if !strings.HasPrefix(out, "## [v1.0.0] - ") {
+		t.Errorf("missing version header, got: %s", out)
+	}
+	if !strings.Contains(out, "### Features") {
+		t.Error("missing Features section")
+	}
+	if !strings.Contains(out, "### Bug Fixes") {
+		t.Error("missing Bug Fixes section")
+	}
+	if !strings.Contains(out, "- **add user profiles** (#1)") {
+		t.Errorf("missing formatted entry, got:\n%s", out)
+	}
+	if !strings.Contains(out, "- **resolve login crash** (#2)") {
+		t.Errorf("missing fix entry, got:\n%s", out)
+	}
+}
+
+func TestRenderMarkdown_NoVersion(t *testing.T) {
+	groups := []CategoryGroup{
+		{Category: CategoryOther, Commits: []CommitInfo{{Title: "update deps"}}},
+	}
+	out := RenderMarkdown("", groups)
+	if strings.Contains(out, "## [") {
+		t.Errorf("should not have version header when version is empty, got:\n%s", out)
+	}
+	if !strings.Contains(out, "### Other") {
+		t.Error("missing Other section")
+	}
+}
+
+func TestRenderPlain(t *testing.T) {
+	groups := []CategoryGroup{
+		{
+			Category: CategoryFeatures,
+			Commits: []CommitInfo{
+				{Title: "add profiles (#5)", PR: 5},
+			},
+		},
+	}
+	out := RenderPlain("v2.0.0", groups)
+	if !strings.HasPrefix(out, "v2.0.0\n======") {
+		t.Errorf("missing plain header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Features\n--------") {
+		t.Error("missing plain Features section")
+	}
+	if !strings.Contains(out, "- add profiles (#5)") {
+		t.Errorf("missing plain entry, got:\n%s", out)
+	}
+}
+
+func TestPRNumberExtraction(t *testing.T) {
+	tests := []struct {
+		subject string
+		wantPR  int
+	}{
+		{"feat: something (#99)", 99},
+		{"fix: no pr here", 0},
+		{"chore: multiple (#1) and (#2)", 1}, // takes first match
+		{"Update README (#123)", 123},
+	}
+	for _, tc := range tests {
+		ci := ParseCommit("abc", tc.subject)
+		if ci.PR != tc.wantPR {
+			t.Errorf("ParseCommit(%q).PR = %d, want %d", tc.subject, ci.PR, tc.wantPR)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `nightshift changelog` CLI command that synthesizes a changelog from git commits between two refs
- Parses conventional commit prefixes (feat/fix/docs/refactor/chore/ci/test) into categorized groups (Features, Bug Fixes, Documentation, Other)
- Extracts PR numbers from commit messages and renders markdown or plain text matching existing CHANGELOG.md style

## Details
- Core logic in `internal/changelog/` for reuse by goreleaser or future release automation
- Flags: `--from` (tag/SHA, default: latest tag), `--to` (default: HEAD), `--version`, `--format` (markdown|plain), `--output` (file path)
- Unit tests for commit parsing, category classification, PR extraction, markdown rendering, and command wiring

## Test plan
- [x] `go vet` passes
- [x] `go build` passes
- [x] Unit tests pass for `internal/changelog/...` and `cmd/nightshift/commands/...`
- [ ] Manual: `nightshift changelog --from v0.3.3 --version v0.3.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightshift-Task: changelog-synth


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: changelog-synth:/Users/marcus/code/nightshift
task-type: changelog-synth
task-title: Changelog Synthesizer
provider: claude
score: 3.0
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 7m56s
run-started: 2026-03-30T03:28:37-07:00
nightshift:metadata -->
