### PR TITLE
feat: improve release-notes task guidance

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -711,11 +711,39 @@ func (o *Orchestrator) PlanPrompt(task *tasks.Task) string {
 	return o.buildPlanPrompt(task)
 }
 
+func taskSpecificPlanGuidance(task *tasks.Task) string {
+	switch task.Type {
+	case tasks.TaskReleaseNotes:
+		return "\n\n## Task-Specific Guidance\n" +
+			"- Inspect the repo's existing release signals before deciding the scope: CHANGELOG.md, .github/workflows/release.yml, and recent git tags/commits.\n" +
+			"- Use recent tags and commits to infer the release boundary. If the boundary is unclear, state the assumptions you made.\n" +
+			"- Prefer updating the current release-notes artifact and format instead of inventing a new template.\n" +
+			"- Plan for release notes with clear sections such as Features, Fixes, Breaking Changes, and Other. Omit empty sections when appropriate.\n"
+	default:
+		return ""
+	}
+}
+
+func taskSpecificImplementGuidance(task *tasks.Task) string {
+	switch task.Type {
+	case tasks.TaskReleaseNotes:
+		return "\n\n## Task-Specific Guidance\n" +
+			"- Inspect the repo's existing release signals before drafting: CHANGELOG.md, .github/workflows/release.yml, and recent git tags/commits.\n" +
+			"- Use recent tags and commits to infer the release boundary. If the boundary is unclear, state the assumptions you made.\n" +
+			"- Prefer updating the current release-notes artifact and format instead of inventing a new template.\n" +
+			"- Organize the draft into clear sections such as Features, Fixes, Breaking Changes, and Other. Omit empty sections when appropriate.\n"
+	default:
+		return ""
+	}
+}
+
 func (o *Orchestrator) buildPlanPrompt(task *tasks.Task) string {
 	branchInstruction := ""
 	if o.runMeta != nil && o.runMeta.Branch != "" {
 		branchInstruction = fmt.Sprintf("\n   Create your feature branch from `%s`.", o.runMeta.Branch)
 	}
+
+	taskGuidance := taskSpecificPlanGuidance(task)
 
 	return fmt.Sprintf(`You are a planning agent. Create a detailed execution plan for this task.
 
@@ -733,7 +761,7 @@ Description: %s
    Nightshift-Ref: https://github.com/marcus/nightshift
 4. Analyze the task requirements
 5. Identify files that need to be modified
-6. Create step-by-step implementation plan
+6. Create step-by-step implementation plan%s
 7. Output only valid JSON (no markdown, no extra text). The output is read by a machine. Use this schema:
 
 {
@@ -741,7 +769,7 @@ Description: %s
   "files": ["file1.go", "file2.go", ...],
   "description": "overall approach"
 }
-`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, branchInstruction, task.Type, taskGuidance)
 }
 
 func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, iteration int) string {
@@ -754,6 +782,8 @@ func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, 
 	if o.runMeta != nil && o.runMeta.Branch != "" {
 		branchInstruction = fmt.Sprintf("\n   Checkout `%s` before creating your feature branch.", o.runMeta.Branch)
 	}
+
+	taskGuidance := taskSpecificImplementGuidance(task)
 
 	return fmt.Sprintf(`You are an implementation agent. Execute the plan for this task.
 
@@ -776,14 +806,14 @@ Description: %s
    Nightshift-Ref: https://github.com/marcus/nightshift
 2. Implement the plan step by step
 3. Make all necessary code changes
-4. Ensure tests pass
+4. Ensure tests pass%s
 5. Output a summary as JSON:
 
 {
   "files_modified": ["file1.go", ...],
   "summary": "what was done"
 }
-`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type, taskGuidance)
 }
 
 func (o *Orchestrator) buildReviewPrompt(task *tasks.Task, impl *ImplementOutput) string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -809,6 +809,103 @@ func TestBuildImplementPrompt_WithoutBranch(t *testing.T) {
 	}
 }
 
+func TestBuildPlanPrompt_ReleaseNotesIncludesRepoAwareGuidance(t *testing.T) {
+	o := New()
+
+	task := &tasks.Task{
+		ID:          "release-notes:/tmp/nightshift",
+		Title:       "Release Note Drafter",
+		Description: "Draft release-ready notes for the next version",
+		Type:        tasks.TaskReleaseNotes,
+	}
+
+	prompt := o.buildPlanPrompt(task)
+
+	expected := []string{
+		"CHANGELOG.md",
+		".github/workflows/release.yml",
+		"recent git tags/commits",
+		"release boundary",
+		"current release-notes artifact and format",
+		"Features, Fixes, Breaking Changes, and Other",
+		"state the assumptions",
+	}
+
+	for _, want := range expected {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("plan prompt missing %q\nGot:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestBuildImplementPrompt_ReleaseNotesIncludesRepoAwareGuidance(t *testing.T) {
+	o := New()
+
+	task := &tasks.Task{
+		ID:          "release-notes:/tmp/nightshift",
+		Title:       "Release Note Drafter",
+		Description: "Draft release-ready notes for the next version",
+		Type:        tasks.TaskReleaseNotes,
+	}
+	plan := &PlanOutput{
+		Steps:       []string{"Inspect release artifacts", "Draft the notes"},
+		Description: "Use the repo's release signals to draft notes for the next release.",
+	}
+
+	prompt := o.buildImplementPrompt(task, plan, 1)
+
+	expected := []string{
+		"CHANGELOG.md",
+		".github/workflows/release.yml",
+		"recent git tags/commits",
+		"release boundary",
+		"current release-notes artifact and format",
+		"Features, Fixes, Breaking Changes, and Other",
+		"state the assumptions",
+	}
+
+	for _, want := range expected {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("implement prompt missing %q\nGot:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestBuildPrompts_GenericTasksDoNotReceiveReleaseNotesGuidance(t *testing.T) {
+	o := New()
+
+	task := &tasks.Task{
+		ID:          "lint-fix:/tmp/nightshift",
+		Title:       "Linter Fixes",
+		Description: "Automatically fix linting errors and style issues",
+		Type:        tasks.TaskLintFix,
+	}
+	plan := &PlanOutput{
+		Steps:       []string{"Run linters", "Fix issues"},
+		Description: "Apply lint fixes.",
+	}
+
+	planPrompt := o.buildPlanPrompt(task)
+	implPrompt := o.buildImplementPrompt(task, plan, 1)
+
+	unexpected := []string{
+		"CHANGELOG.md",
+		".github/workflows/release.yml",
+		"release boundary",
+		"current release-notes artifact and format",
+		"Features, Fixes, Breaking Changes, and Other",
+	}
+
+	for _, notWant := range unexpected {
+		if strings.Contains(planPrompt, notWant) {
+			t.Errorf("generic plan prompt should not contain %q\nGot:\n%s", notWant, planPrompt)
+		}
+		if strings.Contains(implPrompt, notWant) {
+			t.Errorf("generic implement prompt should not contain %q\nGot:\n%s", notWant, implPrompt)
+		}
+	}
+}
+
 func TestBuildMetadataBlock_WithBranch(t *testing.T) {
 	o := New()
 	o.SetRunMetadata(&RunMetadata{

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -350,7 +350,7 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		Type:            TaskReleaseNotes,
 		Category:        CategoryPR,
 		Name:            "Release Note Drafter",
-		Description:     "Draft release notes from changes",
+		Description:     "Draft release-ready notes for the next version",
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 168 * time.Hour,

--- a/website/docs/task-reference.md
+++ b/website/docs/task-reference.md
@@ -25,7 +25,7 @@ Fully formed, review-ready artifacts. These tasks create branches and open pull 
 | `docs-backfill` | Documentation Backfiller | Generate missing documentation | Low | Low | 7d |
 | `commit-normalize` | Commit Message Normalizer | Standardize commit message format | Low | Low | 24h |
 | `changelog-synth` | Changelog Synthesizer | Generate changelog from commits | Low | Low | 7d |
-| `release-notes` | Release Note Drafter | Draft release notes from changes | Low | Low | 7d |
+| `release-notes` | Release Note Drafter | Draft release-ready notes for the next version | Low | Low | 7d |
 | `adr-draft` | ADR Drafter | Draft Architecture Decision Records | Medium | Low | 7d |
 | `td-review` | TD Review Session | Review open td reviews, fix obvious bugs, create tasks for bigger issues | High | Medium | 72h |
 


### PR DESCRIPTION
## Summary
- add release-notes-specific prompt guidance so planning and implementation agents inspect Nightshift release artifacts and recent tags/commits
- distinguish the built-in release-notes task description from changelog-synth and sync the published task reference
- add prompt-builder tests to verify release-notes guidance is injected without changing generic task prompts

## Verification
- go test ./internal/orchestrator ./internal/tasks ./cmd/nightshift/commands
- go run ./cmd/nightshift task show release-notes --project /Users/marcus/code/nightshift --prompt-only


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/marcus/code/nightshift
task-type: release-notes
task-title: Release Note Drafter
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 9m47s
run-started: 2026-04-06T03:53:13-07:00
nightshift:metadata -->
