### PR TITLE
docs: synthesize unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to nightshift are documented in this file.
 
+## [Unreleased]
+
+### Fixes
+- **Run project selection limits** — apply `--max-projects` after filtering projects already processed today so eligible pending projects are not skipped (#45)
+- **Mobile documentation navigation** — keep the sidebar visible when the mobile navbar switches to its secondary panel (#46)
+
+### Other
+- **Pre-commit quality checks** — add a gofmt, go vet, and go build hook with an install target and development docs (#44)
+
 ## [v0.3.4] - 2026-02-28
 
 ### Features


### PR DESCRIPTION
## Summary
- Adds an Unreleased changelog section for commits after v0.3.4.
- Covers PRs #44, #45, and #46 while excluding the existing v0.3.4 release-notes commit already represented in the changelog.

## Commit range
- Based on: v0.3.4..codex/lint-fix-linter-fixes
- Documented as unreleased because v0.3.4 is the latest repository tag.

## Verification
- git diff -- CHANGELOG.md
- go test ./...