### PR TITLE
feat: refine commit-normalize guidance

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -871,6 +871,41 @@ func TestBuildImplementPrompt_ReleaseNotesIncludesRepoAwareGuidance(t *testing.T
 	}
 }
 
+func TestBuildPlanPrompt_CommitNormalizeIncludesSafetyGuidance(t *testing.T) {
+	o := New()
+
+	def, err := tasks.GetDefinition(tasks.TaskCommitNormalize)
+	if err != nil {
+		t.Fatalf("GetDefinition(commit-normalize): %v", err)
+	}
+
+	task := &tasks.Task{
+		ID:          "commit-normalize:/tmp/nightshift",
+		Title:       def.Name,
+		Description: def.Description,
+		Type:        def.Type,
+	}
+
+	prompt := o.buildPlanPrompt(task)
+
+	expected := []string{
+		"Inspect recent commit history",
+		"dominant commit-subject style",
+		"Define a clear default for new commit subjects",
+		"allow sensible exceptions for merges, releases, and version bumps",
+		"preserve any required Nightshift trailers",
+		"updating commit guidance, templates, or lightweight enforcement",
+		"rather than rewriting published history",
+		"Do not rebase, force-push, or mass-edit existing commits",
+	}
+
+	for _, want := range expected {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("commit-normalize plan prompt missing %q\nGot:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestBuildPrompts_GenericTasksDoNotReceiveReleaseNotesGuidance(t *testing.T) {
 	o := New()
 

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -329,10 +329,13 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		DefaultInterval: 168 * time.Hour,
 	},
 	TaskCommitNormalize: {
-		Type:            TaskCommitNormalize,
-		Category:        CategoryPR,
-		Name:            "Commit Message Normalizer",
-		Description:     "Standardize commit message format",
+		Type:     TaskCommitNormalize,
+		Category: CategoryPR,
+		Name:     "Commit Message Normalizer",
+		Description: `Inspect recent commit history to infer the repository's dominant commit-subject style, then standardize future commit guidance around that convention.
+Define a clear default for new commit subjects, allow sensible exceptions for merges, releases, and version bumps, and preserve any required Nightshift trailers on commits you create.
+Keep the work forward-looking and repo-safe: prefer updating commit guidance, templates, or lightweight enforcement for future commits rather than rewriting published history.
+Do not rebase, force-push, or mass-edit existing commits unless the repository already has an explicitly documented local-only workflow that makes that safe.`,
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 24 * time.Hour,

--- a/website/docs/task-reference.md
+++ b/website/docs/task-reference.md
@@ -23,7 +23,7 @@ Fully formed, review-ready artifacts. These tasks create branches and open pull 
 | `backward-compat` | Backward-Compatibility Checks | Check and ensure backward compatibility | Medium | Low | 7d |
 | `build-optimize` | Build Time Optimization | Optimize build configuration for faster builds | High | Medium | 7d |
 | `docs-backfill` | Documentation Backfiller | Generate missing documentation | Low | Low | 7d |
-| `commit-normalize` | Commit Message Normalizer | Standardize commit message format | Low | Low | 24h |
+| `commit-normalize` | Commit Message Normalizer | Standardize future commit conventions without rewriting published history | Low | Low | 24h |
 | `changelog-synth` | Changelog Synthesizer | Generate changelog from commits | Low | Low | 7d |
 | `release-notes` | Release Note Drafter | Draft release-ready notes for the next version | Low | Low | 7d |
 | `adr-draft` | ADR Drafter | Draft Architecture Decision Records | Medium | Low | 7d |


### PR DESCRIPTION
## Summary
- refine the built-in commit-normalize task instructions so they infer existing commit style and standardize future commit guidance
- add prompt regression coverage for the new commit-normalize safety guardrails
- update the public task reference to match the forward-looking, no-history-rewrite behavior

## Testing
- go test ./internal/tasks ./internal/orchestrator ./cmd/nightshift/commands
- ./nightshift task show commit-normalize --prompt-only


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.2
cost-tier: Low (10-50k)
branch: codex/release-notes-drafter
iterations: 2
duration: 13m12s
run-started: 2026-04-15T04:13:44-07:00
nightshift:metadata -->
