### PR TITLE
docs: backfill memory and heartbeat documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Your tokens get reset every week, you might as well use them. Nightshift runs ov
 
 Everything lands as a branch or PR. It never writes directly to your primary branch. Don't like something? Close it. That's the whole rollback plan.
 
+## Implementation Agent Startup
+
+Use this order when working in this repository as an implementation agent:
+
+1. Read [AGENTS.md](AGENTS.md) for mandatory workflow and safety rules.
+2. Read [docs/WORKSPACE_WORKFLOW.md](docs/WORKSPACE_WORKFLOW.md) for first-run and per-session flow.
+3. Read [docs/MEMORY_HEARTBEAT_REFERENCE.md](docs/MEMORY_HEARTBEAT_REFERENCE.md) before touching memory or heartbeat artifacts.
+4. If `BOOTSTRAP.md` exists, treat it as a lifecycle marker that onboarding is still in progress.
+
+## Documentation Map
+
+- [docs/WORKSPACE_WORKFLOW.md](docs/WORKSPACE_WORKFLOW.md): first-run and every-session workflow.
+- [docs/FILE_REFERENCE.md](docs/FILE_REFERENCE.md): concise reference for root files and ownership expectations.
+- [docs/MEMORY_HEARTBEAT_REFERENCE.md](docs/MEMORY_HEARTBEAT_REFERENCE.md): lifecycle, cadence, and safe-usage boundaries for `memory/` artifacts.
+
 ## Features
 
 - **Budget-aware**: Uses remaining daily allotment, never exceeds configurable max (default 75%)

--- a/docs/FILE_REFERENCE.md
+++ b/docs/FILE_REFERENCE.md
@@ -1,0 +1,50 @@
+# File Reference
+
+Quick reference for important root files and memory artifacts in this repository.
+
+## Root Files
+
+- `AGENTS.md`
+Purpose: primary operating contract for task selection, workflow, and safety boundaries.
+Ownership/edit expectations: keep current with workflow changes.
+Used when: at the start of every implementation session.
+
+- `README.md`
+Purpose: project overview, command usage, and documentation navigation.
+Ownership/edit expectations: keep user-facing usage and internal doc links accurate.
+Used when: onboarding to repository behavior and CLI flows.
+
+- `CODEX.md`
+Purpose: Codex-specific project notes.
+Ownership/edit expectations: maintain concise, project-local guidance.
+Used when: Codex runs need repository-specific constraints.
+
+- `BOOTSTRAP.md` (if present)
+Purpose: first-run onboarding marker.
+Ownership/edit expectations: temporary lifecycle signal; remove once onboarding is complete.
+Used when: setting up a brand-new workspace context.
+
+## Memory Files
+
+For lifecycle and safety details, see [MEMORY_HEARTBEAT_REFERENCE.md](./MEMORY_HEARTBEAT_REFERENCE.md).
+
+- `memory/YYYY-MM-DD.md`
+Purpose: raw daily chronology of decisions and events.
+Ownership/edit expectations: append-oriented daily notes.
+Used when: loading recent context at session start.
+
+- `MEMORY.md`
+Purpose: curated long-term memory distilled from daily notes.
+Ownership/edit expectations: maintain high-signal durable context.
+Used when: main-session continuity and preference recall.
+
+- `memory/heartbeat-state.json`
+Purpose: machine-readable heartbeat check recency state (timestamps/status flags).
+Ownership/edit expectations: assistant-maintained operational metadata; keep compact.
+Used when: heartbeat polls decide whether checks are due and avoid duplicate checks.
+
+## Additional Docs
+
+- [WORKSPACE_WORKFLOW.md](./WORKSPACE_WORKFLOW.md): first-run and recurring session workflow.
+- [FILE_REFERENCE.md](./FILE_REFERENCE.md): this ownership and usage reference.
+- [MEMORY_HEARTBEAT_REFERENCE.md](./MEMORY_HEARTBEAT_REFERENCE.md): memory/heartbeat lifecycle and safety boundaries.

--- a/docs/MEMORY_HEARTBEAT_REFERENCE.md
+++ b/docs/MEMORY_HEARTBEAT_REFERENCE.md
@@ -1,0 +1,87 @@
+# Memory and Heartbeat Artifact Reference
+
+This guide defines purpose, ownership, cadence, and safety boundaries for repository-local memory artifacts.
+
+Related docs:
+
+- [WORKSPACE_WORKFLOW.md](./WORKSPACE_WORKFLOW.md)
+- [FILE_REFERENCE.md](./FILE_REFERENCE.md)
+- [../AGENTS.md](../AGENTS.md)
+
+## Artifact Definitions
+
+### `memory/YYYY-MM-DD.md`
+
+Purpose:
+- Raw daily chronology of decisions, outcomes, and relevant context.
+
+Ownership and update expectations:
+- Assistant-maintained during normal execution.
+- Append as meaningful events happen.
+- Keep entries concise and factual.
+
+Usage cadence:
+- Read today and yesterday at session start.
+- Distill durable information into `MEMORY.md`.
+
+Safe-usage boundaries:
+- Do not use as a policy file.
+- Do not store secrets or credentials.
+- Keep as high-signal notes, not chat transcripts.
+
+### `MEMORY.md`
+
+Purpose:
+- Curated long-term memory distilled from daily notes.
+
+Ownership and update expectations:
+- Shared human/assistant artifact.
+- Update only when durable preferences, decisions, or lessons emerge.
+- Remove stale or superseded items.
+
+Usage cadence:
+- Read in direct main-session workflows.
+- Refresh periodically from recent daily notes.
+
+Safe-usage boundaries:
+- Do not load in shared/group contexts unless explicitly required.
+- Keep stable and concise.
+- Avoid mirroring sensitive private data across contexts.
+
+### `memory/heartbeat-state.json`
+
+Purpose:
+- Minimal machine-readable heartbeat recency state (for example, last check timestamps).
+
+Ownership and update expectations:
+- Assistant-maintained operational metadata.
+- Update timestamps after heartbeat checks complete.
+- Keep schema compact and stable.
+
+Usage cadence:
+- Read before heartbeat checks decide what is due.
+- Write only when state changes.
+
+Safe-usage boundaries:
+- Store timestamps/status flags only.
+- Never store tokens, credentials, message bodies, or private conversation text.
+- Treat as operational metadata, not user-facing narrative.
+
+Minimal example:
+
+```json
+{
+  "lastChecks": {
+    "email": 1703275200,
+    "calendar": 1703260800,
+    "weather": null
+  }
+}
+```
+
+## Lifecycle Notes
+
+- `memory/` can be created lazily when first needed.
+- Daily notes are high-frequency and append-oriented.
+- `MEMORY.md` is low-frequency and curated.
+- `memory/heartbeat-state.json` should remain compact operational state.

--- a/docs/WORKSPACE_WORKFLOW.md
+++ b/docs/WORKSPACE_WORKFLOW.md
@@ -1,0 +1,50 @@
+# Workspace Workflow
+
+This guide defines the minimal operating workflow for this repository workspace.
+
+For memory and heartbeat boundaries, see [MEMORY_HEARTBEAT_REFERENCE.md](./MEMORY_HEARTBEAT_REFERENCE.md).
+
+## First Run (Bootstrap)
+
+Use this flow when the workspace is brand new:
+
+1. Read [AGENTS.md](../AGENTS.md).
+2. Review [README.md](../README.md) for repository context.
+3. If `BOOTSTRAP.md` exists, complete onboarding guidance there.
+4. Remove `BOOTSTRAP.md` when onboarding is complete.
+
+## Every Session
+
+Start each session with this order:
+
+1. Read [AGENTS.md](../AGENTS.md) for operating and safety rules.
+2. Read [README.md](../README.md) for current docs map and run context.
+3. Read `memory/YYYY-MM-DD.md` for today and yesterday when present.
+4. In direct main sessions, also read `MEMORY.md` when present.
+
+## Memory Lifecycle
+
+Use three context layers:
+
+- Daily notes: `memory/YYYY-MM-DD.md`
+- Curated long-term memory: `MEMORY.md`
+- Heartbeat operational state: `memory/heartbeat-state.json`
+
+Lifecycle pattern:
+
+1. Capture decisions and outcomes in daily notes as they happen.
+2. For heartbeat polls, read `memory/heartbeat-state.json` before checks and update it after state changes.
+3. Periodically distill durable lessons into `MEMORY.md`.
+4. Keep `MEMORY.md` concise by removing stale items.
+
+## Safety Boundaries
+
+Default behavior:
+
+- Local read/analysis actions can proceed without extra approval.
+- External side effects require explicit user approval.
+- Avoid destructive commands unless explicitly requested.
+
+## Operating Principle
+
+Write durable context to files quickly. Session memory is transient; workspace files are persistent.


### PR DESCRIPTION
## Assumptions
- The task scope is intentionally broad, so this PR focuses on high-value repository-local documentation gaps around memory and heartbeat artifacts.
- Existing README links to `docs/COPILOT_INTEGRATION.md` and `docs/SPEC.md` are pre-existing and outside this task.

## Scope
- Added `docs/MEMORY_HEARTBEAT_REFERENCE.md` to document purpose, ownership, cadence, and safe-usage boundaries for:
  - `memory/YYYY-MM-DD.md`
  - `MEMORY.md`
  - `memory/heartbeat-state.json`
- Added `docs/FILE_REFERENCE.md` with root-file coverage and explicit `memory/heartbeat-state.json` guidance plus cross-links.
- Added `docs/WORKSPACE_WORKFLOW.md` with aligned first-run/session workflow and memory lifecycle guidance.
- Updated `README.md` with implementation-agent startup guidance, documentation map links, and bootstrap lifecycle visibility notes.

## Validation
- `go test ./...` passed.
- Performed manual consistency pass across `AGENTS.md`, `README.md`, and `docs/*` for memory/heartbeat workflow alignment.
- Verified all newly added local links resolve.


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/
task-type: docs-backfill
task-title: Documentation Backfiller
provider: codex
score: 3.0
cost-tier: Low (10-50k)
iterations: 3
duration: 35m58s
run-started: 2026-04-07T02:00:04+05:30
nightshift:metadata -->
