### PR TITLE
chore: restore commit message hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/README.md
+++ b/README.md
@@ -258,18 +258,36 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install the local git hooks before pushing:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This symlinks:
+- `scripts/pre-commit.sh` into `.git/hooks/pre-commit`
+- `scripts/commit-msg.sh` into `.git/hooks/commit-msg`
+
+The pre-commit hook runs:
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
+
+The commit-message hook expects a normalized subject line:
+- `type: summary`
+- `type(scope): summary`
+
+Examples:
+- `fix: restore commit message hook`
+- `feat(tasks): add branch metadata`
+- `docs: describe local git hooks`
+
+Allowed exceptions:
+- Git-generated subjects such as `Merge ...` and `Revert ...`
+- Autosquash subjects such as `fixup! ...` and `squash! ...`
+- Nightshift trailers such as `Nightshift-Task: ...` and `Nightshift-Ref: ...`
 
 To bypass in a pinch: `git commit --no-verify`
 

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+# Install: make install-hooks
+set -euo pipefail
+
+msg_file=${1:-}
+
+if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
+  echo "commit-msg: missing commit message file" >&2
+  exit 1
+fi
+
+normalize_line() {
+  local line=$1
+  line=${line%$'\r'}
+  printf '%s' "$line"
+}
+
+subject=
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+  line=$(normalize_line "$raw_line")
+  [[ -z "$line" ]] && continue
+  [[ $line == \#* ]] && continue
+  subject=$line
+  break
+done <"$msg_file"
+
+if [[ -z "$subject" ]]; then
+  cat >&2 <<'EOF'
+commit-msg: empty commit message
+Use: type: summary
+EOF
+  exit 1
+fi
+
+case "$subject" in
+  Merge\ *|Revert\ *|fixup!\ *|squash!\ *)
+    exit 0
+    ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z0-9#][a-z0-9._/#-]*\))?(!)?: [^[:space:]](.*[^[:space:]])?$'
+
+if [[ $subject =~ $pattern ]]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+commit-msg: invalid subject
+Expected: type: summary
+Example: fix: normalize commit message hook install
+Allowed: optional scope like feat(tasks): ..., plus Merge/Revert/fixup!/squash! subjects
+Bypass: git commit --no-verify
+Found: $subject
+EOF
+exit 1


### PR DESCRIPTION
## Summary
- add the missing commit-msg hook script to enforce normalized commit subjects for new commits
- install both pre-commit and commit-msg hooks from \✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)
✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)
- document the expected commit message format, allowed exceptions, and bypass guidance

## Testing
- make install-hooks
- bash -n scripts/commit-msg.sh
- smoke-test valid and invalid commit message files
- go test ./...
- go build ./cmd/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.1
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 8m34s
run-started: 2026-04-21T03:24:38-07:00
nightshift:metadata -->
