### PR TITLE
feat: enrich release-notes task prompt

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -468,6 +468,35 @@ func TestBuildPrompts(t *testing.T) {
 	}
 }
 
+func TestBuildPlanPrompt_ReleaseNotesIncludesDetailedInstructions(t *testing.T) {
+	o := New()
+
+	def, err := tasks.GetDefinition(tasks.TaskReleaseNotes)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskReleaseNotes) error: %v", err)
+	}
+
+	task := &tasks.Task{
+		ID:          "release-notes:/repo",
+		Title:       def.Name,
+		Description: def.Description,
+		Type:        tasks.TaskReleaseNotes,
+	}
+
+	prompt := o.buildPlanPrompt(task)
+
+	for _, want := range []string{
+		"Inspect the latest tag and CHANGELOG.md first",
+		"Group the draft into clear user-facing sections",
+		"Call out breaking changes, migrations, config updates",
+		"state your assumptions",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("plan prompt missing %q\nGot:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestExtractPRURL(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -347,10 +347,16 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		DefaultInterval: 168 * time.Hour,
 	},
 	TaskReleaseNotes: {
-		Type:            TaskReleaseNotes,
-		Category:        CategoryPR,
-		Name:            "Release Note Drafter",
-		Description:     "Draft release notes from changes",
+		Type:     TaskReleaseNotes,
+		Category: CategoryPR,
+		Name:     "Release Note Drafter",
+		Description: `Draft Nightshift release notes from repository changes.
+Inspect the latest tag and CHANGELOG.md first to understand the last published release and the existing release-note tone.
+Summarize the notable user-facing changes since that release, using commits and merged PRs as supporting evidence.
+Group the draft into clear user-facing sections (for example: Features, Fixes, Improvements, Breaking Changes) based on what changed.
+Call out breaking changes, migrations, config updates, and operator follow-up explicitly so upgrade impact is easy to scan.
+Preserve the concise tone and heading style already used in CHANGELOG.md, and skip low-signal internal churn unless it matters to users.
+If the release scope is unclear, state your assumptions, note missing evidence, and include follow-up questions or validation steps before publishing.`,
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 168 * time.Hour,

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -276,6 +277,28 @@ func TestRegistryCompleteness(t *testing.T) {
 	for _, tt := range taskTypes {
 		if _, err := GetDefinition(tt); err != nil {
 			t.Errorf("Task type %q not in registry: %v", tt, err)
+		}
+	}
+}
+
+func TestReleaseNotesDefinitionIncludesDraftingGuidance(t *testing.T) {
+	def, err := GetDefinition(TaskReleaseNotes)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskReleaseNotes) error: %v", err)
+	}
+
+	if def.Name != "Release Note Drafter" {
+		t.Fatalf("TaskReleaseNotes name = %q, want %q", def.Name, "Release Note Drafter")
+	}
+
+	for _, want := range []string{
+		"Inspect the latest tag and CHANGELOG.md first",
+		"Group the draft into clear user-facing sections",
+		"Call out breaking changes, migrations, config updates",
+		"state your assumptions",
+	} {
+		if !strings.Contains(def.Description, want) {
+			t.Errorf("TaskReleaseNotes description missing %q", want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- expand the built-in `release-notes` task with Nightshift-specific release drafting guidance
- add task and prompt regression tests so the richer description stays registered and reaches the planning prompt

## Assumption
- this intentionally improves the built-in prompt quality rather than adding release automation, new CLI flags, or a changelog pipeline

## Testing
- go test ./internal/tasks ./internal/orchestrator
- go run ./cmd/nightshift task show release-notes --project . --prompt-only


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/marcus/code/nightshift
task-type: release-notes
task-title: Release Note Drafter
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 11m33s
run-started: 2026-04-14T02:54:31-07:00
nightshift:metadata -->
