### PR TITLE
chore: normalize commit messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/README.md
+++ b/README.md
@@ -258,20 +258,46 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install the git hooks to catch formatting, vet, build, and commit message issues before pushing:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit` and `scripts/commit-msg.sh` into `.git/hooks/commit-msg`.
+
+The pre-commit hook runs:
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
 
-To bypass in a pinch: `git commit --no-verify`
+The commit-msg hook requires a concise Conventional Commit-style subject:
+
+```text
+type(scope): concise subject
+type: concise subject
+```
+
+Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`.
+
+Allowed examples:
+
+```text
+feat(tasks): add queue filtering
+fix: handle empty budget snapshots
+docs: clarify hook installation
+```
+
+Subjects must be 72 characters or fewer and must not end with a period. Git-generated merge, revert, `fixup!`, and `squash!` messages are allowed. Commit bodies may include normal Git trailers, including Nightshift metadata:
+
+```text
+Nightshift-Task: lint-fix
+Nightshift-Ref: https://github.com/marcus/nightshift
+```
+
+To bypass hooks for an exceptional case: `git commit --no-verify`
 
 ## Uninstalling
 

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+# Install: make install-hooks  (or: ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "commit-msg: expected path to commit message file" >&2
+  exit 1
+fi
+
+MSG_FILE=$1
+MAX_SUBJECT_LEN=72
+
+subject=$(sed -n '/^[[:space:]]*#/d; /^[[:space:]]*$/d; p; q' "$MSG_FILE")
+
+if [[ -z "$subject" ]]; then
+  echo "commit-msg: empty commit subject" >&2
+  exit 1
+fi
+
+# Let Git-generated messages and autosquash commits through unchanged.
+if [[ "$subject" =~ ^Merge[[:space:]] ]] ||
+  [[ "$subject" =~ ^Revert[[:space:]]\".*\"$ ]] ||
+  [[ "$subject" =~ ^(fixup|squash)![[:space:]] ]]; then
+  exit 0
+fi
+
+if (( ${#subject} > MAX_SUBJECT_LEN )); then
+  echo "commit-msg: subject must be ${MAX_SUBJECT_LEN} characters or fewer" >&2
+  echo "  $subject" >&2
+  exit 1
+fi
+
+if [[ "$subject" == *. ]]; then
+  echo "commit-msg: subject must not end with a period" >&2
+  echo "  $subject" >&2
+  exit 1
+fi
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z0-9._/-]+\))?(!)?: [^[:space:]].*$'
+
+if [[ ! "$subject" =~ $pattern ]]; then
+  cat >&2 <<'EOF'
+commit-msg: subject must use Conventional Commit format
+
+Format:
+  type(scope): concise subject
+
+Allowed types:
+  build chore ci docs feat fix perf refactor style test
+
+Examples:
+  feat(tasks): add queue filtering
+  fix: handle empty budget snapshots
+  docs: clarify hook installation
+EOF
+  echo "" >&2
+  echo "Got:" >&2
+  echo "  $subject" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add commit-msg hook for Conventional Commit subjects
- install commit-msg alongside pre-commit with make install-hooks
- document commit message examples, trailers, and bypass guidance

## Tests
- manual scripts/commit-msg.sh valid/invalid/generated/trailer cases
- bash -n scripts/commit-msg.sh scripts/pre-commit.sh
- go test ./...

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.1
cost-tier: Low (10-50k)
branch: codex/lint-fix
iterations: 1
duration: 7m3s
run-started: 2026-04-25T03:14:20-07:00
nightshift:metadata -->
