### PR TITLE
docs: backfill user reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Other useful flags:
 - `--category` — filter tasks by category (pr, analysis, options, safe, map, emergency)
 - `--cost` — filter by cost tier (low, medium, high, veryhigh)
 - `--prompt-only` — output just the raw prompt text for piping
-- `--provider` — required for `task run`, choose claude or codex
-- `--dry-run` — preview the prompt without executing
+- `--provider` — required for `task run`, choose claude, codex, or copilot
+- `--dry-run` — preview the prompt and generated plan text without executing the provider
 - `--timeout` — execution timeout (default 30m)
 
 ## Authentication (Subscriptions)
@@ -177,15 +177,22 @@ Supports signing in with ChatGPT or an API key.
 ### GitHub Copilot
 
 ```bash
-# Install Copilot CLI
+# Option 1: standalone Copilot CLI
 npm install -g @github/copilot
-# or
-curl -fsSL https://gh.io/copilot-install | bash
+
+# Option 2: GitHub CLI + Copilot extension
+gh extension install github/gh-copilot
 ```
 
-Requires GitHub Copilot subscription. See [docs/COPILOT_INTEGRATION.md](docs/COPILOT_INTEGRATION.md) for details.
+Nightshift auto-detects GitHub Copilot from either a standalone `copilot`
+binary or `gh` with the `gh-copilot` extension installed.
 
 If you prefer API-based usage, you can authenticate Claude and Codex CLIs with API keys instead.
+
+Use `nightshift doctor` after setup to verify that Nightshift can find the
+provider CLIs, config files, and local usage data. Use `nightshift task run
+<task> --provider <name> --dry-run` to preview the prompt Nightshift would
+send. Dry-run is a prompt/preflight check, not a provider-auth smoke test.
 
 ## Configuration
 
@@ -200,7 +207,12 @@ Nightshift uses YAML config files to define:
 
 Run `nightshift setup` to create/update the global config at `~/.config/nightshift/config.yaml`.
 
-See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) or [SPEC.md](docs/SPEC.md) for detailed options.
+You can also bootstrap config files directly with `nightshift init` in a repo
+or `nightshift init --global` for a global config, then inspect or adjust values
+with `nightshift config`, `nightshift config get`, `nightshift config set`, and
+`nightshift config validate`.
+
+See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) for detailed options.
 
 Minimal example:
 
@@ -220,6 +232,7 @@ providers:
   preference:
     - claude
     - codex
+    - copilot
   claude:
     enabled: true
     data_path: "~/.claude"
@@ -228,6 +241,10 @@ providers:
     enabled: true
     data_path: "~/.codex"
     dangerously_bypass_approvals_and_sandbox: true
+  copilot:
+    enabled: true
+    data_path: "~/.copilot"
+    dangerously_skip_permissions: true
 
 projects:
   - path: ~/code/sidecar

--- a/cmd/nightshift/commands/init.go
+++ b/cmd/nightshift/commands/init.go
@@ -146,6 +146,7 @@ providers:
   preference:
     - claude
     - codex
+    - copilot
   claude:
     enabled: true
     data_path: "~/.claude"       # Path to Claude Code data directory
@@ -154,6 +155,10 @@ providers:
     enabled: true
     data_path: "~/.codex"        # Path to Codex data directory
     dangerously_bypass_approvals_and_sandbox: true
+  copilot:
+    enabled: true
+    data_path: "~/.copilot"      # Path to GitHub Copilot data directory
+    dangerously_skip_permissions: true
 
 # Projects to manage
 # Add your project paths here
@@ -161,8 +166,8 @@ projects:
   # - path: ~/code/myproject
   #   priority: 1                # Higher = more important
   #   tasks:                     # Override enabled tasks
-  #     - lint
-  #     - docs
+  #     - lint-fix
+  #     - docs-backfill
   # - path: ~/code/library
   #   priority: 2
   #   config: .nightshift.yaml   # Per-project override file
@@ -170,15 +175,15 @@ projects:
 # Task configuration
 tasks:
   enabled:
-    - lint                       # Linter fixes
-    - docs                       # Documentation backfill
-    - security                   # Security scanning
-    - test-gaps                  # Test coverage gaps
+    - lint-fix                   # Linter fixes
+    - docs-backfill              # Documentation backfill
+    - security-footgun           # Security anti-pattern scan
+    - test-gap                   # Test coverage gaps
     - dead-code                  # Dead code removal
   priorities:
-    lint: 1
-    security: 2
-    docs: 3
+    lint-fix: 1
+    security-footgun: 2
+    docs-backfill: 3
   disabled: []                   # Explicitly disabled tasks
   # custom:                        # User-defined custom tasks
   #   - type: my-review
@@ -226,14 +231,14 @@ func generateProjectConfig() string {
 # Task configuration for this project
 tasks:
   enabled:
-    - lint                       # Linter fixes
-    - docs                       # Documentation backfill
-    - security                   # Security scanning
-    - test-gaps                  # Test coverage gaps
+    - lint-fix                   # Linter fixes
+    - docs-backfill              # Documentation backfill
+    - security-footgun           # Security anti-pattern scan
+    - test-gap                   # Test coverage gaps
   priorities:
-    lint: 1
-    security: 2
-    docs: 3
+    lint-fix: 1
+    security-footgun: 2
+    docs-backfill: 3
   disabled: []                   # Explicitly disabled tasks
   # custom:                        # User-defined custom tasks
   #   - type: my-review

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -5,88 +5,166 @@ title: CLI Reference
 
 # CLI Reference
 
-## Core Commands
+## Root Command
+
+```bash
+nightshift --help
+nightshift --version
+nightshift --verbose
+```
 
 | Command | Description |
 |---------|-------------|
 | `nightshift setup` | Guided global configuration |
-| `nightshift run` | Execute scheduled tasks |
-| `nightshift preview` | Show upcoming runs |
+| `nightshift init` | Write a starter config file |
+| `nightshift config` | Show, get, set, or validate config |
+| `nightshift run` | Execute tasks now |
+| `nightshift preview` | Show upcoming runs and prompts |
 | `nightshift budget` | Check token budget status |
 | `nightshift task` | Browse and run tasks |
 | `nightshift doctor` | Check environment health |
 | `nightshift status` | View run history |
 | `nightshift logs` | Stream or export logs |
-| `nightshift stats` | Token usage statistics |
-| `nightshift daemon` | Background scheduler |
+| `nightshift report` | Summarize recent runs |
+| `nightshift stats` | Show aggregate statistics |
+| `nightshift busfactor` | Analyze ownership concentration |
+| `nightshift daemon` | Manage the background scheduler |
+| `nightshift install` | Install a user service |
+| `nightshift uninstall` | Remove the user service |
+
+Global flags:
+
+| Flag | Description |
+|------|-------------|
+| `-h`, `--help` | Show help |
+| `-v`, `--version` | Show version |
+| `--verbose` | Enable verbose output |
+
+## Init and Config
+
+```bash
+nightshift init
+nightshift init --global
+nightshift init --force
+
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 15
+nightshift config set providers.copilot.enabled false --global
+nightshift config validate
+```
 
 ## Run Options
 
-`nightshift run` shows a preflight summary before executing, then prompts for confirmation in interactive terminals.
+`nightshift run` shows a preflight summary before executing, then prompts for
+confirmation in interactive terminals.
 
 ```bash
-nightshift run                          # Preflight + confirm + execute (1 project, 1 task)
+nightshift run                          # Preflight + confirm + execute
 nightshift run --yes                    # Skip confirmation
 nightshift run --dry-run                # Show preflight, don't execute
 nightshift run --max-projects 3         # Process up to 3 projects
 nightshift run --max-tasks 2            # Run up to 2 tasks per project
 nightshift run --random-task            # Pick a random eligible task
-nightshift run --ignore-budget          # Bypass budget limits (use with caution)
-nightshift run --project ~/code/myapp   # Target specific project (ignores --max-projects)
-nightshift run --task lint-fix          # Run specific task (ignores --max-tasks)
+nightshift run --ignore-budget          # Bypass budget limits
+nightshift run --project ~/code/myapp   # Target specific project
+nightshift run --task lint-fix          # Run a specific task
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--dry-run` | `false` | Show preflight summary and exit without executing |
-| `--yes`, `-y` | `false` | Skip confirmation prompt |
-| `--max-projects` | `1` | Max projects to process (ignored when `--project` is set) |
-| `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
-| `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
+| `--dry-run` | `false` | Show the preflight summary and exit without executing |
+| `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| `--max-projects` | `1` | Max projects to process |
+| `--max-tasks` | `1` | Max tasks per project |
+| `--random-task` | `false` | Choose a random eligible task |
 | `--ignore-budget` | `false` | Bypass budget checks with a warning |
 | `--project`, `-p` | | Target a specific project directory |
 | `--task`, `-t` | | Run a specific task by name |
 
-Non-interactive contexts (daemon, cron, piped output) skip the confirmation prompt automatically.
+Non-interactive contexts such as daemon runs, cron, or piped output skip the
+confirmation prompt automatically.
 
-## Preview Options
+## Preview Commands
 
 ```bash
-nightshift preview                # Default view
-nightshift preview -n 3           # Next 3 runs
-nightshift preview --long         # Detailed view
-nightshift preview --explain      # With prompt previews
-nightshift preview --plain        # No pager
-nightshift preview --json         # JSON output
-nightshift preview --write ./dir  # Write prompts to files
+nightshift preview
+nightshift preview -n 3
+nightshift preview --long
+nightshift preview --explain
+nightshift preview --plain
+nightshift preview --json
+nightshift preview --write ./nightshift-prompts
 ```
 
 ## Task Commands
 
 ```bash
-nightshift task list              # All tasks
+nightshift task list
 nightshift task list --category pr
 nightshift task list --cost low --json
 nightshift task show lint-fix
 nightshift task show lint-fix --prompt-only
 nightshift task run lint-fix --provider claude
 nightshift task run lint-fix --provider codex --dry-run
+nightshift task run docs-backfill --provider copilot --branch main
 ```
+
+Task-run flags:
+
+| Flag | Description |
+|------|-------------|
+| `--provider` | Required provider: `claude`, `codex`, or `copilot` |
+| `-p`, `--project` | Project directory to run in |
+| `--dry-run` | Print the generated prompt without executing |
+| `--timeout` | Execution timeout (default `30m`) |
+| `-b`, `--branch` | Base branch for new feature branches |
 
 ## Budget Commands
 
 ```bash
-nightshift budget                 # Current status
+nightshift budget
 nightshift budget --provider claude
 nightshift budget snapshot --local-only
 nightshift budget history -n 10
 nightshift budget calibrate
 ```
 
-## Global Flags
+## Logs, Reports, and Stats
 
-| Flag | Description |
-|------|-------------|
-| `--verbose` | Verbose output |
-| `--provider` | Select provider (claude, codex) |
-| `--timeout` | Execution timeout (default 30m) |
+```bash
+nightshift logs --tail 100
+nightshift logs --follow --component daemon
+nightshift logs --since 2026-04-01 --level warn
+
+nightshift report --period last-7d --report tasks
+nightshift report --format markdown --paths
+
+nightshift stats
+nightshift stats --period last-30d --json
+```
+
+## Daemon and Service Commands
+
+```bash
+nightshift daemon start
+nightshift daemon start --foreground
+nightshift daemon start --timeout 45m
+nightshift daemon status
+nightshift daemon stop
+
+nightshift install launchd
+nightshift install systemd
+nightshift install cron
+nightshift uninstall
+```
+
+## Bus Factor
+
+```bash
+nightshift busfactor
+nightshift busfactor --path ~/code/nightshift
+nightshift busfactor --file internal/config/config.go
+nightshift busfactor --since 2025-01-01 --json
+nightshift busfactor --save
+```

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -5,12 +5,30 @@ title: Configuration
 
 # Configuration
 
-Nightshift uses YAML config files. Run `nightshift setup` for an interactive setup, or edit directly.
+Nightshift merges configuration from three layers:
 
-## Config Location
+1. Global config at `~/.config/nightshift/config.yaml`
+2. Project config at `nightshift.yaml` in the repo root
+3. Environment variable overrides
 
-- **Global:** `~/.config/nightshift/config.yaml`
-- **Per-project:** `nightshift.yaml` or `.nightshift.yaml` in the repo root
+Use `nightshift setup` for the guided flow, or `nightshift init` when you want a
+starter file you can edit directly.
+
+## Bootstrap and Inspect
+
+```bash
+nightshift init
+nightshift init --global
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 15
+nightshift config set providers.copilot.enabled false --global
+nightshift config validate
+```
+
+`nightshift config set` writes to the project config if one exists in the
+current repo; otherwise it writes to the global config. Use `--global` to force
+the write target.
 
 ## Minimal Config
 
@@ -30,6 +48,7 @@ providers:
   preference:
     - claude
     - codex
+    - copilot
   claude:
     enabled: true
     data_path: "~/.claude"
@@ -38,6 +57,10 @@ providers:
     enabled: true
     data_path: "~/.codex"
     dangerously_bypass_approvals_and_sandbox: true
+  copilot:
+    enabled: true
+    data_path: "~/.copilot"
+    dangerously_skip_permissions: true
 
 projects:
   - path: ~/code/sidecar
@@ -46,29 +69,57 @@ projects:
 
 ## Schedule
 
-Use cron syntax or interval-based scheduling:
+Use cron syntax or interval scheduling:
 
 ```yaml
 schedule:
-  cron: "0 2 * * *"        # Every night at 2am
-  # interval: "8h"         # Or run every 8 hours
+  cron: "0 2 * * *"
+  # interval: "8h"
+  max_projects: 1
+  max_tasks: 1
+  # window:
+  #   start: "22:00"
+  #   end: "06:00"
+  #   timezone: "America/Los_Angeles"
 ```
 
 ## Budget
 
-Control how much of your token budget Nightshift uses:
-
 | Field | Default | Description |
 |-------|---------|-------------|
 | `mode` | `daily` | `daily` or `weekly` |
-| `max_percent` | `75` | Max budget % to use per run |
-| `reserve_percent` | `5` | Always keep this % available |
+| `max_percent` | `75` | Max budget percent to use per run |
+| `reserve_percent` | `5` | Budget to keep in reserve |
+| `weekly_tokens` | `700000` | Fallback weekly budget |
 | `billing_mode` | `subscription` | `subscription` or `api` |
-| `calibrate_enabled` | `true` | Auto-calibrate from local CLI data |
+| `calibrate_enabled` | `true` | Auto-calibrate from local CLI usage data |
+| `snapshot_interval` | `30m` | Snapshot frequency |
+| `snapshot_retention_days` | `90` | Snapshot retention window |
+| `week_start_day` | `monday` | `monday` or `sunday` |
+| `db_path` | platform default | Override Nightshift database path |
+
+## Providers
+
+Nightshift supports Claude Code, Codex, and GitHub Copilot. The
+`providers.preference` list controls fallback order during previews and runs.
+
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+    - copilot
+```
+
+Provider-specific notes:
+
+- `providers.claude.dangerously_skip_permissions` skips Claude permission prompts.
+- `providers.codex.dangerously_bypass_approvals_and_sandbox` controls Codex's
+  headless execution flag.
+- `providers.copilot.dangerously_skip_permissions` enables Copilot's
+  `--allow-all-tools` and `--allow-all-urls` flags.
 
 ## Task Selection
-
-Enable/disable tasks and set priorities:
 
 ```yaml
 tasks:
@@ -84,34 +135,44 @@ tasks:
     docs-backfill: "168h"
 ```
 
-Each task has a default cooldown interval to prevent the same task from running too frequently on a project.
+Each task has a default cooldown interval per project. Override that with
+`tasks.intervals`.
+
+`skill-groom` is enabled by default even if you do not list it in
+`tasks.enabled`. Add it to `tasks.disabled` if you want to opt out.
 
 ## Multi-Project Setup
 
 ```yaml
 projects:
   - path: ~/code/project1
-    priority: 1                # Higher priority = processed first
+    priority: 1
     tasks:
-      - lint
-      - docs
+      - lint-fix
+      - docs-backfill
   - path: ~/code/project2
     priority: 2
 
-  # Or use glob patterns
   - pattern: ~/code/oss/*
     exclude:
       - ~/code/oss/archived
 ```
 
-## Safe Defaults
+## Integrations
 
-| Feature | Default | Override |
-|---------|---------|----------|
-| Read-only first run | Yes | `--enable-writes` |
-| Max budget per run | 75% | `budget.max_percent` |
-| Auto-push to remote | No | Manual only |
-| Reserve budget | 5% | `budget.reserve_percent` |
+Use integrations to pull in repo instructions and external task sources:
+
+```yaml
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
+    - github_issues: true
+    - file: TODO.md
+```
 
 ## File Locations
 
@@ -123,8 +184,5 @@ projects:
 | Database | `~/.local/share/nightshift/nightshift.db` |
 | PID file | `~/.local/share/nightshift/nightshift.pid` |
 
-If `state/state.json` exists from older versions, Nightshift migrates it to the SQLite database and renames the file to `state.json.migrated`.
-
-## Providers
-
-Nightshift supports Claude Code and Codex as execution providers. It will use whichever has budget remaining, in the order specified by `preference`.
+If `state/state.json` exists from older versions, Nightshift migrates it to the
+SQLite database and renames the file to `state.json.migrated`.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -37,18 +37,65 @@ sudo mv nightshift /usr/local/bin/
 ```bash
 nightshift --version
 nightshift --help
+nightshift doctor
 ```
 
-## Prerequisites
+`nightshift doctor` checks config loading, scheduling, provider data paths, and
+whether Nightshift can discover the local CLIs it depends on.
 
-- **Claude Code CLI** (`claude`) and/or **Codex CLI** (`codex`) installed
-- Authenticated via subscription login or API keys:
+## Provider CLIs
+
+Nightshift supports three local providers:
+
+- `claude`
+- `codex`
+- `copilot`, or `gh` with the `gh-copilot` extension installed
+
+Install and authenticate at least one provider before running Nightshift.
+
+### Claude Code
 
 ```bash
-# Claude Code
 claude
 /login
+```
 
-# Codex
+Claude Code can use either a Claude subscription login or Anthropic API
+credentials.
+
+### Codex
+
+```bash
 codex --login
 ```
+
+Codex can use a ChatGPT login or API key.
+
+### GitHub Copilot
+
+```bash
+# Standalone Copilot CLI
+npm install -g @github/copilot
+
+# Or GitHub CLI + Copilot extension
+gh extension install github/gh-copilot
+```
+
+Nightshift prefers a standalone `copilot` binary when it exists in `PATH`, then
+falls back to `gh` if the `gh-copilot` extension is installed.
+
+## Verify Provider Discovery
+
+Use `nightshift doctor` to confirm Nightshift can see your configured provider
+CLIs and data paths.
+
+If you want to inspect the prompt Nightshift would generate for a task without
+executing it, use a dry run:
+
+```bash
+nightshift task run lint-fix --provider claude --dry-run
+```
+
+Dry-run validates task lookup, config loading, provider selection, and prompt
+generation. It does not execute the provider CLI, so it does not confirm auth or
+remote account access.

--- a/website/docs/integrations.md
+++ b/website/docs/integrations.md
@@ -5,52 +5,76 @@ title: Integrations
 
 # Integrations
 
-Nightshift integrates with your existing development workflow.
+Nightshift plugs into the tools you already use: local coding-agent CLIs,
+repository instruction files, and optional task sources.
 
-## Claude Code
+## Provider CLIs
 
-Nightshift uses the Claude Code CLI to execute tasks. Authenticate via subscription or API key:
+Nightshift executes tasks through one of three local provider CLIs:
 
-```bash
-claude
-/login
+- Claude Code via `claude`
+- Codex via `codex`
+- GitHub Copilot via standalone `copilot`, or `gh` with `gh-copilot`
+
+Set the preferred order in config:
+
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+    - copilot
 ```
 
-## Codex
+Use `nightshift doctor` to verify Nightshift can discover those CLIs and their
+usage data paths.
 
-Nightshift supports OpenAI's Codex CLI as an alternative provider:
+## Git Workflow
 
-```bash
-codex --login
-```
+Nightshift works in normal Git repositories and produces branches or PR-ready
+changes instead of writing directly to your primary branch.
 
-## GitHub
+## td Task Sourcing
 
-All output is PR-based. Nightshift creates branches and pull requests for its findings.
-
-## td (Task Management)
-
-Nightshift can source tasks from [td](https://td.haplab.com) — task management for AI-assisted development. Tasks tagged with `nightshift` in td will be picked up automatically.
+Nightshift can source work from [td](https://td.haplab.com):
 
 ```yaml
 integrations:
   task_sources:
     - td:
         enabled: true
-        teach_agent: true   # Include td usage + core workflow in prompts
+        teach_agent: true
 ```
 
-## CLAUDE.md / AGENTS.md
+When `teach_agent` is enabled, td workflow instructions are included in the
+generated agent prompt.
 
-Nightshift reads project-level instruction files to understand context when executing tasks. Place a `CLAUDE.md` or `AGENTS.md` in your repo root to give Nightshift project-specific guidance. Tasks mentioned in these files get a priority bonus (+2).
+## Instruction Files
 
-## GitHub Issues
+Nightshift reads project instruction files and folds them into agent context.
+Supported filenames:
 
-Source tasks from GitHub issues labeled with `nightshift`:
+- `CLAUDE.md`, `claude.md`, `.claude.md`
+- `AGENTS.md`, `agents.md`, `.agents.md`
+
+Enable or disable those readers in config:
 
 ```yaml
 integrations:
-  github_issues:
-    enabled: true
-    label: "nightshift"
+  claude_md: true
+  agents_md: true
+```
+
+Tasks mentioned in those files receive a priority bonus during task selection.
+
+## Other Task Sources
+
+Nightshift also supports GitHub issue and file-based task sources through the
+same `integrations.task_sources` list:
+
+```yaml
+integrations:
+  task_sources:
+    - github_issues: true
+    - file: TODO.md
 ```

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -8,7 +8,7 @@ title: Introduction
 
 > It finds what you forgot to look for.
 
-Nightshift is a Go CLI tool that runs AI-powered maintenance tasks on your codebase overnight, using your remaining daily token budget from Claude Code or Codex subscriptions. Wake up to a cleaner codebase without unexpected costs.
+Nightshift is a Go CLI tool that runs AI-powered maintenance tasks on your codebase overnight, using your remaining daily token budget from Claude Code, Codex, or GitHub Copilot. Wake up to a cleaner codebase without unexpected costs.
 
 Your tokens get reset every week — you might as well use them. Nightshift runs overnight to find dead code, doc drift, test gaps, security issues, and 20+ other things silently accumulating while you ship features.
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -33,8 +33,9 @@ nightshift init --global  # Create global config
 - Set `budget.week_start_day` to `monday` or `sunday`
 
 **"Provider not available"**
-- Ensure Claude/Codex CLI is installed and in PATH
-- Check API key environment variables are set
+- Run `nightshift doctor` to check CLI discovery and provider data paths
+- Ensure `claude`, `codex`, or `copilot`/`gh` is installed and in PATH
+- Remember that `nightshift task run ... --dry-run` previews prompts only; it does not test provider auth
 
 ## Debug Mode
 


### PR DESCRIPTION
## Summary
- refresh README and Docusaurus reference pages to match the shipped CLI surface, including config/init/install/logs/report/stats/busfactor/daemon coverage
- document real provider support and discovery for Claude, Codex, and GitHub Copilot, and clarify that dry-run previews prompts without testing provider auth
- update `nightshift init` starter templates to use current built-in task IDs and include Copilot in provider preference/examples

## Verification
- go test ./...
- npm --prefix website run build