### PR TITLE
docs: backfill user-facing reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Everything lands as a branch or PR. It never writes directly to your primary bra
 
 - **Budget-aware**: Uses remaining daily allotment, never exceeds configurable max (default 75%)
 - **Multi-project**: Point it at your repos, it already knows what to look for
+- **Multi-provider**: Runs with Claude Code, Codex, or GitHub Copilot
 - **Zero risk**: Everything is a PR — merge what surprises you, close the rest
 - **Great DX**: Thoughtful CLI defaults with clear output and reports
 
@@ -32,6 +33,12 @@ Manual install:
 ```bash
 go install github.com/marcus/nightshift/cmd/nightshift@latest
 ```
+
+Nightshift needs at least one provider CLI available in `PATH`:
+
+- Claude Code via `claude`
+- Codex via `codex`
+- GitHub Copilot via standalone `copilot` or `gh copilot`
 
 ## Getting Started
 
@@ -56,6 +63,14 @@ Or kick off a run immediately:
 nightshift run
 ```
 
+If you prefer starter config files instead of the wizard:
+
+```bash
+nightshift init --global
+nightshift init
+nightshift config validate
+```
+
 ## Common CLI Usage
 
 Full reference: [CLI Reference docs](https://nightshift.haplab.com/docs/cli-reference)
@@ -69,14 +84,20 @@ nightshift preview --plain
 nightshift preview --json
 nightshift preview --write ./nightshift-prompts
 
-# Guided global setup
+# Guided setup and config inspection
 nightshift setup
+nightshift init --global
+nightshift config
+nightshift config get providers.preference
+nightshift config set budget.max_percent 60 --global
+nightshift config validate
 
 # Check environment and config health
 nightshift doctor
 
 # Budget status and calibration
 nightshift budget --provider claude
+nightshift budget --provider copilot
 nightshift budget snapshot --local-only
 nightshift budget history -n 10
 nightshift budget calibrate
@@ -94,17 +115,31 @@ nightshift task show lint-fix --prompt-only
 # Run a task immediately
 nightshift task run lint-fix --provider claude
 nightshift task run skill-groom --provider codex --dry-run
-nightshift task run lint-fix --provider codex --dry-run
+nightshift task run docs-backfill --provider copilot --dry-run
+
+# Inspect logs, reports, and stats
+nightshift logs --tail 100
+nightshift logs --follow --component daemon
+nightshift report --report overview --period last-night
+nightshift report --report tasks --period last-7d --format markdown
+nightshift stats --period last-7d
+
+# Analyze repository ownership concentration
+nightshift busfactor .
+
+# Background execution
+nightshift install
+nightshift daemon start --foreground
+nightshift daemon status
+nightshift daemon stop
+nightshift uninstall
 ```
 
 If `gum` is available, preview output is shown through the gum pager. Use `--plain` to disable.
 
 ### `nightshift run`
 
-Before executing, `nightshift run` displays a **preflight summary** showing the
-selected provider, budget status, projects, and planned tasks. In interactive
-terminals you are prompted for confirmation; in non-TTY environments (cron,
-daemon, CI) confirmation is auto-skipped.
+Before executing, `nightshift run` displays a **preflight summary** showing the selected provider, budget status, projects, and planned tasks. In interactive terminals you are prompted for confirmation; in non-TTY environments (cron, daemon, CI) confirmation is auto-skipped.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -116,6 +151,8 @@ daemon, CI) confirmation is auto-skipped.
 | `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
 | `--ignore-budget` | `false` | Bypass budget checks (use with caution) |
 | `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| `--branch`, `-b` | current branch | Base branch for new feature branches |
+| `--timeout` | `30m` | Per-agent execution timeout |
 
 ```bash
 # Interactive run with preflight summary + confirmation prompt
@@ -138,6 +175,9 @@ nightshift run --ignore-budget
 
 # Target a specific project and task directly
 nightshift run -p ./my-project -t lint-fix
+
+# Use a different base branch for generated work
+nightshift run --branch develop
 ```
 
 Other useful flags:
@@ -146,7 +186,7 @@ Other useful flags:
 - `--category` — filter tasks by category (pr, analysis, options, safe, map, emergency)
 - `--cost` — filter by cost tier (low, medium, high, veryhigh)
 - `--prompt-only` — output just the raw prompt text for piping
-- `--provider` — required for `task run`, choose claude or codex
+- `--provider` — required for `task run`, choose claude, codex, or copilot
 - `--dry-run` — preview the prompt without executing
 - `--timeout` — execution timeout (default 30m)
 
@@ -154,14 +194,13 @@ Other useful flags:
 
 Nightshift supports three AI providers:
 - **Claude Code** - Anthropic's Claude via local CLI
-- **Codex** - OpenAI's GPT via local CLI  
-- **GitHub Copilot** - GitHub's Copilot via GitHub CLI
+- **Codex** - OpenAI's GPT via local CLI
+- **GitHub Copilot** - Copilot CLI via standalone `copilot` or `gh copilot`
 
 ### Claude Code
 
 ```bash
-claude
-/login
+claude auth login
 ```
 
 Supports Claude.ai subscriptions or Anthropic Console credentials.
@@ -169,21 +208,23 @@ Supports Claude.ai subscriptions or Anthropic Console credentials.
 ### Codex
 
 ```bash
-codex --login
+codex login
 ```
 
-Supports signing in with ChatGPT or an API key.
+Supports interactive sign-in or API-key login:
+
+```bash
+printenv OPENAI_API_KEY | codex login --with-api-key
+```
 
 ### GitHub Copilot
 
 ```bash
-# Install Copilot CLI
-npm install -g @github/copilot
-# or
-curl -fsSL https://gh.io/copilot-install | bash
+gh auth login
+gh copilot --help
 ```
 
-Requires GitHub Copilot subscription. See [docs/COPILOT_INTEGRATION.md](docs/COPILOT_INTEGRATION.md) for details.
+Nightshift prefers a standalone `copilot` binary when one is present in `PATH`. If not, it falls back to `gh copilot`. After authenticating a provider, run `nightshift doctor` to confirm Nightshift can see it.
 
 If you prefer API-based usage, you can authenticate Claude and Codex CLIs with API keys instead.
 
@@ -198,9 +239,29 @@ Nightshift uses YAML config files to define:
 - Task priorities
 - Schedule preferences
 
-Run `nightshift setup` to create/update the global config at `~/.config/nightshift/config.yaml`.
+Create or update config with either:
 
-See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) or [SPEC.md](docs/SPEC.md) for detailed options.
+```bash
+nightshift setup
+nightshift init --global
+nightshift init
+```
+
+Runtime layering is:
+
+1. Built-in defaults
+2. Global config: `~/.config/nightshift/config.yaml`
+3. Project config: `nightshift.yaml`
+4. Environment overrides such as `NIGHTSHIFT_BUDGET_MAX_PERCENT`
+
+Inspect and edit config from the CLI:
+
+```bash
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set providers.copilot.enabled true --global
+nightshift config validate
+```
 
 Minimal example:
 
@@ -220,18 +281,31 @@ providers:
   preference:
     - claude
     - codex
+    - copilot
   claude:
     enabled: true
     data_path: "~/.claude"
-    dangerously_skip_permissions: true
+    dangerously_skip_permissions: false
   codex:
     enabled: true
     data_path: "~/.codex"
-    dangerously_bypass_approvals_and_sandbox: true
+    dangerously_bypass_approvals_and_sandbox: false
+  copilot:
+    enabled: false
+    data_path: "~/.copilot"
+    dangerously_skip_permissions: false
 
 projects:
   - path: ~/code/sidecar
   - path: ~/code/td
+
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
 ```
 
 Task selection:

--- a/README.md
+++ b/README.md
@@ -221,10 +221,21 @@ printenv OPENAI_API_KEY | codex login --with-api-key
 
 ```bash
 gh auth login
+gh extension install github/gh-copilot
 gh copilot --help
 ```
 
-Nightshift prefers a standalone `copilot` binary when one is present in `PATH`. If not, it falls back to `gh copilot`. After authenticating a provider, run `nightshift doctor` to confirm Nightshift can see it.
+Nightshift prefers a standalone `copilot` binary when one is present in `PATH`. If not, it falls back to `gh copilot`, which Nightshift detects through `gh extension list`.
+
+To verify provider CLI access without executing a task:
+
+```bash
+nightshift task run lint-fix --provider claude --dry-run
+nightshift task run lint-fix --provider codex --dry-run
+nightshift task run lint-fix --provider copilot --dry-run
+```
+
+Then run `nightshift doctor` to inspect config, data paths, usage, and snapshots for the providers you have enabled in config.
 
 If you prefer API-based usage, you can authenticate Claude and Codex CLIs with API keys instead.
 

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -5,88 +5,330 @@ title: CLI Reference
 
 # CLI Reference
 
-## Core Commands
-
-| Command | Description |
-|---------|-------------|
-| `nightshift setup` | Guided global configuration |
-| `nightshift run` | Execute scheduled tasks |
-| `nightshift preview` | Show upcoming runs |
-| `nightshift budget` | Check token budget status |
-| `nightshift task` | Browse and run tasks |
-| `nightshift doctor` | Check environment health |
-| `nightshift status` | View run history |
-| `nightshift logs` | Stream or export logs |
-| `nightshift stats` | Token usage statistics |
-| `nightshift daemon` | Background scheduler |
-
-## Run Options
-
-`nightshift run` shows a preflight summary before executing, then prompts for confirmation in interactive terminals.
-
-```bash
-nightshift run                          # Preflight + confirm + execute (1 project, 1 task)
-nightshift run --yes                    # Skip confirmation
-nightshift run --dry-run                # Show preflight, don't execute
-nightshift run --max-projects 3         # Process up to 3 projects
-nightshift run --max-tasks 2            # Run up to 2 tasks per project
-nightshift run --random-task            # Pick a random eligible task
-nightshift run --ignore-budget          # Bypass budget limits (use with caution)
-nightshift run --project ~/code/myapp   # Target specific project (ignores --max-projects)
-nightshift run --task lint-fix          # Run specific task (ignores --max-tasks)
-```
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--dry-run` | `false` | Show preflight summary and exit without executing |
-| `--yes`, `-y` | `false` | Skip confirmation prompt |
-| `--max-projects` | `1` | Max projects to process (ignored when `--project` is set) |
-| `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
-| `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
-| `--ignore-budget` | `false` | Bypass budget checks with a warning |
-| `--project`, `-p` | | Target a specific project directory |
-| `--task`, `-t` | | Run a specific task by name |
-
-Non-interactive contexts (daemon, cron, piped output) skip the confirmation prompt automatically.
-
-## Preview Options
-
-```bash
-nightshift preview                # Default view
-nightshift preview -n 3           # Next 3 runs
-nightshift preview --long         # Detailed view
-nightshift preview --explain      # With prompt previews
-nightshift preview --plain        # No pager
-nightshift preview --json         # JSON output
-nightshift preview --write ./dir  # Write prompts to files
-```
-
-## Task Commands
-
-```bash
-nightshift task list              # All tasks
-nightshift task list --category pr
-nightshift task list --cost low --json
-nightshift task show lint-fix
-nightshift task show lint-fix --prompt-only
-nightshift task run lint-fix --provider claude
-nightshift task run lint-fix --provider codex --dry-run
-```
-
-## Budget Commands
-
-```bash
-nightshift budget                 # Current status
-nightshift budget --provider claude
-nightshift budget snapshot --local-only
-nightshift budget history -n 10
-nightshift budget calibrate
-```
+Run `nightshift --help` or `nightshift COMMAND --help` for the full generated help text. This page focuses on the commands and flags most people reach for.
 
 ## Global Flags
 
 | Flag | Description |
 |------|-------------|
-| `--verbose` | Verbose output |
-| `--provider` | Select provider (claude, codex) |
-| `--timeout` | Execution timeout (default 30m) |
+| `--verbose` | Enable verbose output |
+| `--version`, `-v` | Print the installed Nightshift version |
+
+## Top-Level Commands
+
+| Command | Description |
+|---------|-------------|
+| `nightshift setup` | Guided global onboarding wizard |
+| `nightshift init` | Create a starter config file |
+| `nightshift config` | Show, read, write, or validate config |
+| `nightshift preview` | Preview upcoming runs without executing |
+| `nightshift run` | Execute tasks immediately |
+| `nightshift budget` | Inspect budget status and snapshots |
+| `nightshift task` | Browse tasks, inspect prompts, or run one directly |
+| `nightshift logs` | Tail, filter, or export logs |
+| `nightshift report` | Summarize recent Nightshift activity |
+| `nightshift stats` | Show aggregate run and token statistics |
+| `nightshift busfactor` | Analyze ownership concentration in a repo |
+| `nightshift daemon` | Start, stop, or inspect the background daemon |
+| `nightshift install` | Install a launchd, systemd, or cron service |
+| `nightshift uninstall` | Remove the installed service |
+| `nightshift doctor` | Check config, providers, snapshots, and DB health |
+| `nightshift status` | Show recent runs or today's activity |
+
+## Setup And Configuration
+
+### `nightshift setup`
+
+Interactive onboarding that writes the global config, validates providers, runs a snapshot, previews the next run, and can install the daemon.
+
+```bash
+nightshift setup
+```
+
+### `nightshift init`
+
+Create starter config files without the wizard.
+
+```bash
+nightshift init
+nightshift init --global
+nightshift init --force
+```
+
+| Flag | Description |
+|------|-------------|
+| `--global` | Write `~/.config/nightshift/config.yaml` instead of `./nightshift.yaml` |
+| `--force`, `-f` | Overwrite an existing config without prompting |
+
+### `nightshift config`
+
+Show the merged config and work with specific keys.
+
+```bash
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 60 --global
+nightshift config validate
+```
+
+Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `config get KEY` | Print a specific config value |
+| `config set KEY VALUE` | Write a specific config value |
+| `config validate` | Validate global, project, and merged config |
+
+`config set` writes to `nightshift.yaml` when it exists in the current repo. Otherwise it writes to the global config unless `--global` is provided explicitly.
+
+## Running Work
+
+### `nightshift run`
+
+`nightshift run` shows a preflight summary before executing. Interactive terminals prompt for confirmation; non-TTY environments skip confirmation automatically.
+
+```bash
+nightshift run
+nightshift run --dry-run
+nightshift run --yes
+nightshift run --max-projects 3 --max-tasks 2
+nightshift run --random-task
+nightshift run --ignore-budget
+nightshift run --project ~/code/myapp --task lint-fix
+nightshift run --branch develop
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Show the preflight summary and exit |
+| `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| `--project`, `-p` | unset | Limit the run to one project path |
+| `--task`, `-t` | unset | Run a specific task type |
+| `--max-projects` | `1` | Max projects to process when `--project` is not set |
+| `--max-tasks` | `1` | Max tasks per project when `--task` is not set |
+| `--random-task` | `false` | Choose a random eligible task instead of the top-scored task |
+| `--ignore-budget` | `false` | Bypass budget checks |
+| `--branch`, `-b` | current branch | Base branch for new feature branches |
+| `--timeout` | `30m` | Per-agent execution timeout |
+| `--no-color` | `false` | Disable colored output |
+
+### `nightshift preview`
+
+Preview the next scheduled runs without changing state.
+
+```bash
+nightshift preview
+nightshift preview -n 5
+nightshift preview --long
+nightshift preview --explain
+nightshift preview --json
+nightshift preview --write ./nightshift-prompts
+```
+
+Key flags:
+
+| Flag | Description |
+|------|-------------|
+| `--runs`, `-n` | Number of upcoming runs to preview |
+| `--project`, `-p` | Preview only one project |
+| `--task`, `-t` | Preview only one task type |
+| `--long` | Show full prompts instead of truncated previews |
+| `--explain` | Show budget and cooldown explanations |
+| `--json` | Machine-readable output |
+| `--plain` | Disable the `gum` pager |
+| `--write DIR` | Write prompt files to a directory |
+
+### `nightshift task`
+
+Browse tasks, inspect their prompts, or run one directly against a specific provider.
+
+```bash
+nightshift task list
+nightshift task list --category pr
+nightshift task list --cost low --json
+nightshift task show lint-fix
+nightshift task show lint-fix --prompt-only
+nightshift task run lint-fix --provider claude
+nightshift task run docs-backfill --provider copilot --dry-run
+```
+
+Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `task list` | List available tasks with filters |
+| `task show TASK_TYPE` | Show task metadata and the planning prompt |
+| `task run TASK_TYPE --provider PROVIDER` | Execute one task immediately |
+
+## Budget And Reporting
+
+### `nightshift budget`
+
+Inspect provider budget state or work with usage snapshots.
+
+```bash
+nightshift budget
+nightshift budget --provider claude
+nightshift budget --provider copilot
+nightshift budget snapshot --provider codex
+nightshift budget snapshot --local-only
+nightshift budget history -n 10
+nightshift budget calibrate
+```
+
+Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `budget snapshot` | Capture a usage snapshot |
+| `budget history` | Show recent snapshots |
+| `budget calibrate` | Show inferred calibration status |
+
+### `nightshift logs`
+
+Tail and filter Nightshift logs.
+
+```bash
+nightshift logs
+nightshift logs --tail 200 --level warn
+nightshift logs --follow --component daemon
+nightshift logs --match copilot --since 2026-04-01
+nightshift logs --export ./nightshift.log
+```
+
+Common flags:
+
+| Flag | Description |
+|------|-------------|
+| `--follow`, `-f` | Stream new log lines |
+| `--tail`, `-n` | Number of lines to show |
+| `--component` | Filter by component substring |
+| `--level` | Minimum level: `debug`, `info`, `warn`, `error` |
+| `--match` | Filter by message substring |
+| `--since`, `--until` | Time window filters |
+| `--summary` | Show summary only |
+| `--raw` | Print raw log lines |
+| `--export FILE` | Write matching logs to a file |
+
+### `nightshift report`
+
+Summarize recent work in a more structured format than `status`.
+
+```bash
+nightshift report
+nightshift report --report overview --period last-night
+nightshift report --report tasks --period last-7d --format markdown
+nightshift report --report raw --format json --runs 1
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--report`, `-r` | `overview` | `overview`, `tasks`, `projects`, `budget`, or `raw` |
+| `--period`, `-p` | `last-night` | `last-night`, `last-run`, `last-24h`, `last-7d`, `today`, `yesterday`, or `all` |
+| `--format` | `fancy` | `fancy`, `plain`, `markdown`, or `json` |
+| `--runs`, `-n` | `3` | Max runs to include (`0` means all) |
+| `--max-items` | `5` | Max highlights per run |
+| `--paths` | `false` | Include report and log file paths |
+| `--since`, `--until` | unset | Explicit time bounds |
+
+### `nightshift stats`
+
+Show aggregate run counts, task outcomes, token usage, and projections.
+
+```bash
+nightshift stats
+nightshift stats --period last-7d
+nightshift stats --json
+```
+
+### `nightshift status`
+
+Show recent runs or a same-day summary.
+
+```bash
+nightshift status
+nightshift status --last 10
+nightshift status --today
+```
+
+## Ownership Analysis
+
+### `nightshift busfactor`
+
+Analyze commit concentration for a repo, directory, or file subset.
+
+```bash
+nightshift busfactor .
+nightshift busfactor --path ~/code/nightshift --since 2026-01-01
+nightshift busfactor --file 'internal/**/*.go' --save
+nightshift busfactor --json
+```
+
+Key flags:
+
+| Flag | Description |
+|------|-------------|
+| `--path`, `-p` | Repo or directory to analyze |
+| `--file`, `-f` | Restrict analysis to a file or pattern |
+| `--since`, `--until` | Date range filters |
+| `--save` | Persist results to the database |
+| `--json` | Machine-readable output |
+| `--db` | Override the database path |
+
+## Background Execution
+
+### `nightshift install`
+
+Install a scheduled service. If you omit the service type, Nightshift auto-detects one from the current OS.
+
+```bash
+nightshift install
+nightshift install launchd
+nightshift install systemd
+nightshift install cron
+nightshift uninstall
+```
+
+Supported service types:
+
+| Type | Environment |
+|------|-------------|
+| `launchd` | macOS user LaunchAgent |
+| `systemd` | Linux user service and timer |
+| `cron` | Generic cron entry |
+
+### `nightshift daemon`
+
+Run the scheduler as a foreground or background daemon.
+
+```bash
+nightshift daemon start
+nightshift daemon start --foreground
+nightshift daemon start --foreground --timeout 45m
+nightshift daemon status
+nightshift daemon stop
+```
+
+Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `daemon start` | Start the daemon |
+| `daemon status` | Check whether the daemon is running |
+| `daemon stop` | Stop the running daemon |
+
+`daemon start` supports:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--foreground`, `-f` | `false` | Stay in the foreground instead of daemonizing |
+| `--timeout` | `30m` | Per-agent execution timeout |
+
+## Diagnostics
+
+```bash
+nightshift doctor
+nightshift status --today
+```
+
+Use `nightshift doctor` after installing provider CLIs, changing config, or troubleshooting budget/provider detection.

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -331,4 +331,4 @@ nightshift doctor
 nightshift status --today
 ```
 
-Use `nightshift doctor` after installing provider CLIs, changing config, or troubleshooting budget/provider detection.
+Use `nightshift doctor` after changing config or troubleshooting provider data and snapshot health. To smoke-test a specific provider CLI, run `nightshift task run lint-fix --provider PROVIDER --dry-run`.

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -5,22 +5,50 @@ title: Configuration
 
 # Configuration
 
-Nightshift uses YAML config files. Run `nightshift setup` for an interactive setup, or edit directly.
+Nightshift uses YAML config files. Use `nightshift setup` for the guided global wizard, `nightshift init` to generate starter files, or edit YAML directly.
 
-## Config Location
+## Config Layering
 
-- **Global:** `~/.config/nightshift/config.yaml`
-- **Per-project:** `nightshift.yaml` or `.nightshift.yaml` in the repo root
+Load order is:
 
-## Minimal Config
+1. Built-in defaults
+2. Global config: `~/.config/nightshift/config.yaml`
+3. Project config: `nightshift.yaml`
+4. Environment overrides
+
+Project config overrides the global config for that repo.
+
+## Bootstrap Config
+
+```bash
+nightshift setup
+nightshift init --global
+nightshift init
+```
+
+Inspect and validate config from the CLI:
+
+```bash
+nightshift config
+nightshift config get providers.preference
+nightshift config set budget.max_percent 60 --global
+nightshift config validate
+```
+
+`nightshift config set` is best for scalar values. Arrays and larger nested structures are usually easier to edit directly in YAML.
+
+## Minimal Global Config
 
 ```yaml
 schedule:
   cron: "0 2 * * *"
+  max_projects: 1
+  max_tasks: 1
 
 budget:
   mode: daily
   max_percent: 75
+  weekly_tokens: 700000
   reserve_percent: 5
   billing_mode: subscription
   calibrate_enabled: true
@@ -30,18 +58,31 @@ providers:
   preference:
     - claude
     - codex
+    - copilot
   claude:
     enabled: true
     data_path: "~/.claude"
-    dangerously_skip_permissions: true
+    dangerously_skip_permissions: false
   codex:
     enabled: true
     data_path: "~/.codex"
-    dangerously_bypass_approvals_and_sandbox: true
+    dangerously_bypass_approvals_and_sandbox: false
+  copilot:
+    enabled: false
+    data_path: "~/.copilot"
+    dangerously_skip_permissions: false
 
 projects:
   - path: ~/code/sidecar
   - path: ~/code/td
+
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
 ```
 
 ## Schedule
@@ -52,6 +93,8 @@ Use cron syntax or interval-based scheduling:
 schedule:
   cron: "0 2 * * *"        # Every night at 2am
   # interval: "8h"         # Or run every 8 hours
+  # max_projects: 2        # Default project cap for scheduled runs
+  # max_tasks: 1           # Default task cap per project
 ```
 
 ## Budget
@@ -63,12 +106,65 @@ Control how much of your token budget Nightshift uses:
 | `mode` | `daily` | `daily` or `weekly` |
 | `max_percent` | `75` | Max budget % to use per run |
 | `reserve_percent` | `5` | Always keep this % available |
+| `weekly_tokens` | `700000` | Fallback weekly budget when provider data is incomplete |
+| `per_provider` | unset | Override budget per provider, for example `copilot: 500` |
 | `billing_mode` | `subscription` | `subscription` or `api` |
 | `calibrate_enabled` | `true` | Auto-calibrate from local CLI data |
+| `snapshot_interval` | `30m` | How often Nightshift captures budget snapshots |
+| `snapshot_retention_days` | `90` | How long snapshots are retained |
+| `week_start_day` | `monday` | Week anchor for weekly budget calculations |
+| `db_path` | platform default | Override the SQLite database path |
+
+Example:
+
+```yaml
+budget:
+  mode: weekly
+  max_percent: 60
+  reserve_percent: 10
+  weekly_tokens: 700000
+  per_provider:
+    claude: 700000
+    codex: 500000
+    copilot: 300
+```
+
+## Providers
+
+Nightshift supports `claude`, `codex`, and `copilot`.
+
+| Key | Description |
+|-----|-------------|
+| `providers.preference` | Ordered provider preference used for automatic selection |
+| `providers.PROVIDER.enabled` | Enable or disable a provider |
+| `providers.PROVIDER.data_path` | Override the local data directory used for usage tracking |
+| `providers.claude.dangerously_skip_permissions` | Allow Claude to bypass permission prompts |
+| `providers.codex.dangerously_bypass_approvals_and_sandbox` | Allow headless Codex execution without approvals |
+| `providers.copilot.dangerously_skip_permissions` | Allow Copilot to use the broad permission flags |
+
+Example:
+
+```yaml
+providers:
+  preference:
+    - codex
+    - claude
+    - copilot
+  claude:
+    enabled: true
+    data_path: "~/.claude"
+  codex:
+    enabled: true
+    data_path: "~/.codex"
+    dangerously_bypass_approvals_and_sandbox: true
+  copilot:
+    enabled: true
+    data_path: "~/.copilot"
+```
 
 ## Task Selection
 
-Enable/disable tasks and set priorities:
+Enable or disable tasks and set priorities:
 
 ```yaml
 tasks:
@@ -76,6 +172,7 @@ tasks:
     - lint-fix
     - docs-backfill
     - bug-finder
+    - skill-groom
   priorities:
     lint-fix: 1
     bug-finder: 2
@@ -86,32 +183,58 @@ tasks:
 
 Each task has a default cooldown interval to prevent the same task from running too frequently on a project.
 
-## Multi-Project Setup
+## Projects
+
+The global config can manage multiple repos:
 
 ```yaml
 projects:
   - path: ~/code/project1
-    priority: 1                # Higher priority = processed first
-    tasks:
-      - lint
-      - docs
-  - path: ~/code/project2
     priority: 2
-
-  # Or use glob patterns
+  - path: ~/code/project2
+    priority: 1
   - pattern: ~/code/oss/*
     exclude:
-      - ~/code/oss/archived
+      - ~/code/oss/archive
 ```
 
-## Safe Defaults
+Project-local overrides belong in each repo's `nightshift.yaml`.
 
-| Feature | Default | Override |
-|---------|---------|----------|
-| Read-only first run | Yes | `--enable-writes` |
-| Max budget per run | 75% | `budget.max_percent` |
-| Auto-push to remote | No | Manual only |
-| Reserve budget | 5% | `budget.reserve_percent` |
+## Integrations
+
+```yaml
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
+    - github_issues: true
+```
+
+Use `claude_md` and `agents_md` to ingest repo instructions automatically. Use `task_sources` to pull work from `td` or GitHub issues.
+
+## Logging And Reporting
+
+```yaml
+logging:
+  level: info
+  path: ~/.local/share/nightshift/logs
+  format: json
+
+reporting:
+  morning_summary: true
+```
+
+## Environment Overrides
+
+Nightshift binds a few common overrides directly from the environment:
+
+- `NIGHTSHIFT_BUDGET_MAX_PERCENT`
+- `NIGHTSHIFT_BUDGET_MODE`
+- `NIGHTSHIFT_LOG_LEVEL`
+- `NIGHTSHIFT_LOG_PATH`
 
 ## File Locations
 
@@ -124,7 +247,3 @@ projects:
 | PID file | `~/.local/share/nightshift/nightshift.pid` |
 
 If `state/state.json` exists from older versions, Nightshift migrates it to the SQLite database and renames the file to `state.json.migrated`.
-
-## Providers
-
-Nightshift supports Claude Code and Codex as execution providers. It will use whichever has budget remaining, in the order specified by `preference`.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -39,16 +39,75 @@ nightshift --version
 nightshift --help
 ```
 
-## Prerequisites
+## Provider Prerequisites
 
-- **Claude Code CLI** (`claude`) and/or **Codex CLI** (`codex`) installed
-- Authenticated via subscription login or API keys:
+Nightshift needs at least one provider CLI available in `PATH`. It can run with Claude Code, Codex, or GitHub Copilot.
+
+### Claude Code
+
+Authenticate Claude Code before running `nightshift setup` or `nightshift doctor`:
 
 ```bash
-# Claude Code
-claude
-/login
+claude auth login
+claude --help
+```
 
-# Codex
-codex --login
+Nightshift reads local Claude usage data from `~/.claude` by default. Override that with `providers.claude.data_path` if needed.
+
+### Codex
+
+Codex works with either interactive login or an API key:
+
+```bash
+codex login
+codex --help
+```
+
+API-key flow:
+
+```bash
+printenv OPENAI_API_KEY | codex login --with-api-key
+```
+
+Nightshift reads local Codex data from `~/.codex` by default.
+
+### GitHub Copilot
+
+Nightshift supports GitHub Copilot in two modes:
+
+- Standalone `copilot` binary in `PATH`
+- `gh copilot` via GitHub CLI
+
+Typical setup:
+
+```bash
+gh auth login
+gh copilot --help
+```
+
+Nightshift prefers a standalone `copilot` binary when one exists. If it does not find one, it falls back to `gh copilot`. Copilot usage tracking is stored under `~/.copilot` by default.
+
+## First Run
+
+The onboarding wizard writes the global config, validates providers, captures a budget snapshot, previews the next run, and can install the daemon:
+
+```bash
+nightshift setup
+```
+
+If you want starter config files without the wizard:
+
+```bash
+nightshift init --global
+nightshift init
+nightshift config validate
+```
+
+## Verify Provider Detection
+
+After installing and authenticating provider CLIs, confirm Nightshift can see them:
+
+```bash
+nightshift doctor
+nightshift preview
 ```

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -82,10 +82,11 @@ Typical setup:
 
 ```bash
 gh auth login
+gh extension install github/gh-copilot
 gh copilot --help
 ```
 
-Nightshift prefers a standalone `copilot` binary when one exists. If it does not find one, it falls back to `gh copilot`. Copilot usage tracking is stored under `~/.copilot` by default.
+Nightshift prefers a standalone `copilot` binary when one exists. If it does not find one, it falls back to `gh copilot`, which Nightshift detects through `gh extension list`. Copilot usage tracking is stored under `~/.copilot` by default.
 
 ## First Run
 
@@ -103,11 +104,18 @@ nightshift init
 nightshift config validate
 ```
 
-## Verify Provider Detection
+## Verify Provider Access And Health
 
-After installing and authenticating provider CLIs, confirm Nightshift can see them:
+Use a dry run to confirm Nightshift can invoke the provider CLI you plan to use:
+
+```bash
+nightshift task run lint-fix --provider claude --dry-run
+nightshift task run lint-fix --provider codex --dry-run
+nightshift task run lint-fix --provider copilot --dry-run
+```
+
+Then run doctor to inspect config, data paths, usage, and snapshots for providers that are enabled in config:
 
 ```bash
 nightshift doctor
-nightshift preview
 ```

--- a/website/docs/integrations.md
+++ b/website/docs/integrations.md
@@ -39,10 +39,11 @@ Nightshift uses the local `codex` CLI and reads usage data from `providers.codex
 
 ```bash
 gh auth login
+gh extension install github/gh-copilot
 gh copilot --help
 ```
 
-Nightshift supports either a standalone `copilot` binary or `gh copilot`. It prefers standalone `copilot` when one is present in `PATH`, otherwise it falls back to `gh`.
+Nightshift supports either a standalone `copilot` binary or `gh copilot`. It prefers standalone `copilot` when one is present in `PATH`, otherwise it falls back to `gh`, which must have the `gh-copilot` extension installed.
 
 ## GitHub Workflow
 

--- a/website/docs/integrations.md
+++ b/website/docs/integrations.md
@@ -5,52 +5,110 @@ title: Integrations
 
 # Integrations
 
-Nightshift integrates with your existing development workflow.
+Nightshift integrates with your existing development workflow for provider execution, task sourcing, and repo-level instruction files.
 
-## Claude Code
+## Execution Providers
 
-Nightshift uses the Claude Code CLI to execute tasks. Authenticate via subscription or API key:
+Nightshift can execute tasks with Claude Code, Codex, or GitHub Copilot. Automatic selection follows `providers.preference`, and `nightshift task run --provider ...` lets you target one provider directly.
 
-```bash
-claude
-/login
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+    - copilot
 ```
 
-## Codex
-
-Nightshift supports OpenAI's Codex CLI as an alternative provider:
+### Claude Code
 
 ```bash
-codex --login
+claude auth login
 ```
 
-## GitHub
+Nightshift uses the local `claude` CLI and reads usage data from `providers.claude.data_path` (default `~/.claude`).
 
-All output is PR-based. Nightshift creates branches and pull requests for its findings.
+### Codex
+
+```bash
+codex login
+```
+
+Nightshift uses the local `codex` CLI and reads usage data from `providers.codex.data_path` (default `~/.codex`).
+
+### GitHub Copilot
+
+```bash
+gh auth login
+gh copilot --help
+```
+
+Nightshift supports either a standalone `copilot` binary or `gh copilot`. It prefers standalone `copilot` when one is present in `PATH`, otherwise it falls back to `gh`.
+
+## GitHub Workflow
+
+Nightshift works on branches and PRs instead of writing directly to your primary branch. In GitHub repos it can also source work from labeled issues when the GitHub task-source integration is enabled.
 
 ## td (Task Management)
 
-Nightshift can source tasks from [td](https://td.haplab.com) — task management for AI-assisted development. Tasks tagged with `nightshift` in td will be picked up automatically.
+Nightshift can source tasks from [td](https://td.haplab.com). When `teach_agent` is enabled, it also injects td workflow instructions into the agent prompt.
 
 ```yaml
 integrations:
   task_sources:
     - td:
         enabled: true
-        teach_agent: true   # Include td usage + core workflow in prompts
+        teach_agent: true
 ```
 
-## CLAUDE.md / AGENTS.md
-
-Nightshift reads project-level instruction files to understand context when executing tasks. Place a `CLAUDE.md` or `AGENTS.md` in your repo root to give Nightshift project-specific guidance. Tasks mentioned in these files get a priority bonus (+2).
+Nightshift shells out to the local `td` CLI, reads tasks from the current project, and merges them into task selection.
 
 ## GitHub Issues
 
-Source tasks from GitHub issues labeled with `nightshift`:
+Nightshift can source open GitHub issues labeled `nightshift` through the `gh` CLI:
 
 ```yaml
 integrations:
-  github_issues:
-    enabled: true
-    label: "nightshift"
+  task_sources:
+    - github_issues: true
+```
+
+The repo must have a GitHub `origin`, `gh` must be installed, and issue access must already work in that checkout.
+
+## CLAUDE.md And AGENTS.md
+
+Nightshift reads project instruction files and folds them into prompt context before execution.
+
+Supported filenames:
+
+- `CLAUDE.md`, `claude.md`, `.claude.md`
+- `AGENTS.md`, `agents.md`, `.agents.md`
+
+Enable or disable them in config:
+
+```yaml
+integrations:
+  claude_md: true
+  agents_md: true
+```
+
+Use these files for repo-specific conventions, safety rules, workflow instructions, or architecture context you want Nightshift to inherit automatically.
+
+## Common Integration Config
+
+```yaml
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
+    - github_issues: true
+```
+
+After changing integrations, run:
+
+```bash
+nightshift config validate
+nightshift preview --explain
 ```

--- a/website/docs/task-reference.md
+++ b/website/docs/task-reference.md
@@ -7,7 +7,7 @@ title: Task Reference
 
 Nightshift includes **59 built-in tasks** organized into 6 categories. Each task has a cost tier, risk level, and default cooldown interval.
 
-Use `nightshift task list` to browse tasks, or `nightshift task show <name>` to see details for a specific task.
+Use `nightshift task list` to browse tasks, or `nightshift task show TASK_TYPE` to see details for a specific task.
 
 ## PR Tasks — "It's done — here's the PR"
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -55,7 +55,7 @@ logging:
 
 ```bash
 nightshift --help
-nightshift <command> --help
+nightshift COMMAND --help
 ```
 
 Report issues: https://github.com/marcus/nightshift/issues


### PR DESCRIPTION
## Summary
- carry forward the user-facing docs backfill on a fresh branch from main
- fix provider verification guidance so docs use `task run --dry-run` for CLI smoke tests
- clarify GitHub Copilot `gh-copilot` extension expectations and keep `doctor` scoped to config/data-path health

## Verification
- go test ./...
- npm --prefix website run build