### PR TITLE
Add backward-compatibility tests for tasks, state, and orchestrator

### DIFF
--- a/internal/orchestrator/backward_compat_test.go
+++ b/internal/orchestrator/backward_compat_test.go
@@ -1,0 +1,228 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestBackwardCompat_TaskStatusConstants verifies that TaskStatus string
+// values haven't changed. These are stored in databases and used in CLI
+// output and reporting.
+func TestBackwardCompat_TaskStatusConstants(t *testing.T) {
+	expected := map[TaskStatus]string{
+		StatusPending:   "pending",
+		StatusPlanning:  "planning",
+		StatusExecuting: "executing",
+		StatusReviewing: "reviewing",
+		StatusCompleted: "completed",
+		StatusFailed:    "failed",
+		StatusAbandoned: "abandoned",
+	}
+
+	for status, wantStr := range expected {
+		if string(status) != wantStr {
+			t.Errorf("TaskStatus constant changed: got %q, want %q", string(status), wantStr)
+		}
+	}
+}
+
+// TestBackwardCompat_TaskResultJSONFields verifies that TaskResult JSON
+// field names haven't changed. External tools parsing nightshift output
+// depend on these field names.
+func TestBackwardCompat_TaskResultJSONFields(t *testing.T) {
+	result := TaskResult{
+		TaskID:     "test-task-1",
+		Status:     StatusCompleted,
+		Iterations: 2,
+		Plan: &PlanOutput{
+			Steps:       []string{"step 1", "step 2"},
+			Files:       []string{"file1.go"},
+			Description: "test plan",
+		},
+		Output:     "task output",
+		OutputType: "PR",
+		OutputRef:  "https://github.com/example/repo/pull/1",
+		Error:      "",
+		Duration:   5 * time.Minute,
+		Logs: []LogEntry{
+			{Time: time.Now(), Level: "info", Message: "started"},
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{
+		"task_id", "status", "iterations", "duration", "logs",
+	}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("TaskResult JSON missing required field %q", field)
+		}
+	}
+
+	// Optional fields with omitempty should be present when set
+	optionalPresent := []string{"plan", "output", "output_type", "output_ref"}
+	for _, field := range optionalPresent {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("TaskResult JSON missing optional field %q (should be present when set)", field)
+		}
+	}
+}
+
+// TestBackwardCompat_PlanOutputJSONFields verifies PlanOutput JSON structure.
+func TestBackwardCompat_PlanOutputJSONFields(t *testing.T) {
+	plan := PlanOutput{
+		Steps:       []string{"analyze", "implement", "test"},
+		Files:       []string{"main.go", "main_test.go"},
+		Description: "Fix the bug",
+		Raw:         "raw plan text",
+	}
+
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"steps", "files", "description"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("PlanOutput JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_ReviewOutputJSONFields verifies ReviewOutput JSON structure.
+func TestBackwardCompat_ReviewOutputJSONFields(t *testing.T) {
+	review := ReviewOutput{
+		Passed:   true,
+		Feedback: "looks good",
+		Issues:   []string{"minor: consider renaming"},
+		Raw:      "raw review",
+	}
+
+	data, err := json.Marshal(review)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"passed", "feedback"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("ReviewOutput JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_ImplementOutputJSONFields verifies ImplementOutput JSON structure.
+func TestBackwardCompat_ImplementOutputJSONFields(t *testing.T) {
+	impl := ImplementOutput{
+		FilesModified: []string{"main.go", "handler.go"},
+		Summary:       "Fixed the auth bug",
+		Raw:           "raw output",
+	}
+
+	data, err := json.Marshal(impl)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"files_modified", "summary"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("ImplementOutput JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_LogEntryJSONFields verifies LogEntry JSON structure.
+func TestBackwardCompat_LogEntryJSONFields(t *testing.T) {
+	entry := LogEntry{
+		Time:    time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+		Level:   "info",
+		Message: "task started",
+		Fields:  map[string]any{"task_id": "test-1"},
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"time", "level", "message"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("LogEntry JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_TaskResultDeserialization verifies that JSON from
+// an earlier version (without output_type/output_ref) still deserializes.
+func TestBackwardCompat_TaskResultDeserialization(t *testing.T) {
+	// Simulate older format without output_type and output_ref
+	oldJSON := `{
+		"task_id": "old-task",
+		"status": "completed",
+		"iterations": 1,
+		"output": "some output",
+		"duration": 300000000000,
+		"logs": []
+	}`
+
+	var result TaskResult
+	if err := json.Unmarshal([]byte(oldJSON), &result); err != nil {
+		t.Fatalf("Unmarshal old TaskResult JSON: %v", err)
+	}
+
+	if result.TaskID != "old-task" {
+		t.Errorf("TaskID = %q, want %q", result.TaskID, "old-task")
+	}
+	if result.Status != StatusCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, StatusCompleted)
+	}
+	if result.OutputType != "" {
+		t.Errorf("OutputType = %q, want empty (old format)", result.OutputType)
+	}
+	if result.OutputRef != "" {
+		t.Errorf("OutputRef = %q, want empty (old format)", result.OutputRef)
+	}
+}
+
+// TestBackwardCompat_DefaultConstants verifies orchestrator constants.
+func TestBackwardCompat_DefaultConstants(t *testing.T) {
+	if DefaultMaxIterations != 3 {
+		t.Errorf("DefaultMaxIterations = %d, want 3", DefaultMaxIterations)
+	}
+	if DefaultAgentTimeout != 30*time.Minute {
+		t.Errorf("DefaultAgentTimeout = %v, want 30m", DefaultAgentTimeout)
+	}
+}

--- a/internal/state/backward_compat_test.go
+++ b/internal/state/backward_compat_test.go
@@ -1,0 +1,308 @@
+package state
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marcus/nightshift/internal/db"
+)
+
+// TestBackwardCompat_RunRecordJSONFields verifies that RunRecord JSON field
+// names haven't changed. External tools and stored history may depend on
+// these exact field names.
+func TestBackwardCompat_RunRecordJSONFields(t *testing.T) {
+	record := RunRecord{
+		ID:         "run-123",
+		StartTime:  time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 1, 15, 2, 30, 0, 0, time.UTC),
+		Provider:   "claude",
+		Project:    "/path/to/project",
+		Tasks:      []string{"lint-fix", "test-gap"},
+		TokensUsed: 50000,
+		Status:     "success",
+		Error:      "",
+		Branch:     "main",
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	// Verify all expected JSON field names are present
+	requiredFields := []string{
+		"id", "start_time", "end_time", "project",
+		"tasks", "tokens_used", "status",
+	}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("RunRecord JSON missing required field %q", field)
+		}
+	}
+
+	// Verify omitempty fields work correctly
+	// Provider should be present when set
+	if _, ok := raw["provider"]; !ok {
+		t.Error("RunRecord JSON missing 'provider' field when set")
+	}
+	// Branch should be present when set
+	if _, ok := raw["branch"]; !ok {
+		t.Error("RunRecord JSON missing 'branch' field when set")
+	}
+}
+
+// TestBackwardCompat_RunRecordOmitEmpty verifies that omitempty fields
+// are correctly omitted when empty, maintaining backward compatibility
+// with consumers that may not expect these fields.
+func TestBackwardCompat_RunRecordOmitEmpty(t *testing.T) {
+	record := RunRecord{
+		ID:        "run-456",
+		StartTime: time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+		Project:   "/path/to/project",
+		Tasks:     []string{"lint-fix"},
+		Status:    "success",
+		// Provider, Error, Branch intentionally empty
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	// omitempty fields should be absent when empty
+	omitFields := []string{"provider", "error", "branch"}
+	for _, field := range omitFields {
+		if _, ok := raw[field]; ok {
+			t.Errorf("RunRecord JSON should omit empty field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_RunRecordDeserialization verifies that a JSON payload
+// matching the v0.3.0 format (no provider/branch fields) can still be
+// deserialized into the current RunRecord struct.
+func TestBackwardCompat_RunRecordDeserialization(t *testing.T) {
+	// Simulate v0.3.0 JSON that lacks provider and branch fields
+	oldJSON := `{
+		"id": "run-old",
+		"start_time": "2026-01-15T02:00:00Z",
+		"end_time": "2026-01-15T02:30:00Z",
+		"project": "/old/project",
+		"tasks": ["lint-fix"],
+		"tokens_used": 25000,
+		"status": "success"
+	}`
+
+	var record RunRecord
+	if err := json.Unmarshal([]byte(oldJSON), &record); err != nil {
+		t.Fatalf("Unmarshal old JSON: %v", err)
+	}
+
+	if record.ID != "run-old" {
+		t.Errorf("ID = %q, want %q", record.ID, "run-old")
+	}
+	if record.Project != "/old/project" {
+		t.Errorf("Project = %q, want %q", record.Project, "/old/project")
+	}
+	if record.Provider != "" {
+		t.Errorf("Provider = %q, want empty (old format)", record.Provider)
+	}
+	if record.Branch != "" {
+		t.Errorf("Branch = %q, want empty (old format)", record.Branch)
+	}
+	if record.Status != "success" {
+		t.Errorf("Status = %q, want %q", record.Status, "success")
+	}
+	if len(record.Tasks) != 1 || record.Tasks[0] != "lint-fix" {
+		t.Errorf("Tasks = %v, want [lint-fix]", record.Tasks)
+	}
+}
+
+// TestBackwardCompat_ProjectStateJSONFields verifies that ProjectState JSON
+// field names haven't changed.
+func TestBackwardCompat_ProjectStateJSONFields(t *testing.T) {
+	state := ProjectState{
+		Path:        "/path/to/project",
+		LastRun:     time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+		TaskHistory: map[string]time.Time{"lint-fix": time.Now()},
+		RunCount:    5,
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"path", "last_run", "task_history", "run_count"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("ProjectState JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_AssignedTaskJSONFields verifies that AssignedTask JSON
+// field names haven't changed.
+func TestBackwardCompat_AssignedTaskJSONFields(t *testing.T) {
+	task := AssignedTask{
+		TaskID:     "lint-fix:/path",
+		Project:    "/path/to/project",
+		TaskType:   "lint-fix",
+		AssignedAt: time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	requiredFields := []string{"task_id", "project", "task_type", "assigned_at"}
+	for _, field := range requiredFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("AssignedTask JSON missing required field %q", field)
+		}
+	}
+}
+
+// TestBackwardCompat_StalenessBonus verifies the staleness calculation
+// formula hasn't changed, as task selection depends on it.
+func TestBackwardCompat_StalenessBonus(t *testing.T) {
+	s := newBackwardCompatTestState(t)
+	project := "/compat/project"
+
+	// Never-run task should get max bonus of 3.0
+	bonus := s.StalenessBonus(project, "never-run-task")
+	if bonus != 3.0 {
+		t.Errorf("StalenessBonus for never-run task = %f, want 3.0", bonus)
+	}
+
+	// Recently run task should get low bonus
+	s.RecordTaskRun(project, "recent-task")
+	bonus = s.StalenessBonus(project, "recent-task")
+	if bonus != 0.0 {
+		t.Errorf("StalenessBonus for just-run task = %f, want 0.0", bonus)
+	}
+}
+
+// TestBackwardCompat_DaysSinceLastRun verifies the sentinel value for
+// never-run tasks (-1) hasn't changed.
+func TestBackwardCompat_DaysSinceLastRun(t *testing.T) {
+	s := newBackwardCompatTestState(t)
+
+	days := s.DaysSinceLastRun("/some/project", "untracked-task")
+	if days != -1 {
+		t.Errorf("DaysSinceLastRun for untracked task = %d, want -1", days)
+	}
+}
+
+// TestBackwardCompat_RunHistoryPersistence verifies that run records can
+// be stored and retrieved with all fields intact across the current schema.
+func TestBackwardCompat_RunHistoryPersistence(t *testing.T) {
+	s := newBackwardCompatTestState(t)
+
+	record := RunRecord{
+		ID:         "compat-run-1",
+		StartTime:  time.Now().Add(-time.Hour),
+		EndTime:    time.Now(),
+		Provider:   "claude",
+		Project:    "/compat/project",
+		Tasks:      []string{"lint-fix", "test-gap"},
+		TokensUsed: 75000,
+		Status:     "success",
+		Branch:     "main",
+	}
+
+	s.AddRunRecord(record)
+
+	history := s.GetRunHistory(1)
+	if len(history) != 1 {
+		t.Fatalf("GetRunHistory returned %d records, want 1", len(history))
+	}
+
+	got := history[0]
+	if got.ID != record.ID {
+		t.Errorf("ID = %q, want %q", got.ID, record.ID)
+	}
+	if got.Provider != record.Provider {
+		t.Errorf("Provider = %q, want %q", got.Provider, record.Provider)
+	}
+	if got.Branch != record.Branch {
+		t.Errorf("Branch = %q, want %q", got.Branch, record.Branch)
+	}
+	if got.TokensUsed != record.TokensUsed {
+		t.Errorf("TokensUsed = %d, want %d", got.TokensUsed, record.TokensUsed)
+	}
+	if len(got.Tasks) != 2 {
+		t.Errorf("Tasks length = %d, want 2", len(got.Tasks))
+	}
+}
+
+// TestBackwardCompat_TodaySummaryStructure verifies that TodaySummary
+// fields are preserved for consumers.
+func TestBackwardCompat_TodaySummaryStructure(t *testing.T) {
+	s := newBackwardCompatTestState(t)
+
+	// Add a run for today
+	s.AddRunRecord(RunRecord{
+		ID:         "today-run-1",
+		StartTime:  time.Now(),
+		Project:    "/today/project",
+		Tasks:      []string{"lint-fix"},
+		TokensUsed: 10000,
+		Status:     "success",
+	})
+
+	summary := s.GetTodaySummary()
+	if summary.TotalRuns != 1 {
+		t.Errorf("TotalRuns = %d, want 1", summary.TotalRuns)
+	}
+	if summary.SuccessfulRuns != 1 {
+		t.Errorf("SuccessfulRuns = %d, want 1", summary.SuccessfulRuns)
+	}
+	if summary.TotalTokens != 10000 {
+		t.Errorf("TotalTokens = %d, want 10000", summary.TotalTokens)
+	}
+	if summary.TaskCounts == nil {
+		t.Error("TaskCounts should not be nil")
+	}
+}
+
+// newBackwardCompatTestState creates a State backed by a temporary database for testing.
+func newBackwardCompatTestState(t *testing.T) *State {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	s, err := New(database)
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	return s
+}

--- a/internal/tasks/backward_compat_test.go
+++ b/internal/tasks/backward_compat_test.go
@@ -1,0 +1,291 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBackwardCompat_TaskTypeConstants verifies that all built-in task type
+// string constants are stable. Changing these would break config files,
+// database records, and CLI usage referencing task types by name.
+func TestBackwardCompat_TaskTypeConstants(t *testing.T) {
+	// Exhaustive map of task type constant -> expected string value.
+	// If a constant is renamed or its value changes, this test catches it.
+	expected := map[TaskType]string{
+		// Category 1: PR
+		TaskLintFix:           "lint-fix",
+		TaskBugFinder:         "bug-finder",
+		TaskAutoDRY:           "auto-dry",
+		TaskSkillGroom:        "skill-groom",
+		TaskAPIContractVerify: "api-contract-verify",
+		TaskBackwardCompat:    "backward-compat",
+		TaskBuildOptimize:     "build-optimize",
+		TaskDocsBackfill:      "docs-backfill",
+		TaskCommitNormalize:   "commit-normalize",
+		TaskChangelogSynth:    "changelog-synth",
+		TaskReleaseNotes:      "release-notes",
+		TaskADRDraft:          "adr-draft",
+		TaskTDReview:          "td-review",
+		// Category 2: Analysis
+		TaskDocDrift:        "doc-drift",
+		TaskSemanticDiff:    "semantic-diff",
+		TaskDeadCode:        "dead-code",
+		TaskDependencyRisk:  "dependency-risk",
+		TaskTestGap:         "test-gap",
+		TaskTestFlakiness:   "test-flakiness",
+		TaskLoggingAudit:    "logging-audit",
+		TaskMetricsCoverage: "metrics-coverage",
+		TaskPerfRegression:  "perf-regression",
+		TaskCostAttribution: "cost-attribution",
+		TaskSecurityFootgun: "security-footgun",
+		TaskPIIScanner:      "pii-scanner",
+		TaskPrivacyPolicy:   "privacy-policy",
+		TaskSchemaEvolution: "schema-evolution",
+		TaskEventTaxonomy:   "event-taxonomy",
+		TaskRoadmapEntropy:  "roadmap-entropy",
+		TaskBusFactor:       "bus-factor",
+		TaskKnowledgeSilo:   "knowledge-silo",
+		// Category 3: Options
+		TaskGroomer:           "task-groomer",
+		TaskGuideImprover:     "guide-improver",
+		TaskIdeaGenerator:     "idea-generator",
+		TaskTechDebtClassify:  "tech-debt-classify",
+		TaskWhyAnnotator:      "why-annotator",
+		TaskEdgeCaseEnum:      "edge-case-enum",
+		TaskErrorMsgImprove:   "error-msg-improve",
+		TaskSLOSuggester:      "slo-suggester",
+		TaskUXCopySharpener:   "ux-copy-sharpener",
+		TaskA11yLint:          "a11y-lint",
+		TaskServiceAdvisor:    "service-advisor",
+		TaskOwnershipBoundary: "ownership-boundary",
+		TaskOncallEstimator:   "oncall-estimator",
+		// Category 4: Safe
+		TaskMigrationRehearsal: "migration-rehearsal",
+		TaskContractFuzzer:     "contract-fuzzer",
+		TaskGoldenPath:         "golden-path",
+		TaskPerfProfile:        "perf-profile",
+		TaskAllocationProfile:  "allocation-profile",
+		// Category 5: Map
+		TaskVisibilityInstrument: "visibility-instrument",
+		TaskRepoTopology:         "repo-topology",
+		TaskPermissionsMapper:    "permissions-mapper",
+		TaskDataLifecycle:        "data-lifecycle",
+		TaskFeatureFlagMonitor:   "feature-flag-monitor",
+		TaskCISignalNoise:        "ci-signal-noise",
+		TaskHistoricalContext:    "historical-context",
+		// Category 6: Emergency
+		TaskRunbookGen:    "runbook-gen",
+		TaskRollbackPlan:  "rollback-plan",
+		TaskPostmortemGen: "postmortem-gen",
+	}
+
+	for taskType, wantStr := range expected {
+		if string(taskType) != wantStr {
+			t.Errorf("TaskType constant changed: got %q, want %q", string(taskType), wantStr)
+		}
+	}
+}
+
+// TestBackwardCompat_RegistryContainsAllBuiltinTasks verifies that the
+// registry contains all expected built-in task types and none have been
+// accidentally removed.
+func TestBackwardCompat_RegistryContainsAllBuiltinTasks(t *testing.T) {
+	requiredTypes := []TaskType{
+		TaskLintFix, TaskBugFinder, TaskAutoDRY, TaskSkillGroom,
+		TaskAPIContractVerify, TaskBackwardCompat, TaskBuildOptimize,
+		TaskDocsBackfill, TaskCommitNormalize, TaskChangelogSynth,
+		TaskReleaseNotes, TaskADRDraft, TaskTDReview,
+		TaskDocDrift, TaskSemanticDiff, TaskDeadCode, TaskDependencyRisk,
+		TaskTestGap, TaskTestFlakiness, TaskLoggingAudit, TaskMetricsCoverage,
+		TaskPerfRegression, TaskCostAttribution, TaskSecurityFootgun,
+		TaskPIIScanner, TaskPrivacyPolicy, TaskSchemaEvolution,
+		TaskEventTaxonomy, TaskRoadmapEntropy, TaskBusFactor, TaskKnowledgeSilo,
+		TaskGroomer, TaskGuideImprover, TaskIdeaGenerator, TaskTechDebtClassify,
+		TaskWhyAnnotator, TaskEdgeCaseEnum, TaskErrorMsgImprove,
+		TaskSLOSuggester, TaskUXCopySharpener, TaskA11yLint,
+		TaskServiceAdvisor, TaskOwnershipBoundary, TaskOncallEstimator,
+		TaskMigrationRehearsal, TaskContractFuzzer, TaskGoldenPath,
+		TaskPerfProfile, TaskAllocationProfile,
+		TaskVisibilityInstrument, TaskRepoTopology, TaskPermissionsMapper,
+		TaskDataLifecycle, TaskFeatureFlagMonitor, TaskCISignalNoise,
+		TaskHistoricalContext,
+		TaskRunbookGen, TaskRollbackPlan, TaskPostmortemGen,
+	}
+
+	for _, tt := range requiredTypes {
+		if _, err := GetDefinition(tt); err != nil {
+			t.Errorf("built-in task %q missing from registry: %v", tt, err)
+		}
+	}
+}
+
+// TestBackwardCompat_CostTierValues verifies that CostTier iota values
+// haven't shifted. These values may be stored in databases or serialized.
+func TestBackwardCompat_CostTierValues(t *testing.T) {
+	tests := []struct {
+		tier CostTier
+		want int
+	}{
+		{CostLow, 0},
+		{CostMedium, 1},
+		{CostHigh, 2},
+		{CostVeryHigh, 3},
+	}
+	for _, tt := range tests {
+		if int(tt.tier) != tt.want {
+			t.Errorf("CostTier %v = %d, want %d", tt.tier.String(), int(tt.tier), tt.want)
+		}
+	}
+}
+
+// TestBackwardCompat_RiskLevelValues verifies that RiskLevel iota values
+// haven't shifted.
+func TestBackwardCompat_RiskLevelValues(t *testing.T) {
+	tests := []struct {
+		risk RiskLevel
+		want int
+	}{
+		{RiskLow, 0},
+		{RiskMedium, 1},
+		{RiskHigh, 2},
+	}
+	for _, tt := range tests {
+		if int(tt.risk) != tt.want {
+			t.Errorf("RiskLevel %v = %d, want %d", tt.risk.String(), int(tt.risk), tt.want)
+		}
+	}
+}
+
+// TestBackwardCompat_CategoryValues verifies that TaskCategory iota values
+// haven't shifted.
+func TestBackwardCompat_CategoryValues(t *testing.T) {
+	tests := []struct {
+		cat  TaskCategory
+		want int
+	}{
+		{CategoryPR, 0},
+		{CategoryAnalysis, 1},
+		{CategoryOptions, 2},
+		{CategorySafe, 3},
+		{CategoryMap, 4},
+		{CategoryEmergency, 5},
+	}
+	for _, tt := range tests {
+		if int(tt.cat) != tt.want {
+			t.Errorf("TaskCategory %v = %d, want %d", tt.cat.String(), int(tt.cat), tt.want)
+		}
+	}
+}
+
+// TestBackwardCompat_DefaultIntervalForCategory verifies that default
+// intervals for each category haven't changed, as users may rely on
+// these defaults for scheduling.
+func TestBackwardCompat_DefaultIntervalForCategory(t *testing.T) {
+	tests := []struct {
+		cat  TaskCategory
+		want time.Duration
+	}{
+		{CategoryPR, 168 * time.Hour},
+		{CategoryAnalysis, 72 * time.Hour},
+		{CategoryOptions, 168 * time.Hour},
+		{CategorySafe, 336 * time.Hour},
+		{CategoryMap, 168 * time.Hour},
+		{CategoryEmergency, 720 * time.Hour},
+	}
+	for _, tt := range tests {
+		got := DefaultIntervalForCategory(tt.cat)
+		if got != tt.want {
+			t.Errorf("DefaultIntervalForCategory(%v) = %v, want %v", tt.cat.String(), got, tt.want)
+		}
+	}
+}
+
+// TestBackwardCompat_CustomTaskRegistration verifies that custom task
+// registration and unregistration still work correctly.
+func TestBackwardCompat_CustomTaskRegistration(t *testing.T) {
+	customType := TaskType("test-custom-compat")
+
+	// Ensure clean state
+	UnregisterCustom(customType)
+
+	def := TaskDefinition{
+		Type:            customType,
+		Category:        CategoryAnalysis,
+		Name:            "Test Custom Compat",
+		Description:     "Test task for backward compat",
+		CostTier:        CostLow,
+		RiskLevel:       RiskLow,
+		DefaultInterval: 24 * time.Hour,
+	}
+
+	// Register should succeed
+	if err := RegisterCustom(def); err != nil {
+		t.Fatalf("RegisterCustom: %v", err)
+	}
+	defer UnregisterCustom(customType)
+
+	// Should be retrievable
+	got, err := GetDefinition(customType)
+	if err != nil {
+		t.Fatalf("GetDefinition after register: %v", err)
+	}
+	if got.Name != def.Name {
+		t.Errorf("Name = %q, want %q", got.Name, def.Name)
+	}
+
+	// Should be marked as custom
+	if !IsCustom(customType) {
+		t.Error("IsCustom = false, want true")
+	}
+
+	// Duplicate registration should fail
+	if err := RegisterCustom(def); err == nil {
+		t.Error("duplicate RegisterCustom should fail")
+	}
+
+	// Unregister
+	UnregisterCustom(customType)
+
+	// Should no longer exist
+	if _, err := GetDefinition(customType); err == nil {
+		t.Error("GetDefinition should fail after unregister")
+	}
+	if IsCustom(customType) {
+		t.Error("IsCustom should be false after unregister")
+	}
+}
+
+// TestBackwardCompat_CostTierTokenRanges verifies the token ranges for
+// each cost tier haven't changed, as budget calculations depend on these.
+func TestBackwardCompat_CostTierTokenRanges(t *testing.T) {
+	tests := []struct {
+		tier    CostTier
+		wantMin int
+		wantMax int
+	}{
+		{CostLow, 10_000, 50_000},
+		{CostMedium, 50_000, 150_000},
+		{CostHigh, 150_000, 500_000},
+		{CostVeryHigh, 500_000, 1_000_000},
+	}
+	for _, tt := range tests {
+		min, max := tt.tier.TokenRange()
+		if min != tt.wantMin || max != tt.wantMax {
+			t.Errorf("CostTier(%d).TokenRange() = (%d, %d), want (%d, %d)",
+				tt.tier, min, max, tt.wantMin, tt.wantMax)
+		}
+	}
+}
+
+// TestBackwardCompat_TDReviewDisabledByDefault verifies that the td-review
+// task remains opt-in only, preventing surprise task execution for users
+// upgrading from older versions.
+func TestBackwardCompat_TDReviewDisabledByDefault(t *testing.T) {
+	def, err := GetDefinition(TaskTDReview)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskTDReview): %v", err)
+	}
+	if !def.DisabledByDefault {
+		t.Error("TaskTDReview.DisabledByDefault should be true")
+	}
+}


### PR DESCRIPTION
## Summary
- Add backward-compat test suite for **tasks** package: task type string constants, registry completeness, enum iota values (CostTier, RiskLevel, TaskCategory), token ranges, default intervals, custom task registration, and DisabledByDefault contract
- Add backward-compat test suite for **state** package: RunRecord/ProjectState/AssignedTask JSON field names, omitempty behavior, v0.3.0 JSON deserialization, staleness bonus formula, sentinel values, run history persistence, TodaySummary
- Add backward-compat test suite for **orchestrator** package: TaskStatus constants, TaskResult/PlanOutput/ReviewOutput/ImplementOutput/LogEntry JSON structure, old-format deserialization, default constants

These 26 new tests complement the existing backward-compat coverage in `config`, `db`, and `commands/setup` by guarding the three previously untested packages whose serialization formats, database-stored values, and public API contracts downstream tools and stored data depend on.

## Test plan
- [x] All 26 new backward-compat tests pass
- [x] Full test suite (`go test ./...`) passes with no regressions

Nightshift-Task: backward-compat
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)