### PR TITLE
docs: backfill missing package and API documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Nightshift
+
+Thanks for taking the time to contribute. This document captures the
+conventions that keep history readable and reviews short.
+
+## Getting Started
+
+1. Install Go 1.21+.
+2. Clone this repository and run `make deps` to fetch modules.
+3. Install the pre-commit hook: `make install-hooks`.
+4. Build the binary: `make build` (produces `./nightshift`).
+
+## Branching
+
+- Branch from `main`.
+- Name branches with a short type prefix: `feat/...`, `fix/...`,
+  `docs/...`, `chore/...`, `refactor/...`.
+- Keep branches focused: one logical change per branch.
+
+## Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/):
+  `type(optional-scope): imperative subject`.
+- Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`,
+  `perf`, `build`, `ci`, `revert`.
+- Subject line in the imperative mood, <= 72 characters, no trailing
+  period.
+- Wrap the body at 72 columns. Explain the *why*, not the *what*.
+
+## Code Style
+
+- Run `gofmt` before committing (the pre-commit hook enforces this).
+- Run `go vet ./...` and address findings.
+- Keep logs hyper-concise: include needed info, minimize words (see
+  [AGENTS.md](AGENTS.md)).
+- Wrap errors with context (`fmt.Errorf("do thing: %w", err)`); never
+  silently drop them.
+- Tests live in `_test.go` files alongside code and prefer table-driven
+  style.
+
+## Running Checks
+
+```bash
+make test          # unit tests
+make test-race     # race detector
+make coverage      # coverage report
+make lint          # golangci-lint (install separately)
+make check         # test + lint
+```
+
+## Pull Requests
+
+Before opening a PR:
+
+- [ ] Rebase on the latest `main`.
+- [ ] Run `make check` and confirm it passes.
+- [ ] Update docs affected by the change (README, ARCHITECTURE,
+      inline doc comments).
+- [ ] Fill out the PR description: summary, motivation, test plan.
+
+Small, reviewable PRs land faster than large ones. If a change grows
+beyond ~400 lines of diff, consider splitting it.
+
+## Reporting Issues
+
+Open a GitHub issue with:
+
+- A short descriptive title.
+- Steps to reproduce or a minimal code sample.
+- Expected vs. actual behavior.
+- Relevant environment details (OS, Go version, provider CLIs in use).
+
+## License
+
+By contributing, you agree that your contributions will be licensed
+under the [MIT License](LICENSE).

--- a/cmd/provider-calibration/main.go
+++ b/cmd/provider-calibration/main.go
@@ -1,3 +1,6 @@
+// Package main is the provider-calibration CLI: an offline tool that
+// scans local Claude and Codex session transcripts to produce token
+// usage metrics used for tuning Nightshift's budget model.
 package main
 
 import (

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# Architecture
+
+High-level overview of the Nightshift codebase. Update this document
+whenever top-level directories are added, removed, or significantly
+refactored.
+
+## Top-Level Layout
+
+```
+cmd/                  CLI entry points (main packages)
+  nightshift/         Primary user-facing binary
+  provider-calibration/  Offline tool that compares Claude/Codex usage
+internal/             Application code (not importable externally)
+docs/                 Reference docs and migration notes
+scripts/              Local developer scripts (pre-commit hook, etc.)
+website/              Docusaurus site published as nightshift.haplab.com
+.claude/              Project-local Claude skills and agents
+```
+
+## Runtime Flow
+
+```
+nightshift <cmd>
+    │
+    ▼
+cmd/nightshift/commands  (Cobra command tree)
+    │
+    ▼
+internal/config          ── loads ~/.config/nightshift/config.yaml
+internal/projects        ── resolves target repos
+internal/budget          ── checks remaining daily allotment
+internal/scheduler       ── decides whether a run should fire now
+internal/tasks           ── scores and selects tasks per project
+internal/orchestrator    ── drives providers, streams output
+internal/providers       ── concrete backends (Claude, Codex, Copilot)
+internal/snapshots       ── persists usage telemetry
+internal/state / db      ── SQLite-backed durable state
+internal/reporting       ── morning summary reports
+internal/logging         ── structured logs with rotation
+```
+
+## Package Responsibilities
+
+| Package | Responsibility |
+|---------|----------------|
+| `internal/agents` | Interfaces and implementations for spawning AI agents. |
+| `internal/analysis` | Code ownership and bus-factor analysis. |
+| `internal/budget` | Token budget calculation and allocation. |
+| `internal/calibrator` | Tune task budgets and scheduling from history. |
+| `internal/config` | Load and validate the nightshift config. |
+| `internal/db` | SQLite-backed storage for state and snapshots. |
+| `internal/integrations` | Readers for external config and task sources. |
+| `internal/logging` | Structured logging with file rotation. |
+| `internal/orchestrator` | Coordinate AI agents across tasks. |
+| `internal/projects` | Multi-project discovery, resolution, budget split. |
+| `internal/providers` | Interfaces and implementations for coding agents. |
+| `internal/reporting` | Generate morning summary reports. |
+| `internal/scheduler` | Time-based job scheduling. |
+| `internal/security` | Audit logging for operations. |
+| `internal/setup` | Interactive configuration and preset selection. |
+| `internal/snapshots` | Periodic usage data capture from providers. |
+| `internal/state` | Persistent state for nightshift runs. |
+| `internal/stats` | Aggregate statistics from run data. |
+| `internal/tasks` | Task selection and priority scoring. |
+| `internal/tmux` | Scrape tmux sessions to detect agent processes. |
+| `internal/trends` | Analyze snapshots to surface patterns and anomalies. |
+
+## Data Flow
+
+1. **Config load** (`internal/config`) — parses
+   `~/.config/nightshift/config.yaml` into strongly-typed structures.
+2. **Project resolution** (`internal/projects`) — expands configured
+   paths, verifies repos, and computes per-project budget shares.
+3. **Budget gating** (`internal/budget` + `internal/snapshots`) — reads
+   recent usage snapshots, compares against `budget.max_percent`, and
+   decides whether to proceed.
+4. **Task scoring** (`internal/tasks`) — applies priorities, cooldowns,
+   and eligibility filters to rank candidate tasks per project.
+5. **Orchestration** (`internal/orchestrator` + `internal/providers`) —
+   spawns the chosen provider CLI for the top-ranked task, streams
+   output, and enforces timeouts.
+6. **Persistence** (`internal/state` + `internal/db`) — records runs,
+   outcomes, and provider usage.
+7. **Reporting** (`internal/reporting`) — assembles the morning
+   summary for the operator.
+
+## External Dependencies
+
+- **SQLite** via `modernc.org/sqlite` — durable state, snapshots, and
+  run history. Database file lives under
+  `~/.local/share/nightshift/`.
+- **Claude Code CLI** (`claude`) — invoked for the `claude` provider.
+  Auth is whatever `claude /login` configured.
+- **Codex CLI** (`codex`) — invoked for the `codex` provider. Auth is
+  whatever `codex --login` configured.
+- **GitHub Copilot CLI** (`@github/copilot`) — optional Copilot
+  provider; see [COPILOT_INTEGRATION.md](COPILOT_INTEGRATION.md) if
+  present.
+- **tmux** — optional, used by `internal/tmux` to correlate running
+  agent processes with their sessions.
+- **gum** — optional, used to page preview output when available.
+
+## Safety Model
+
+Nightshift never writes directly to the primary branch. Every task
+lands as its own branch (and, where `gh` auth allows, an open PR).
+The preflight summary in `nightshift run` shows provider, budget,
+projects, and planned tasks before work begins; in TTYs the user
+confirms, in non-TTYs confirmation is auto-skipped.


### PR DESCRIPTION
## Summary

Fills three clearly-missing documentation gaps:

- **`CONTRIBUTING.md`** — branching, conventional-commit style, required checks (`make check`), and PR expectations. Aligned with conventions already called out in `AGENTS.md` and the Makefile.
- **`docs/ARCHITECTURE.md`** — top-level layout, package-responsibility table, runtime/data flow, external dependencies, and a short note on the branch/PR safety model.
- **`cmd/provider-calibration/main.go`** — adds the missing `// Package main ...` doc comment (every other package in the repo already has one).

## Scope

Docs-only. No behavioral code changes. `gofmt -l .`, `go vet ./...`, and `go build ./...` all clean.

## Assumptions

- Target repo inferred from the Nightshift task trailer (`Nightshift-Ref: https://github.com/marcus/nightshift`); the launching environment's cwd was `/` so the repo was cloned fresh to work on it.
- Kept scope deliberately small: only added docs that were clearly missing rather than sweeping exported-symbol comments across all packages.

## Files Touched

- `CONTRIBUTING.md` (new)
- `docs/ARCHITECTURE.md` (new)
- `cmd/provider-calibration/main.go` (3-line package doc comment)

Nightshift-Task: docs-backfill
Nightshift-Ref: https://github.com/marcus/nightshift