### PR TITLE
Fix lint and style issues

### DIFF
--- a/cmd/nightshift/commands/budget.go
+++ b/cmd/nightshift/commands/budget.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -316,7 +317,7 @@ func formatTokens64(tokens int64) string {
 	if tokens >= 1000 {
 		return fmt.Sprintf("%.1fK", float64(tokens)/1000)
 	}
-	return fmt.Sprintf("%d", tokens)
+	return strconv.FormatInt(tokens, 10)
 }
 
 func formatBudgetMeta(estimate budget.BudgetEstimate) string {
@@ -391,10 +392,10 @@ func progressBar(percent float64, width int) string {
 	empty := width - filled
 
 	bar := ""
-	for i := 0; i < filled; i++ {
+	for range filled {
 		bar += "#"
 	}
-	for i := 0; i < empty; i++ {
+	for range empty {
 		bar += "-"
 	}
 

--- a/cmd/nightshift/commands/budget_helpers.go
+++ b/cmd/nightshift/commands/budget_helpers.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,15 +14,15 @@ func resolveProviderList(cfg *config.Config, filter string) ([]string, error) {
 		switch filter {
 		case "claude":
 			if !cfg.Providers.Claude.Enabled {
-				return nil, fmt.Errorf("claude provider not enabled")
+				return nil, errors.New("claude provider not enabled")
 			}
 		case "codex":
 			if !cfg.Providers.Codex.Enabled {
-				return nil, fmt.Errorf("codex provider not enabled")
+				return nil, errors.New("codex provider not enabled")
 			}
 		case "copilot":
 			if !cfg.Providers.Copilot.Enabled {
-				return nil, fmt.Errorf("copilot provider not enabled")
+				return nil, errors.New("copilot provider not enabled")
 			}
 		default:
 			return nil, fmt.Errorf("unknown provider: %s (valid: claude, codex, copilot)", filter)

--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -158,7 +158,7 @@ func runConfigSet(key, value string, useGlobal bool) error {
 
 	// Ensure directory exists
 	configDir := filepath.Dir(configPath)
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 
@@ -351,7 +351,7 @@ func printStruct(v reflect.Value, indent int) {
 	t := v.Type()
 	prefix := strings.Repeat("  ", indent)
 
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := t.Field(i)
 		value := v.Field(i)
 
@@ -414,7 +414,7 @@ func isZero(v reflect.Value) bool {
 		return v.Len() == 0
 	case reflect.Struct:
 		// Check if all fields are zero
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			if !isZero(v.Field(i)) {
 				return false
 			}

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -63,8 +64,10 @@ var daemonStatusCmd = &cobra.Command{
 	RunE:  runDaemonStatus,
 }
 
-var daemonForegroundFlag bool
-var daemonTimeoutFlag time.Duration
+var (
+	daemonForegroundFlag bool
+	daemonTimeoutFlag    time.Duration
+)
 
 func init() {
 	daemonStartCmd.Flags().BoolVarP(&daemonForegroundFlag, "foreground", "f", false, "Run in foreground (don't daemonize)")
@@ -84,7 +87,7 @@ func pidFilePath() string {
 // ensurePidDir ensures the PID file directory exists.
 func ensurePidDir() error {
 	dir := filepath.Dir(pidFilePath())
-	return os.MkdirAll(dir, 0755)
+	return os.MkdirAll(dir, 0o755)
 }
 
 // writePidFile writes the current process PID to the PID file.
@@ -92,7 +95,7 @@ func writePidFile() error {
 	if err := ensurePidDir(); err != nil {
 		return fmt.Errorf("creating pid dir: %w", err)
 	}
-	return os.WriteFile(pidFilePath(), []byte(strconv.Itoa(os.Getpid())), 0644)
+	return os.WriteFile(pidFilePath(), []byte(strconv.Itoa(os.Getpid())), 0o644)
 }
 
 // readPidFile reads the PID from the PID file.
@@ -238,7 +241,7 @@ func runDaemonLoop(cfg *config.Config) error {
 	<-ctx.Done()
 
 	// Stop scheduler gracefully
-	if err := sched.Stop(); err != nil && err != scheduler.ErrNotRunning {
+	if err := sched.Stop(); err != nil && !errors.Is(err, scheduler.ErrNotRunning) {
 		log.Errorf("stopping scheduler: %v", err)
 	}
 

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -76,7 +76,7 @@ func newCopilotAgentFromConfig(cfg *config.Config, binaryPath ...string) *agents
 		return agents.NewCopilotAgent()
 	}
 
-	binary := ""
+	var binary string
 	if len(binaryPath) > 0 && binaryPath[0] != "" {
 		binary = binaryPath[0]
 	} else {

--- a/cmd/nightshift/commands/init.go
+++ b/cmd/nightshift/commands/init.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ANSI color codes for terminal output
+// ANSI color codes for terminal output.
 const (
 	colorReset  = "\033[0m"
 	colorGreen  = "\033[32m"

--- a/cmd/nightshift/commands/install.go
+++ b/cmd/nightshift/commands/install.go
@@ -12,14 +12,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Service type constants
+// Service type constants.
 const (
 	ServiceLaunchd = "launchd"
 	ServiceSystemd = "systemd"
 	ServiceCron    = "cron"
 )
 
-// File paths for installed services
+// File paths for installed services.
 const (
 	launchdPlistName   = "com.nightshift.agent.plist"
 	systemdServiceName = "nightshift.service"
@@ -57,7 +57,7 @@ func init() {
 // runInstall implements the install command
 func runInstall(cmd *cobra.Command, args []string) error {
 	// Determine service type
-	serviceType := ""
+	var serviceType string
 	if len(args) > 0 {
 		serviceType = args[0]
 	} else {

--- a/cmd/nightshift/commands/report.go
+++ b/cmd/nightshift/commands/report.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -423,7 +424,7 @@ func renderReportFancy(runs []reportRun, rng reportRange, opts reportOptions) er
 			if err != nil {
 				return err
 			}
-			b.WriteString(string(payload))
+			b.Write(payload)
 			b.WriteString("\n")
 		}
 	default:
@@ -1082,7 +1083,7 @@ func formatTokensCompact(tokens int) string {
 	case tokens >= 1_000:
 		return fmt.Sprintf("%.1fk", float64(tokens)/1_000)
 	default:
-		return fmt.Sprintf("%d", tokens)
+		return strconv.Itoa(tokens)
 	}
 }
 

--- a/cmd/nightshift/commands/setup_test.go
+++ b/cmd/nightshift/commands/setup_test.go
@@ -63,7 +63,10 @@ func TestHandleProjectsInput_RejectsFilePath(t *testing.T) {
 	m.projectInput.SetValue(filePath)
 
 	model, _ := m.handleProjectsInput(tea.KeyMsg{Type: tea.KeyEnter})
-	got := model.(*setupModel)
+	got, ok := model.(*setupModel)
+	if !ok {
+		t.Fatal("expected *setupModel type")
+	}
 	if got.projectErr != "path must be a directory" {
 		t.Fatalf("projectErr = %q, want %q", got.projectErr, "path must be a directory")
 	}
@@ -80,7 +83,10 @@ func TestHandleTaskInput_RequiresSelection(t *testing.T) {
 	}
 
 	model, cmd := m.handleTaskInput(tea.KeyMsg{Type: tea.KeyEnter})
-	got := model.(*setupModel)
+	got, ok := model.(*setupModel)
+	if !ok {
+		t.Fatal("expected *setupModel type")
+	}
 	if cmd != nil {
 		t.Fatal("expected no transition cmd when no tasks selected")
 	}

--- a/cmd/nightshift/commands/status.go
+++ b/cmd/nightshift/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -152,7 +153,7 @@ func formatTokens(tokens int) string {
 	if tokens >= 1000 {
 		return fmt.Sprintf("%.1fK", float64(tokens)/1000)
 	}
-	return fmt.Sprintf("%d", tokens)
+	return strconv.Itoa(tokens)
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -414,7 +415,7 @@ func formatK(tokens int) string {
 	if tokens >= 1_000 {
 		return fmt.Sprintf("%dk", tokens/1_000)
 	}
-	return fmt.Sprintf("%d", tokens)
+	return strconv.Itoa(tokens)
 }
 
 // --- JSON output ---

--- a/cmd/provider-calibration/main.go
+++ b/cmd/provider-calibration/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -226,7 +228,7 @@ func collectCodex(root, repoFilter, originatorFilter string, minUserTurns int) (
 				}
 			}
 		}
-		if scanErr := scanner.Err(); scanErr != nil && scanErr != io.EOF {
+		if scanErr := scanner.Err(); scanErr != nil && !errors.Is(scanErr, io.EOF) {
 			return nil
 		}
 
@@ -349,7 +351,7 @@ func collectClaude(root, repoFilter string, minUserTurns int) ([]sessionMetrics,
 			primary += u.InputTokens + u.OutputTokens
 			alt += u.InputTokens + u.OutputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 		}
-		if scanErr := scanner.Err(); scanErr != nil && scanErr != io.EOF {
+		if scanErr := scanner.Err(); scanErr != nil && !errors.Is(scanErr, io.EOF) {
 			return nil
 		}
 
@@ -608,7 +610,7 @@ func userHomeDir() string {
 }
 
 func formatInt(v int64) string {
-	s := fmt.Sprintf("%d", v)
+	s := strconv.FormatInt(v, 10)
 	n := len(s)
 	if n <= 3 {
 		return s

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -175,7 +176,8 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 
 	// Check for other errors
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			result.ExitCode = exitErr.ExitCode()
 			result.Error = stderr
 		} else {

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -4,6 +4,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -133,7 +134,8 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 
 	// Check for other errors
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			result.ExitCode = exitErr.ExitCode()
 			result.Error = stderr
 		} else {

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -4,6 +4,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -145,7 +146,8 @@ func (a *CopilotAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execu
 
 	// Check for other errors
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			result.ExitCode = exitErr.ExitCode()
 			result.Error = stderr
 		} else {

--- a/internal/analysis/report.go
+++ b/internal/analysis/report.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -128,10 +129,10 @@ func (rg *ReportGenerator) RenderMarkdown(report *Report) string {
 		buf.WriteString("## Recommendations\n\n")
 		for _, rec := range report.Recommendations {
 			// Check if this is a priority item (starts with risk level keywords)
-			isHighPriority := len(rec) > 0 && (bytes.HasPrefix([]byte(rec), []byte("GOOD")) ||
-				bytes.HasPrefix([]byte(rec), []byte("HIGH")) ||
-				bytes.HasPrefix([]byte(rec), []byte("CRITICAL")) ||
-				bytes.HasPrefix([]byte(rec), []byte("MEDIUM")))
+			isHighPriority := len(rec) > 0 && (strings.HasPrefix(rec, "GOOD") ||
+				strings.HasPrefix(rec, "HIGH") ||
+				strings.HasPrefix(rec, "CRITICAL") ||
+				strings.HasPrefix(rec, "MEDIUM"))
 
 			if isHighPriority {
 				// High priority items

--- a/internal/integrations/github.go
+++ b/internal/integrations/github.go
@@ -95,7 +95,7 @@ func (r *GitHubReader) listIssues(ctx context.Context, projectPath string) ([]Ta
 		return nil, err
 	}
 
-	var tasks []TaskItem
+	tasks := make([]TaskItem, 0, len(ghIssues))
 	for _, issue := range ghIssues {
 		labels := make([]string, len(issue.Labels))
 		for i, l := range issue.Labels {

--- a/internal/integrations/td.go
+++ b/internal/integrations/td.go
@@ -96,7 +96,7 @@ func (r *TDReader) listTasks(ctx context.Context, projectPath string) ([]TaskIte
 	}
 
 	// Convert to TaskItems
-	var tasks []TaskItem
+	tasks := make([]TaskItem, 0, len(tdTasks))
 	for _, t := range tdTasks {
 		tasks = append(tasks, TaskItem{
 			ID:          t.ID,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -50,7 +50,10 @@ func (m *mockAgent) Execute(ctx context.Context, opts agents.ExecuteOptions) (*a
 
 // Helper to create JSON response.
 func jsonResponse(v any) agents.ExecuteResult {
-	data, _ := json.Marshal(v)
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic("jsonResponse: " + err.Error())
+	}
 	return agents.ExecuteResult{
 		Output:   string(data),
 		JSON:     data,
@@ -538,7 +541,10 @@ func TestRunTaskExtractsPRURL(t *testing.T) {
 		FilesModified: []string{"file1.go"},
 		Summary:       "opened PR",
 	}
-	implJSON, _ := json.Marshal(implData)
+	implJSON, err := json.Marshal(implData)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
 	implResp := agents.ExecuteResult{
 		Output:   "Created https://github.com/owner/repo/pull/42 for review",
 		JSON:     implJSON,

--- a/internal/providers/claude_test.go
+++ b/internal/providers/claude_test.go
@@ -1,9 +1,9 @@
 package providers
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -597,8 +597,8 @@ func writeJSONLFile(t *testing.T, path string, lines []string) {
 // makeAssistantLine returns a JSONL line for an assistant message with usage.
 func makeAssistantLine(ts time.Time, inputTokens, outputTokens int64) string {
 	return `{"type":"assistant","message":{"model":"claude-sonnet-4","usage":{"input_tokens":` +
-		fmt.Sprintf("%d", inputTokens) + `,"output_tokens":` +
-		fmt.Sprintf("%d", outputTokens) + `,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"` +
+		strconv.FormatInt(inputTokens, 10) + `,"output_tokens":` +
+		strconv.FormatInt(outputTokens, 10) + `,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"` +
 		ts.Format(time.RFC3339) + `"}`
 }
 

--- a/internal/security/audit.go
+++ b/internal/security/audit.go
@@ -290,7 +290,7 @@ func (l *AuditLogger) GetLogFiles() ([]string, error) {
 		return nil, fmt.Errorf("reading audit log dir: %w", err)
 	}
 
-	var files []string
+	files := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".jsonl" {
 			files = append(files, filepath.Join(l.logDir, entry.Name()))
@@ -307,8 +307,8 @@ func ReadEvents(path string) ([]AuditEvent, error) {
 		return nil, fmt.Errorf("reading audit log: %w", err)
 	}
 
-	var events []AuditEvent
 	lines := splitLines(data)
+	events := make([]AuditEvent, 0, len(lines))
 
 	for _, line := range lines {
 		if len(line) == 0 {

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -188,7 +188,7 @@ func (s *Stats) loadReports() []*reporting.RunResults {
 		return nil
 	}
 
-	var results []*reporting.RunResults
+	results := make([]*reporting.RunResults, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue

--- a/internal/tasks/register.go
+++ b/internal/tasks/register.go
@@ -12,7 +12,7 @@ import (
 // and registers them. If any registration fails, previously registered tasks from
 // this call are rolled back.
 func RegisterCustomTasksFromConfig(customs []config.CustomTaskConfig) error {
-	var registered []TaskType
+	registered := make([]TaskType, 0, len(customs))
 	for _, c := range customs {
 		cat := parseCategoryString(c.Category)
 		cost := parseCostTierString(c.CostTier)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (s *Session) Start(ctx context.Context) error {
 
 // Resize sets the pane size.
 func (s *Session) Resize(ctx context.Context, width, height int) error {
-	if _, err := s.run(ctx, "resize-pane", "-t", s.name, "-x", fmt.Sprint(width), "-y", fmt.Sprint(height)); err != nil {
+	if _, err := s.run(ctx, "resize-pane", "-t", s.name, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height)); err != nil {
 		return fmt.Errorf("tmux resize-pane: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- applies lint/style cleanup already staged on codex/lint-fix across 24 Go files
- no additional edits were needed on verification branch codex/lint-fix-automated-cleanup-2
- opens the delivery PR from codex/lint-fix into main, correcting the prior branch-to-base PR path

## Checks
- gofmt -l $(rg --files -g '*.go')
- go vet ./...
- make lint
- go test ./...
- git diff --check main..codex/lint-fix

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/marcus/code/nightshift
task-type: lint-fix
task-title: Linter Fixes
provider: codex
score: 0.2
cost-tier: Low (10-50k)
branch: codex/lint-fix
iterations: 2
duration: 10m32s
run-started: 2026-04-25T03:14:20-07:00
nightshift:metadata -->
