### PR TITLE
Align lint tooling with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download
@@ -44,9 +44,16 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: make fmt-check
+
+      - name: Run go vet
+        run: make vet
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64.8
+          args: ./...

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: build test test-verbose test-race coverage coverage-html lint clean deps check install calibrate-providers install-hooks help
+.PHONY: build test test-verbose test-race coverage coverage-html fmt fmt-check vet lint clean deps check install calibrate-providers install-hooks help
 
 # Binary name
 BINARY=nightshift
 PKG=./cmd/nightshift
+GO_FILES := $(shell rg --files -g '*.go')
+GOLANGCI_LINT_VERSION ?= v1.64.8
 
 # Build the binary
 build:
@@ -16,6 +18,18 @@ install:
 # Run provider calibration comparison tool
 calibrate-providers:
 	go run ./cmd/provider-calibration --repo "$$(pwd)" --codex-originator codex_cli_rs --min-user-turns 2
+
+# Format Go files
+fmt:
+	gofmt -w $(GO_FILES)
+
+# Check Go formatting
+fmt-check:
+	@UNFORMATTED="$$(gofmt -l $(GO_FILES))"; \
+	if [ -n "$$UNFORMATTED" ]; then \
+		echo "$$UNFORMATTED"; \
+		exit 1; \
+	fi
 
 # Run all tests
 test:
@@ -41,10 +55,14 @@ coverage-html: coverage
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
 
+# Run go vet
+vet:
+	go vet ./...
+
 # Run golangci-lint (if installed)
 lint:
-	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest" && exit 1)
-	golangci-lint run
+	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)" && exit 1)
+	golangci-lint run ./...
 
 # Clean build artifacts
 clean:
@@ -57,8 +75,8 @@ deps:
 	go mod download
 	go mod tidy
 
-# Run all checks (test + lint)
-check: test lint
+# Run all checks
+check: fmt-check vet lint test
 
 # Show help
 help:
@@ -69,10 +87,13 @@ help:
 	@echo "  test-race     - Run tests with race detection"
 	@echo "  coverage      - Run tests with coverage report"
 	@echo "  coverage-html - Generate HTML coverage report"
+	@echo "  fmt           - Format all Go files"
+	@echo "  fmt-check     - Verify Go files are formatted"
+	@echo "  vet           - Run go vet"
 	@echo "  lint          - Run golangci-lint"
 	@echo "  clean         - Clean build artifacts"
 	@echo "  deps          - Download and tidy dependencies"
-	@echo "  check         - Run tests and lint"
+	@echo "  check         - Run fmt, vet, lint, and tests"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
 	@echo "  install-hooks  - Install git pre-commit hook"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -8,48 +8,27 @@ FAIL=0
 
 echo "🪡 pre-commit checks"
 
-# --- gofmt: only staged .go files ---
-STAGED_GO=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+run_check() {
+  local label="$1"
+  shift
 
-if [[ -n "$STAGED_GO" ]]; then
-  printf "  %-20s" "gofmt"
-  UNFORMATTED=$(echo "$STAGED_GO" | xargs gofmt -l 2>&1)
-  if [[ -z "$UNFORMATTED" ]]; then
+  printf "  %-20s" "$label"
+  if OUTPUT=$("$@" 2>&1); then
     echo "✓"
     PASS=$((PASS+1))
-  else
-    echo "✗ FAILED — run: gofmt -w ."
-    echo "$UNFORMATTED" | sed 's/^/    /'
-    FAIL=$((FAIL+1))
+    return 0
   fi
-else
-  printf "  %-20s" "gofmt"
-  echo "– (no .go files staged)"
-fi
 
-# --- go vet ---
-printf "  %-20s" "go vet"
-VET_OUT=$(go vet ./... 2>&1)
-if [[ $? -eq 0 ]]; then
-  echo "✓"
-  PASS=$((PASS+1))
-else
   echo "✗ FAILED"
-  echo "$VET_OUT" | sed 's/^/    /'
+  if [[ -n "$OUTPUT" ]]; then
+    echo "$OUTPUT" | sed 's/^/    /'
+  fi
   FAIL=$((FAIL+1))
-fi
+}
 
-# --- go build ---
-printf "  %-20s" "go build"
-BUILD_OUT=$(go build ./... 2>&1)
-if [[ $? -eq 0 ]]; then
-  echo "✓"
-  PASS=$((PASS+1))
-else
-  echo "✗ FAILED"
-  echo "$BUILD_OUT" | sed 's/^/    /'
-  FAIL=$((FAIL+1))
-fi
+run_check "gofmt" make fmt-check
+run_check "go vet" make vet
+run_check "golangci-lint" make lint
 
 echo ""
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- align CI Go setup with the version declared in go.mod
- enforce gofmt, go vet, and a pinned golangci-lint version in CI and local entry points
- update the pre-commit hook to run the same formatting, vet, and lint checks as CI

## Verification
- make fmt-check
- make vet
- make lint
- ./scripts/pre-commit.sh
- go test ./... (fails on existing out-of-scope test: internal/providers/copilot_test.go:152, TestCopilot_GetRequestCount_OldMonth)