### PR TITLE
chore: add commit message normalization

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,34 @@
+# Subject format:
+#   type(scope): description
+#
+# Types:
+#   build    Build system, packaging, or dependencies
+#   chore    Maintenance that does not affect runtime behavior
+#   ci       CI configuration or automation
+#   docs     Documentation-only changes
+#   feat     User-facing feature
+#   fix      User-facing bug fix
+#   perf     Performance improvement
+#   refactor Code change that is neither a feature nor a bug fix
+#   style    Formatting-only changes
+#   test     Tests or test infrastructure
+#
+# Scope is optional and should be short: fix(config): read env overrides
+# Keep the subject at 72 characters or less.
+#
+# Body:
+#   Wrap body text near 72 characters.
+#   Leave one blank line between the subject and body.
+#   Explain why the change was made when the subject is not enough.
+#
+# Trailers:
+#   Leave one blank line before trailers.
+#   Example:
+#   Nightshift-Task: task-id
+#   Nightshift-Ref: https://github.com/marcus/nightshift
+#
+# Examples:
+#   feat(tasks): add docs backfill task
+#   fix(config): preserve default budget limit
+#   docs: document provider calibration
+#   chore: update release metadata

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git development hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/README.md
+++ b/README.md
@@ -258,18 +258,49 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Development hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install the git hooks to catch formatting, vet, build, and commit message
+issues before pushing:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This symlinks:
+- `scripts/pre-commit.sh` into `.git/hooks/pre-commit`
+- `scripts/commit-msg.sh` into `.git/hooks/commit-msg`
+
+The pre-commit hook runs:
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
+
+The commit-msg hook validates the first subject line only. Use Conventional
+Commits with a short subject:
+
+```text
+type(scope): description
+```
+
+Allowed types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `style`, and `test`. Scope is optional, the description must be
+non-empty, and the subject must be 72 characters or less. Merge and revert
+commits are allowed.
+
+Examples:
+
+```text
+feat(tasks): add docs backfill task
+fix(config): preserve default budget limit
+docs: document provider calibration
+```
+
+To use the commit message template:
+
+```bash
+git config commit.template .gitmessage
+```
 
 To bypass in a pinch: `git commit --no-verify`
 

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+# Install: make install-hooks  (or: ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "commit-msg: missing commit message file"
+  exit 1
+fi
+
+MSG_FILE=$1
+if [[ ! -f "$MSG_FILE" ]]; then
+  echo "commit-msg: message file not found: $MSG_FILE"
+  exit 1
+fi
+
+SUBJECT=$(sed -n '/^[[:space:]]*#/d; /^[[:space:]]*$/d; {p; q;}' "$MSG_FILE")
+
+fail() {
+  echo "commit-msg: invalid subject"
+  echo "  found: ${SUBJECT:-<empty>}"
+  echo "  want:  type(scope): description"
+  echo "  types: build chore ci docs feat fix perf refactor style test"
+  echo "  rules: <=72 chars, non-empty description; merge/revert allowed"
+  exit 1
+}
+
+if [[ -z "$SUBJECT" ]]; then
+  fail
+fi
+
+if [[ "$SUBJECT" =~ ^Merge[[:space:]] ]] || [[ "$SUBJECT" =~ ^Revert[[:space:]] ]]; then
+  exit 0
+fi
+
+if (( ${#SUBJECT} > 72 )); then
+  fail
+fi
+
+TYPE='(build|chore|ci|docs|feat|fix|perf|refactor|style|test)'
+SCOPE='(\([A-Za-z0-9._/#-]+\))?'
+
+if [[ ! "$SUBJECT" =~ ^${TYPE}${SCOPE}:[[:space:]][^[:space:]].* ]]; then
+  fail
+fi


### PR DESCRIPTION
## Detected convention

Recent history already mixes Conventional Commit subjects such as `fix:`, `feat(tasks):`, `docs:`, and `refactor:` with older free-form release commits. GoReleaser changelog filters also key off Conventional Commit prefixes for `docs:`, `test:`, `ci:`, and `chore:`, so this standardizes future commits on that format.

## Implementation

- Added a root `.gitmessage` template documenting `type(scope): description`, allowed types, 72-character subjects, body/trailer spacing, and examples.
- Added executable `scripts/commit-msg.sh` to validate the first real subject line, allow merge/revert commits, require an allowed Conventional Commit type with optional scope, require a non-empty description, and enforce the 72-character subject limit.
- Updated `make install-hooks` to install both pre-commit and commit-msg hooks.
- Documented the hook behavior and `git config commit.template .gitmessage` setup in README.

## Verification

- Manual commit-msg hook checks with temporary valid, invalid, merge, and revert message files.
- `make install-hooks`
- `go test ./...`
- Commit verified through installed pre-commit and commit-msg hooks.