### PR TITLE
chore: pin golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  GOLANGCI_LINT_VERSION: v1.64.8
+
 on:
   push:
     branches: [main]
@@ -49,4 +52,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Binary name
 BINARY=nightshift
 PKG=./cmd/nightshift
+GOLANGCI_LINT_VERSION?=v1.64.8
 
 # Build the binary
 build:
@@ -43,7 +44,7 @@ coverage-html: coverage
 
 # Run golangci-lint (if installed)
 lint:
-	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest" && exit 1)
+	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)" && exit 1)
 	golangci-lint run
 
 # Clean build artifacts


### PR DESCRIPTION
## Summary
- pin CI golangci-lint to `v1.64.8` instead of `latest`
- align the local `make lint` install hint with the same pinned version
- keep the diff scoped to lint-tooling stabilization after the repo-wide Go checks came back clean

## Validation
- `gofmt -l $(rg --files -g '*.go')`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`