### PR TITLE
chore: add commit message normalizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,13 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
-	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+	@echo "hooks installed:"
+	@echo "  pre-commit -> scripts/pre-commit.sh"
+	@echo "  commit-msg -> scripts/commit-msg.sh"

--- a/README.md
+++ b/README.md
@@ -258,18 +258,46 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install the repo-local git hooks before contributing:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This symlinks:
+- `scripts/pre-commit.sh` into `.git/hooks/pre-commit`
+- `scripts/commit-msg.sh` into `.git/hooks/commit-msg`
+
+The pre-commit hook runs:
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
+
+The commit-message hook standardizes future commits without rewriting existing history. It expects a lightweight Conventional Commit subject:
+- `type: subject`
+- `type(scope): subject`
+
+Allowed types:
+- `feat`
+- `fix`
+- `docs`
+- `refactor`
+- `test`
+- `build`
+- `ci`
+- `chore`
+
+Valid examples:
+- `feat: add pause command`
+- `fix(budget): handle weekly reset`
+- `docs: update setup notes`
+
+The hook ignores merge, revert, `fixup!`, and `squash!` commits. It also auto-normalizes low-risk first-line issues when safe:
+- trims leading and trailing whitespace
+- removes a trailing period
+- lowercases a recognized commit type such as `Fix:` to `fix:`
 
 To bypass in a pinch: `git commit --no-verify`
 

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "commit-msg hook expects the commit message file path" >&2
+  exit 1
+fi
+
+MESSAGE_FILE=$1
+ALLOWED_TYPES="feat|fix|docs|refactor|test|build|ci|chore"
+HEADER_PATTERN='^([[:alpha:]]+)(\([^)]+\))?:[[:space:]]+(.+)$'
+VALID_PATTERN="^(${ALLOWED_TYPES})(\\([^)]+\\))?: .+$"
+
+trim() {
+  sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+normalize_subject() {
+  local subject=$1
+  local normalized
+  normalized=$(printf '%s' "$subject" | trim | sed -E 's/\.$//')
+
+  if [[ $normalized =~ $HEADER_PATTERN ]]; then
+    local raw_type=${BASH_REMATCH[1]}
+    local scope=${BASH_REMATCH[2]:-}
+    local summary=${BASH_REMATCH[3]}
+    local lower_type
+    lower_type=$(printf '%s' "$raw_type" | tr '[:upper:]' '[:lower:]')
+
+    case "$lower_type" in
+      feat|fix|docs|refactor|test|build|ci|chore)
+        normalized="${lower_type}${scope}: ${summary}"
+        ;;
+    esac
+  fi
+
+  printf '%s' "$normalized"
+}
+
+rewrite_first_line() {
+  local subject=$1
+  local tmp
+  tmp=$(mktemp)
+  awk -v subject="$subject" 'NR == 1 { $0 = subject } { print }' "$MESSAGE_FILE" > "$tmp"
+  mv "$tmp" "$MESSAGE_FILE"
+}
+
+subject=$(sed -n '1p' "$MESSAGE_FILE")
+trimmed_subject=$(printf '%s' "$subject" | trim)
+
+case "$trimmed_subject" in
+  Merge\ *|Revert\ *|fixup!\ *|squash!\ *)
+    exit 0
+    ;;
+esac
+
+normalized_subject=$(normalize_subject "$subject")
+
+if [[ "$normalized_subject" != "$subject" ]]; then
+  rewrite_first_line "$normalized_subject"
+fi
+
+if [[ $normalized_subject =~ $VALID_PATTERN ]]; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+commit subject must match: type: subject
+or: type(scope): subject
+allowed types: feat, fix, docs, refactor, test, build, ci, chore
+examples:
+  feat: add pause command
+  fix(budget): handle weekly reset
+use --no-verify to bypass
+EOF
+exit 1


### PR DESCRIPTION
## Summary
- add a repo-local commit-msg hook that enforces lightweight Conventional Commit subjects for future commits
- install both pre-commit and commit-msg hooks via make install-hooks and document the workflow in the README
- auto-normalize safe first-line issues, exempt merge/revert/fixup/squash commits, and avoid rewriting historical commits

## Verification
- ran representative hook samples for valid, auto-normalizable, invalid, and exempt commit subjects
- ran go test ./...

## Notes
- reconciled the missing local base by creating codex/lint-fix from the existing lint-fix / origin/lint-fix ref; PR targets remote branch lint-fix because origin/codex/lint-fix does not exist


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.1
cost-tier: Low (10-50k)
branch: codex/lint-fix
iterations: 2
duration: 10m53s
run-started: 2026-04-23T04:11:11-07:00
nightshift:metadata -->
