### PR TITLE
fix: register custom tasks in task list/show/run commands

### DIFF
--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -11,12 +11,24 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/marcus/nightshift/internal/config"
 	"github.com/marcus/nightshift/internal/logging"
 	"github.com/marcus/nightshift/internal/orchestrator"
 	"github.com/marcus/nightshift/internal/security"
 	"github.com/marcus/nightshift/internal/tasks"
 	"github.com/spf13/cobra"
 )
+
+// registerCustomTasks loads config and registers any user-defined custom tasks
+// so they appear in task list/show/run. Mirrors the registration in run.go.
+func registerCustomTasks() {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	tasks.ClearCustom()
+	_ = tasks.RegisterCustomTasksFromConfig(cfg.Tasks.Custom)
+}
 
 var taskCmd = &cobra.Command{
 	Use:   "task",
@@ -80,6 +92,8 @@ func init() {
 }
 
 func runTaskList(cmd *cobra.Command, args []string) error {
+	registerCustomTasks()
+
 	categoryFilter, _ := cmd.Flags().GetString("category")
 	costFilter, _ := cmd.Flags().GetString("cost")
 	asJSON, _ := cmd.Flags().GetBool("json")
@@ -134,6 +148,8 @@ func runTaskList(cmd *cobra.Command, args []string) error {
 }
 
 func runTaskShow(cmd *cobra.Command, args []string) error {
+	registerCustomTasks()
+
 	taskType := tasks.TaskType(args[0])
 	promptOnly, _ := cmd.Flags().GetBool("prompt-only")
 	asJSON, _ := cmd.Flags().GetBool("json")
@@ -177,6 +193,8 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 }
 
 func runTaskRun(cmd *cobra.Command, args []string) error {
+	registerCustomTasks()
+
 	taskType := tasks.TaskType(args[0])
 	provider, _ := cmd.Flags().GetString("provider")
 	projectPath, _ := cmd.Flags().GetString("project")


### PR DESCRIPTION
## Summary

Custom tasks defined under `tasks.custom` in config were parsed and validated correctly, but only registered at runtime by the `run` and `preview` commands. The `task list`, `task show`, and `task run` subcommands called `tasks.AllDefinitionsSorted()` / `tasks.GetDefinition()` without first registering custom tasks, so they only saw built-in tasks.

## Fix

Added a `registerCustomTasks()` helper in `task.go` that loads config and calls `RegisterCustomTasksFromConfig` — the same pattern already used in `run.go:228-230` and `preview.go`. Called at the top of `runTaskList`, `runTaskShow`, and `runTaskRun`.

## Before/After

```
# Before
$ nightshift task list | grep custom
(nothing)

$ nightshift task show my-custom-task
Error: unknown task: my-custom-task

# After
$ nightshift task list | grep custom
my-custom-task [custom]  My Custom Task  Analysis  Low  10k-50k  Low

$ nightshift task show my-custom-task
Task:    My Custom Task
Type:    my-custom-task
Custom:  yes
...
```

## Test plan

- [x] Existing `TestTaskInstanceFromDef` passes
- [x] Existing `TestRegisterCustom_*` tests pass
- [x] Manual: `task list` shows custom tasks with `[custom]` label
- [x] Manual: `task show <custom>` displays details and prompt
- [x] Manual: `task run <custom> --dry-run` shows correct prompt