### PR TITLE
chore(orchestrator): normalize commit prompt format

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,6 +26,15 @@ const (
 	DefaultAgentTimeout  = 30 * time.Minute
 )
 
+const (
+	commitSubjectFormat       = "type(scope): subject"
+	commitOptionalBodyFormat  = "[optional body after a blank line]"
+	nightshiftRepositoryRef   = "https://github.com/marcus/nightshift"
+	commitMessageInstruction  = "use a Conventional Commit subject, optional body, and required Nightshift trailers:"
+	nightshiftTaskTrailerName = "Nightshift-Task"
+	nightshiftRefTrailerName  = "Nightshift-Ref"
+)
+
 // TaskStatus represents the outcome of task execution.
 type TaskStatus string
 
@@ -711,6 +720,19 @@ func (o *Orchestrator) PlanPrompt(task *tasks.Task) string {
 	return o.buildPlanPrompt(task)
 }
 
+func commitMessageFormat(taskType tasks.TaskType) string {
+	return fmt.Sprintf(`%s
+   %s
+   %s
+   %s: %s
+   %s: %s`,
+		commitMessageInstruction,
+		commitSubjectFormat,
+		commitOptionalBodyFormat,
+		nightshiftTaskTrailerName, taskType,
+		nightshiftRefTrailerName, nightshiftRepositoryRef)
+}
+
 func (o *Orchestrator) buildPlanPrompt(task *tasks.Task) string {
 	branchInstruction := ""
 	if o.runMeta != nil && o.runMeta.Branch != "" {
@@ -728,9 +750,7 @@ Description: %s
 0. You are running autonomously. If the task is broad or ambiguous, choose a concrete, minimal scope that delivers value and state any assumptions in the description.
 1. Work on a new branch and plan to submit a PR. Never work directly on the primary branch.%s
 2. Before creating your branch, record the current branch name and plan to switch back after the PR is opened.
-3. If you create commits, include a concise message with these git trailers:
-   Nightshift-Task: %s
-   Nightshift-Ref: https://github.com/marcus/nightshift
+3. If you create commits, %s
 4. Analyze the task requirements
 5. Identify files that need to be modified
 6. Create step-by-step implementation plan
@@ -741,7 +761,7 @@ Description: %s
   "files": ["file1.go", "file2.go", ...],
   "description": "overall approach"
 }
-`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, branchInstruction, commitMessageFormat(task.Type))
 }
 
 func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, iteration int) string {
@@ -771,9 +791,7 @@ Description: %s
 ## Instructions
 0. Before creating your branch, record the current branch name. Create and work on a new branch. Never modify or commit directly to the primary branch.%s
    When finished, open a PR. After the PR is submitted, switch back to the original branch. If you cannot open a PR, leave the branch and explain next steps.
-1. If you create commits, include a concise message with these git trailers:
-   Nightshift-Task: %s
-   Nightshift-Ref: https://github.com/marcus/nightshift
+1. If you create commits, %s
 2. Implement the plan step by step
 3. Make all necessary code changes
 4. Ensure tests pass
@@ -783,7 +801,7 @@ Description: %s
   "files_modified": ["file1.go", ...],
   "summary": "what was done"
 }
-`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, commitMessageFormat(task.Type))
 }
 
 func (o *Orchestrator) buildReviewPrompt(task *tasks.Task, impl *ImplementOutput) string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -430,6 +430,7 @@ func TestBuildPrompts(t *testing.T) {
 		ID:          "prompt-test",
 		Title:       "Build Prompts",
 		Description: "Test prompt generation",
+		Type:        tasks.TaskCommitNormalize,
 	}
 
 	// Test plan prompt
@@ -440,6 +441,7 @@ func TestBuildPrompts(t *testing.T) {
 	if !containsIgnoreCase(planPrompt, "prompt-test") {
 		t.Error("plan prompt should contain task ID")
 	}
+	assertCommitMessagePrompt(t, planPrompt, task.Type)
 
 	// Test implement prompt
 	plan := &PlanOutput{
@@ -450,6 +452,7 @@ func TestBuildPrompts(t *testing.T) {
 	if !containsIgnoreCase(implPrompt, "implementation") {
 		t.Error("implement prompt should mention implementation")
 	}
+	assertCommitMessagePrompt(t, implPrompt, task.Type)
 
 	// Test implement prompt iteration 2
 	implPrompt2 := o.buildImplementPrompt(task, plan, 2)
@@ -465,6 +468,45 @@ func TestBuildPrompts(t *testing.T) {
 	reviewPrompt := o.buildReviewPrompt(task, impl)
 	if !containsIgnoreCase(reviewPrompt, "review") {
 		t.Error("review prompt should mention review")
+	}
+}
+
+func TestPlanAndImplementPromptsUseStandardCommitFormat(t *testing.T) {
+	o := New()
+	task := &tasks.Task{
+		ID:          "commit-normalize:/repo",
+		Title:       "Commit Message Normalizer",
+		Description: "Standardize commit message format",
+		Type:        tasks.TaskCommitNormalize,
+	}
+	plan := &PlanOutput{
+		Steps:       []string{"update prompts", "add tests"},
+		Description: "Normalize future generated commit messages",
+	}
+
+	for name, prompt := range map[string]string{
+		"plan":      o.buildPlanPrompt(task),
+		"implement": o.buildImplementPrompt(task, plan, 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assertCommitMessagePrompt(t, prompt, task.Type)
+		})
+	}
+}
+
+func assertCommitMessagePrompt(t *testing.T, prompt string, taskType tasks.TaskType) {
+	t.Helper()
+
+	for _, want := range []string{
+		"Conventional Commit subject",
+		"type(scope): subject",
+		"[optional body after a blank line]",
+		"Nightshift-Task: " + string(taskType),
+		"Nightshift-Ref: https://github.com/marcus/nightshift",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\ngot:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -332,7 +332,7 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		Type:            TaskCommitNormalize,
 		Category:        CategoryPR,
 		Name:            "Commit Message Normalizer",
-		Description:     "Standardize commit message format",
+		Description:     "Improve consistency and validation for future Nightshift-generated commit messages using Conventional Commit subjects with required Nightshift trailers; do not rewrite existing history",
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 24 * time.Hour,

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -104,6 +104,39 @@ func TestGetDefinition(t *testing.T) {
 	}
 }
 
+func TestCommitNormalizeDefinition(t *testing.T) {
+	def, err := GetDefinition(TaskCommitNormalize)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskCommitNormalize) returned error: %v", err)
+	}
+
+	wantDescription := "Improve consistency and validation for future Nightshift-generated commit messages using Conventional Commit subjects with required Nightshift trailers; do not rewrite existing history"
+	if def.Type != TaskCommitNormalize {
+		t.Errorf("Type = %q, want %q", def.Type, TaskCommitNormalize)
+	}
+	if def.Name != "Commit Message Normalizer" {
+		t.Errorf("Name = %q, want %q", def.Name, "Commit Message Normalizer")
+	}
+	if def.Description != wantDescription {
+		t.Errorf("Description = %q, want %q", def.Description, wantDescription)
+	}
+	if def.Category != CategoryPR {
+		t.Errorf("Category = %d, want %d", def.Category, CategoryPR)
+	}
+	if def.CostTier != CostLow {
+		t.Errorf("CostTier = %d, want %d", def.CostTier, CostLow)
+	}
+	if def.RiskLevel != RiskLow {
+		t.Errorf("RiskLevel = %d, want %d", def.RiskLevel, RiskLow)
+	}
+	if def.DefaultInterval != 24*time.Hour {
+		t.Errorf("DefaultInterval = %v, want %v", def.DefaultInterval, 24*time.Hour)
+	}
+	if def.DisabledByDefault {
+		t.Error("TaskCommitNormalize should not be DisabledByDefault")
+	}
+}
+
 func TestGetCostEstimate(t *testing.T) {
 	// Low cost task
 	min, max, err := GetCostEstimate(TaskLintFix)


### PR DESCRIPTION
## Summary
- centralize Nightshift commit message prompt contract around Conventional Commit subjects
- preserve required Nightshift-Task and Nightshift-Ref trailers in plan and implementation prompts
- clarify commit-normalize task metadata and add focused prompt/registry tests

## Tests
- go test ./...


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.1
cost-tier: Low (10-50k)
branch: codex/lint-fix-linter-fixes
iterations: 1
duration: 6m17s
run-started: 2026-04-27T02:45:37-07:00
nightshift:metadata -->
