### PR TITLE
chore: standardize future commit messages

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,16 @@
+# Commit format:
+#   <type>(<optional-scope>): <imperative summary>
+#
+# Examples:
+#   fix(tasks): standardize commit prompt handling
+#   docs: add commit message guide
+#
+# Allowed types:
+#   build, chore, ci, docs, feat, fix, perf, refactor, release, revert, style, test
+#
+# Keep the subject under 72 characters and do not end it with a period.
+# Add a body only when it helps explain why or captures tradeoffs.
+#
+# When Nightshift creates the change, include both trailers:
+# Nightshift-Task: <task-id>
+# Nightshift-Ref: https://github.com/marcus/nightshift

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,26 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git hooks and commit template"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git hooks and commit template
 install-hooks:
-	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
-	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@repo_root="$$(git rev-parse --show-toplevel)"; \
+	hooks_dir="$$(git rev-parse --path-format=absolute --git-path hooks)"; \
+	git_dir="$$(git rev-parse --path-format=absolute --git-dir)"; \
+	common_dir="$$(git rev-parse --path-format=absolute --git-common-dir)"; \
+	template_path="$$repo_root/.gitmessage"; \
+	mkdir -p "$$hooks_dir"; \
+	ln -sf "$$repo_root/scripts/pre-commit.sh" "$$hooks_dir/pre-commit"; \
+	ln -sf "$$repo_root/scripts/commit-msg.sh" "$$hooks_dir/commit-msg"; \
+	if [ "$$git_dir" != "$$common_dir" ]; then \
+		git config extensions.worktreeConfig true; \
+		git config --worktree commit.template "$$template_path"; \
+		config_scope="worktree"; \
+	else \
+		git config --local commit.template "$$template_path"; \
+		config_scope="local"; \
+	fi; \
+	echo "✓ hooks installed ($$hooks_dir/pre-commit, $$hooks_dir/commit-msg)"; \
+	echo "✓ commit template configured ($$config_scope: $$template_path)"

--- a/README.md
+++ b/README.md
@@ -258,18 +258,35 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git Hooks And Commit Template
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install the local git hooks and commit template:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This installs:
+
+- `scripts/pre-commit.sh` into the active git hooks directory
+- `scripts/commit-msg.sh` into the active git hooks directory
+- `.gitmessage` as the repo-local commit template
+
+`make install-hooks` is worktree-safe: it resolves the hook directory through git and stores the commit template in worktree-local config when you're inside a linked worktree.
+
+The commit-message standard for this repo is:
+
+```text
+<type>(<optional-scope>): <imperative summary>
+```
+
+See `docs/guides/commit-messages.md` for examples and the Nightshift trailer rules.
+
+The hooks run:
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
+- **commit-msg** — validates conventional-style subjects and Nightshift trailers
 
 To bypass in a pinch: `git commit --no-verify`
 

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -369,13 +369,8 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 			projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
 
 			// Create task instance
-			taskInstance := &tasks.Task{
-				ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
-				Title:       scoredTask.Definition.Name,
-				Description: scoredTask.Definition.Description,
-				Priority:    int(scoredTask.Score),
-				Type:        scoredTask.Definition.Type,
-			}
+			taskInstance := taskInstanceFromDef(scoredTask.Definition, projectPath)
+			taskInstance.Priority = int(scoredTask.Score)
 
 			// Mark as assigned
 			st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))

--- a/cmd/nightshift/commands/preview.go
+++ b/cmd/nightshift/commands/preview.go
@@ -359,13 +359,8 @@ func buildPreviewResult(cfg *config.Config, database *db.DB, projects []string, 
 			}
 			projectResult.Tasks = make([]previewTask, 0, len(selected))
 			for idx, scored := range selected {
-				taskInstance := &tasks.Task{
-					ID:          fmt.Sprintf("%s:%s", scored.Definition.Type, project),
-					Title:       scored.Definition.Name,
-					Description: scored.Definition.Description,
-					Priority:    int(scored.Score),
-					Type:        scored.Definition.Type,
-				}
+				taskInstance := taskInstanceFromDef(scored.Definition, project)
+				taskInstance.Priority = int(scored.Score)
 				prompt := orch.PlanPrompt(taskInstance)
 				minTokens, maxTokens := scored.Definition.EstimatedTokens()
 

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -717,13 +717,8 @@ func executeRun(ctx context.Context, p executeRunParams) error {
 			projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
 
 			// Create task instance
-			taskInstance := &tasks.Task{
-				ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, projectPath),
-				Title:       scoredTask.Definition.Name,
-				Description: scoredTask.Definition.Description,
-				Priority:    int(scoredTask.Score),
-				Type:        scoredTask.Definition.Type,
-			}
+			taskInstance := taskInstanceFromDef(scoredTask.Definition, projectPath)
+			taskInstance.Priority = int(scoredTask.Score)
 
 			// Mark as assigned
 			p.st.MarkAssigned(taskInstance.ID, projectPath, string(scoredTask.Definition.Type))

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -307,11 +307,12 @@ func taskInstanceFromDef(def tasks.TaskDefinition, projectPath string) *tasks.Ta
 		id = fmt.Sprintf("%s:%s", def.Type, projectPath)
 	}
 	return &tasks.Task{
-		ID:          id,
-		Title:       def.Name,
-		Description: def.Description,
-		Priority:    0,
-		Type:        def.Type,
+		ID:                id,
+		Title:             def.Name,
+		Description:       def.Description,
+		AgentInstructions: def.PromptText(),
+		Priority:          0,
+		Type:              def.Type,
 	}
 }
 

--- a/cmd/nightshift/commands/task_test.go
+++ b/cmd/nightshift/commands/task_test.go
@@ -143,9 +143,10 @@ func TestCategoryShort(t *testing.T) {
 
 func TestTaskInstanceFromDef(t *testing.T) {
 	def := tasks.TaskDefinition{
-		Type:        "lint-fix",
-		Name:        "Linter Fixes",
-		Description: "Fix lint errors",
+		Type:              "lint-fix",
+		Name:              "Linter Fixes",
+		Description:       "Fix lint errors",
+		AgentInstructions: "Inspect lint output and apply safe fixes",
 	}
 
 	// Without project path
@@ -156,11 +157,30 @@ func TestTaskInstanceFromDef(t *testing.T) {
 	if task.Title != "Linter Fixes" {
 		t.Errorf("Title = %q", task.Title)
 	}
+	if task.Description != def.Description {
+		t.Errorf("Description = %q, want %q", task.Description, def.Description)
+	}
+	if task.AgentInstructions != def.AgentInstructions {
+		t.Errorf("AgentInstructions = %q, want %q", task.AgentInstructions, def.AgentInstructions)
+	}
 
 	// With project path
 	task = taskInstanceFromDef(def, "/tmp/proj")
 	if task.ID != "lint-fix:/tmp/proj" {
 		t.Errorf("ID = %q, want %q", task.ID, "lint-fix:/tmp/proj")
+	}
+}
+
+func TestTaskInstanceFromDefFallsBackToDescription(t *testing.T) {
+	def := tasks.TaskDefinition{
+		Type:        "docs-backfill",
+		Name:        "Docs",
+		Description: "Generate missing documentation",
+	}
+
+	task := taskInstanceFromDef(def, "")
+	if task.AgentInstructions != def.Description {
+		t.Errorf("AgentInstructions = %q, want fallback %q", task.AgentInstructions, def.Description)
 	}
 }
 

--- a/docs/guides/adding-tasks.md
+++ b/docs/guides/adding-tasks.md
@@ -25,14 +25,25 @@ TaskMyNewTask: {
     Type:            TaskMyNewTask,
     Category:        CategoryPR,       // See categories below
     Name:            "My New Task",
-    Description:     "What the agent should do, written as instructions",
+    Description:     "Short summary shown in task lists",
+    AgentInstructions: `Optional richer instructions for the agent.
+Use this when the CLI summary should stay concise but the prompt
+needs more concrete scope or guardrails.`,
     CostTier:        CostMedium,       // Estimated token usage
     RiskLevel:       RiskLow,          // Risk of unintended changes
     DefaultInterval: 72 * time.Hour,   // Minimum time between runs per project
 },
 ```
 
-The `Description` field is what the agent sees as its task instructions. Write it as a clear directive.
+Use `Description` for the concise user-facing summary shown in task lists, previews, and JSON metadata. Add `AgentInstructions` when the agent needs richer directions; if it is omitted, Nightshift falls back to `Description`.
+
+`commit-normalize` is the reference example for this split: it stays a short "Standardize commit message format" entry in the catalog, while the agent prompt makes the scope explicit:
+
+- treat it as a PR task for future commit-message consistency
+- inspect existing repo conventions before choosing a format
+- avoid rewriting published history
+- preserve Nightshift's required commit trailers
+- prefer small, explainable enforcement or documentation changes
 
 ### Step 3: Update the Completeness Test
 
@@ -115,7 +126,7 @@ tasks:
 
 ### How It Works
 
-Custom tasks register into the same task registry as built-in tasks. They participate in the same scoring, cooldown, budget filtering, and plan-implement-review orchestration cycle. The `description` field becomes the agent's task prompt.
+Custom tasks register into the same task registry as built-in tasks. They participate in the same scoring, cooldown, budget filtering, and plan-implement-review orchestration cycle. For custom tasks, the `description` field still becomes the agent's task prompt.
 
 Custom tasks appear in `nightshift task list` with a `[custom]` label and in JSON output with a `"custom": true` field.
 
@@ -134,7 +145,8 @@ tasks:
 
 ### Tips
 
-- Write descriptions as direct instructions to the agent — they become the task prompt
+- For built-in tasks, keep `Description` short and add `AgentInstructions` only when the agent needs extra guardrails
+- For custom tasks, write `description` as direct instructions to the agent — it becomes the task prompt
 - Use `nightshift preview --explain` to verify custom tasks appear in the run plan
 - Run `nightshift run --task my-custom-type --dry-run` to test a specific custom task
 - Custom task types must not match any built-in task name

--- a/docs/guides/commit-messages.md
+++ b/docs/guides/commit-messages.md
@@ -1,0 +1,49 @@
+# Commit Message Guide
+
+Nightshift now standardizes future commits around a small conventional format that matches most recent history:
+
+```text
+<type>(<optional-scope>): <imperative summary>
+```
+
+Examples:
+
+- `fix(tasks): standardize commit message template`
+- `feat(run): add preflight summary display`
+- `docs: add commit message guide`
+
+## Rules
+
+- Use one of: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `revert`, `style`, `test`
+- Keep the subject under 72 characters
+- Use an imperative summary
+- Do not end the subject with a period
+- Add a body only when it adds useful context
+
+## Nightshift Trailers
+
+When a change is made by Nightshift or one of its agents, include both trailers together:
+
+```text
+Nightshift-Task: <task-id>
+Nightshift-Ref: https://github.com/marcus/nightshift
+```
+
+Leave a blank line before the trailers.
+
+## Local Setup
+
+Run:
+
+```bash
+make install-hooks
+```
+
+This installs:
+
+- the active git hooks directory for formatting, vet, build, and commit message checks
+- `.gitmessage` as the repo-local commit template for this repository
+
+In linked worktrees, `make install-hooks` writes the template setting to worktree-local git config so one worktree does not overwrite another.
+
+The hook is intentionally forward-looking. It does not rewrite or validate old history.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -741,7 +741,7 @@ Description: %s
   "files": ["file1.go", "file2.go", ...],
   "description": "overall approach"
 }
-`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
+`, task.ID, task.Title, task.PromptText(), branchInstruction, task.Type)
 }
 
 func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, iteration int) string {
@@ -783,7 +783,7 @@ Description: %s
   "files_modified": ["file1.go", ...],
   "summary": "what was done"
 }
-`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+`, task.ID, task.Title, task.PromptText(), plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
 }
 
 func (o *Orchestrator) buildReviewPrompt(task *tasks.Task, impl *ImplementOutput) string {
@@ -814,7 +814,7 @@ Description: %s
 }
 
 Set "passed" to true ONLY if the implementation is correct and complete.
-`, task.ID, task.Title, task.Description, impl.Summary, impl.FilesModified)
+`, task.ID, task.Title, task.PromptText(), impl.Summary, impl.FilesModified)
 }
 
 // prURLPattern matches standard GitHub pull request URLs.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -468,6 +468,38 @@ func TestBuildPrompts(t *testing.T) {
 	}
 }
 
+func TestBuildPromptsUseAgentInstructions(t *testing.T) {
+	o := New()
+	task := &tasks.Task{
+		ID:                "prompt-test",
+		Title:             "Build Prompts",
+		Description:       "Short summary",
+		AgentInstructions: "Detailed agent-only instructions",
+	}
+
+	plan := &PlanOutput{
+		Steps:       []string{"step1"},
+		Description: "test plan",
+	}
+	impl := &ImplementOutput{
+		FilesModified: []string{"file1.go"},
+		Summary:       "test implementation",
+	}
+
+	for name, prompt := range map[string]string{
+		"plan":      o.buildPlanPrompt(task),
+		"implement": o.buildImplementPrompt(task, plan, 1),
+		"review":    o.buildReviewPrompt(task, impl),
+	} {
+		if !strings.Contains(prompt, task.AgentInstructions) {
+			t.Errorf("%s prompt missing agent instructions\nGot:\n%s", name, prompt)
+		}
+		if strings.Contains(prompt, "Description: "+task.Description) {
+			t.Errorf("%s prompt should use agent instructions instead of short summary\nGot:\n%s", name, prompt)
+		}
+	}
+}
+
 func TestExtractPRURL(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/tasks/commit_message_hook_test.go
+++ b/internal/tasks/commit_message_hook_test.go
@@ -1,0 +1,78 @@
+package tasks
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCommitMsgHookAcceptsConventionalSubject(t *testing.T) {
+	out, err := runCommitMsgHook(t, "fix(tasks): standardize commit message template\n")
+	if err != nil {
+		t.Fatalf("commit-msg hook rejected valid message: %v\n%s", err, out)
+	}
+}
+
+func TestCommitMsgHookRejectsNonStandardSubject(t *testing.T) {
+	out, err := runCommitMsgHook(t, "Update commit message handling\n")
+	if err == nil {
+		t.Fatal("expected commit-msg hook to reject non-standard subject")
+	}
+	if !strings.Contains(out, "<type>(<optional-scope>): <imperative summary>") {
+		t.Fatalf("unexpected hook output:\n%s", out)
+	}
+}
+
+func TestCommitMsgHookRequiresPairedNightshiftTrailers(t *testing.T) {
+	out, err := runCommitMsgHook(t, "fix(tasks): standardize commit message template\n\nNightshift-Task: commit-normalize\n")
+	if err == nil {
+		t.Fatal("expected commit-msg hook to reject partial Nightshift trailers")
+	}
+	if !strings.Contains(out, "Nightshift commits must include both trailers") {
+		t.Fatalf("unexpected hook output:\n%s", out)
+	}
+}
+
+func TestCommitMsgHookAcceptsNightshiftTrailers(t *testing.T) {
+	msg := strings.Join([]string{
+		"docs: add commit message guide",
+		"",
+		"Nightshift-Task: commit-normalize",
+		"Nightshift-Ref: https://github.com/marcus/nightshift",
+		"",
+	}, "\n")
+
+	out, err := runCommitMsgHook(t, msg)
+	if err != nil {
+		t.Fatalf("commit-msg hook rejected valid Nightshift trailers: %v\n%s", err, out)
+	}
+}
+
+func runCommitMsgHook(t *testing.T, message string) (string, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	msgFile := filepath.Join(dir, "COMMIT_EDITMSG")
+	if err := os.WriteFile(msgFile, []byte(message), 0644); err != nil {
+		t.Fatalf("write temp commit message: %v", err)
+	}
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "commit-msg.sh")
+	cmd := exec.Command("bash", scriptPath, msgFile)
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -215,6 +216,7 @@ type TaskDefinition struct {
 	Category          TaskCategory
 	Name              string
 	Description       string
+	AgentInstructions string
 	CostTier          CostTier
 	RiskLevel         RiskLevel
 	DefaultInterval   time.Duration
@@ -244,6 +246,15 @@ func DefaultIntervalForCategory(cat TaskCategory) time.Duration {
 // EstimatedTokens returns the token range for this task definition.
 func (d TaskDefinition) EstimatedTokens() (min, max int) {
 	return d.CostTier.TokenRange()
+}
+
+// PromptText returns the agent-facing instructions for this task definition.
+// When no explicit agent instructions are provided, Description is reused.
+func (d TaskDefinition) PromptText() string {
+	if strings.TrimSpace(d.AgentInstructions) != "" {
+		return d.AgentInstructions
+	}
+	return d.Description
 }
 
 // customTypes tracks which task types were registered via RegisterCustom.
@@ -329,10 +340,22 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		DefaultInterval: 168 * time.Hour,
 	},
 	TaskCommitNormalize: {
-		Type:            TaskCommitNormalize,
-		Category:        CategoryPR,
-		Name:            "Commit Message Normalizer",
-		Description:     "Standardize commit message format",
+		Type:        TaskCommitNormalize,
+		Category:    CategoryPR,
+		Name:        "Commit Message Normalizer",
+		Description: "Standardize commit message format",
+		AgentInstructions: `Inspect recent repository history, contribution docs, release tooling, and any automation that depends on commit messages.
+Choose or infer one concise commit-message convention that fits this repo, then make safe forward-looking changes so future commits follow it consistently.
+
+Scope:
+- Treat this as a PR task that standardizes future behavior; do not rewrite published history.
+- Preserve Nightshift's required commit trailers and do not weaken existing PR/issue linkage conventions.
+- Prefer minimal, explainable changes such as docs, templates, hooks, validation, or helper scripts over broad workflow churn.
+
+Deliverable:
+- Update or add the smallest set of files needed to document or enforce the chosen convention.
+- Keep commit output concise and consistent with the repository's prevailing style.
+- If the repo already has a solid standard, tighten gaps rather than inventing a new format.`,
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 24 * time.Hour,
@@ -976,12 +999,22 @@ func ClearCustom() {
 
 // Task represents a unit of work for an AI agent.
 type Task struct {
-	ID          string
-	Title       string
-	Description string
-	Priority    int
-	Type        TaskType // Optional: links to a TaskDefinition
+	ID                string
+	Title             string
+	Description       string
+	AgentInstructions string
+	Priority          int
+	Type              TaskType // Optional: links to a TaskDefinition
 	// TODO: Add more fields (labels, assignee, source, etc.)
+}
+
+// PromptText returns the agent-facing prompt text for this task instance.
+// When no explicit instructions are attached, Description is reused.
+func (t Task) PromptText() string {
+	if strings.TrimSpace(t.AgentInstructions) != "" {
+		return t.AgentInstructions
+	}
+	return t.Description
 }
 
 // Queue holds tasks to be processed.

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -240,6 +241,91 @@ func TestTaskDefinitionEstimatedTokens(t *testing.T) {
 	min, max := def.EstimatedTokens()
 	if min != 10_000 || max != 50_000 {
 		t.Errorf("TaskDefinition.EstimatedTokens() = (%d, %d), want (10000, 50000)", min, max)
+	}
+}
+
+func TestTaskDefinitionPromptText(t *testing.T) {
+	tests := []struct {
+		name string
+		def  TaskDefinition
+		want string
+	}{
+		{
+			name: "falls back to description",
+			def: TaskDefinition{
+				Description: "summary only",
+			},
+			want: "summary only",
+		},
+		{
+			name: "uses explicit agent instructions",
+			def: TaskDefinition{
+				Description:       "short summary",
+				AgentInstructions: "detailed agent prompt",
+			},
+			want: "detailed agent prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.def.PromptText(); got != tt.want {
+				t.Errorf("PromptText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskPromptText(t *testing.T) {
+	tests := []struct {
+		name string
+		task Task
+		want string
+	}{
+		{
+			name: "falls back to description",
+			task: Task{
+				Description: "summary only",
+			},
+			want: "summary only",
+		},
+		{
+			name: "uses explicit agent instructions",
+			task: Task{
+				Description:       "short summary",
+				AgentInstructions: "detailed agent prompt",
+			},
+			want: "detailed agent prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.task.PromptText(); got != tt.want {
+				t.Errorf("PromptText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommitNormalizeHasDedicatedAgentInstructions(t *testing.T) {
+	def, err := GetDefinition(TaskCommitNormalize)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskCommitNormalize) error: %v", err)
+	}
+
+	if def.Description != "Standardize commit message format" {
+		t.Errorf("Description = %q, want short catalog summary", def.Description)
+	}
+
+	for _, want := range []string{
+		"do not rewrite published history",
+		"Preserve Nightshift's required commit trailers",
+		"Inspect recent repository history",
+	} {
+		if !strings.Contains(def.PromptText(), want) {
+			t.Errorf("PromptText() missing %q\nGot:\n%s", want, def.PromptText())
+		}
 	}
 }
 

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+# Install: make install-hooks
+set -euo pipefail
+
+msg_file="${1:-}"
+if [[ -z "${msg_file}" || ! -f "${msg_file}" ]]; then
+  echo "commit-msg: expected path to commit message file" >&2
+  exit 1
+fi
+
+subject=$(
+  grep -vE '^[[:space:]]*#' "$msg_file" | awk 'NF { print; exit }'
+)
+
+if [[ -z "${subject}" ]]; then
+  exit 0
+fi
+
+case "${subject}" in
+  Merge\ *|Revert\ *|fixup!\ *|squash!\ *)
+    exit 0
+    ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^ ].+$'
+if ! [[ "${subject}" =~ ${pattern} ]]; then
+  cat >&2 <<'EOF'
+commit-msg: subject must use:
+  <type>(<optional-scope>): <imperative summary>
+
+Examples:
+  fix(tasks): standardize commit message template
+  docs: add commit message guide
+
+Allowed types:
+  build, chore, ci, docs, feat, fix, perf, refactor, release, revert, style, test
+
+See docs/guides/commit-messages.md for details.
+EOF
+  exit 1
+fi
+
+if ((${#subject} > 72)); then
+  echo "commit-msg: subject is ${#subject} chars; keep it under 72" >&2
+  exit 1
+fi
+
+if [[ "${subject}" == *. ]]; then
+  echo "commit-msg: subject should not end with a period" >&2
+  exit 1
+fi
+
+nightshift_task_count=$(grep -c '^Nightshift-Task: ' "$msg_file" || true)
+nightshift_ref_count=$(grep -c '^Nightshift-Ref: ' "$msg_file" || true)
+
+if ((nightshift_task_count + nightshift_ref_count == 0)); then
+  exit 0
+fi
+
+if ((nightshift_task_count != 1 || nightshift_ref_count != 1)); then
+  cat >&2 <<'EOF'
+commit-msg: Nightshift commits must include both trailers:
+  Nightshift-Task: <task-id>
+  Nightshift-Ref: https://github.com/marcus/nightshift
+EOF
+  exit 1
+fi
+
+if ! grep -qx 'Nightshift-Ref: https://github.com/marcus/nightshift' "$msg_file"; then
+  echo "commit-msg: Nightshift-Ref must be https://github.com/marcus/nightshift" >&2
+  exit 1
+fi
+
+first_trailer_line=$(grep -n '^Nightshift-\(Task\|Ref\): ' "$msg_file" | head -n 1 | cut -d: -f1)
+if [[ -n "${first_trailer_line}" ]] && ((first_trailer_line > 1)); then
+  line_before=$(sed -n "$((first_trailer_line - 1))p" "$msg_file")
+  if [[ -n "${line_before}" ]]; then
+    echo "commit-msg: leave a blank line before Nightshift trailers" >&2
+    exit 1
+  fi
+fi

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -56,6 +56,12 @@ nightshift task run lint-fix --provider claude --dry-run
 nightshift task run lint-fix --provider claude
 ```
 
+## Built-in Task Prompts
+
+Built-in task descriptions stay short in `nightshift task list`, previews, and JSON output. When a task needs extra guardrails, Nightshift uses richer agent instructions behind the scenes for `task show --prompt-only`, `task run`, and orchestrated runs.
+
+`commit-normalize` is the reference example: it remains a concise PR task in the catalog, but the agent prompt tells Nightshift to inspect existing repo conventions, standardize future commit behavior with minimal docs or enforcement changes, preserve Nightshift trailers, and avoid rewriting published history.
+
 ## Skill Grooming Task
 
 Nightshift includes a built-in `skill-groom` task for keeping project-local skills aligned with the current codebase.


### PR DESCRIPTION
## Summary
- split built-in task summaries from agent-facing instructions and give `commit-normalize` actionable prompt guidance
- add a forward-looking commit message standard with template, hook validation, and docs
- make `make install-hooks` work in linked worktrees by resolving absolute hook paths and writing commit.template to worktree-local config

## Testing
- go test ./internal/tasks ./internal/orchestrator ./cmd/nightshift/commands
- go test ./...
- make install-hooks
- make -C <temp-worktree> -f /Users/marcus/code/nightshift/Makefile install-hooks