### PR TITLE
docs: backfill CLI reference gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ npm install -g @github/copilot
 curl -fsSL https://gh.io/copilot-install | bash
 ```
 
-Requires GitHub Copilot subscription. See [docs/COPILOT_INTEGRATION.md](docs/COPILOT_INTEGRATION.md) for details.
+Requires GitHub Copilot subscription. See the [Integrations docs](https://nightshift.haplab.com/docs/integrations) for details.
 
 If you prefer API-based usage, you can authenticate Claude and Codex CLIs with API keys instead.
 
@@ -200,7 +200,7 @@ Nightshift uses YAML config files to define:
 
 Run `nightshift setup` to create/update the global config at `~/.config/nightshift/config.yaml`.
 
-See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) or [SPEC.md](docs/SPEC.md) for detailed options.
+See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) for detailed options.
 
 Minimal example:
 

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -10,15 +10,43 @@ title: CLI Reference
 | Command | Description |
 |---------|-------------|
 | `nightshift setup` | Guided global configuration |
+| `nightshift init` | Create project or global configuration files |
 | `nightshift run` | Execute scheduled tasks |
 | `nightshift preview` | Show upcoming runs |
 | `nightshift budget` | Check token budget status |
 | `nightshift task` | Browse and run tasks |
+| `nightshift config` | View, update, and validate configuration |
 | `nightshift doctor` | Check environment health |
 | `nightshift status` | View run history |
 | `nightshift logs` | Stream or export logs |
 | `nightshift stats` | Token usage statistics |
+| `nightshift report` | Show structured run reports |
+| `nightshift busfactor` | Analyze code ownership concentration |
 | `nightshift daemon` | Background scheduler |
+| `nightshift install` | Install a launchd, systemd, or cron service |
+| `nightshift uninstall` | Remove the installed system service |
+| `nightshift completion` | Generate shell completion scripts |
+| `nightshift help` | Show command help |
+
+## Setup and Configuration Commands
+
+```bash
+nightshift setup                  # Guided onboarding wizard
+nightshift init                   # Create ./nightshift.yaml
+nightshift init --global          # Create ~/.config/nightshift/config.yaml
+nightshift init --force           # Overwrite an existing config without prompting
+
+nightshift config                 # Show merged global + project config
+nightshift config get budget.max_percent
+nightshift config get providers.claude.enabled
+nightshift config set budget.max_percent 75
+nightshift config set logging.level debug --global
+nightshift config validate
+```
+
+`nightshift init` is the quick file generator. `nightshift setup` is the guided wizard for provider configuration, project selection, budget calibration, and daemon setup.
+
+`nightshift config set` writes to the project config when one exists; otherwise it writes to the global config. Use `--global` to force a global write.
 
 ## Run Options
 
@@ -69,8 +97,11 @@ nightshift task list --category pr
 nightshift task list --cost low --json
 nightshift task show lint-fix
 nightshift task show lint-fix --prompt-only
-nightshift task run lint-fix --provider claude
+nightshift task show lint-fix --project ~/code/myapp
+nightshift task run lint-fix --provider claude --project ~/code/myapp
 nightshift task run lint-fix --provider codex --dry-run
+nightshift task run lint-fix --provider copilot --timeout 45m
+nightshift task run lint-fix --provider codex --branch main
 ```
 
 ## Budget Commands
@@ -83,10 +114,83 @@ nightshift budget history -n 10
 nightshift budget calibrate
 ```
 
+## Reports, Logs, and Stats
+
+```bash
+nightshift status                 # Last 5 runs
+nightshift status --today         # Today's activity summary
+nightshift status -n 10
+
+nightshift report                 # Polished overview for last night
+nightshift report --period last-run
+nightshift report --period last-7d --runs 0
+nightshift report --since "2026-05-01" --until "2026-05-04 09:00"
+nightshift report --report tasks --format markdown
+nightshift report --format json --paths
+
+nightshift logs                   # Last 50 log lines
+nightshift logs --follow
+nightshift logs --level warn --component orchestrator
+nightshift logs --since "2026-05-01" --summary
+nightshift logs --export ./nightshift-logs.jsonl
+
+nightshift stats                  # Aggregate statistics
+nightshift stats --period last-7d
+nightshift stats --json
+```
+
+## Daemon and Service Commands
+
+```bash
+nightshift daemon start
+nightshift daemon start --foreground
+nightshift daemon stop
+nightshift daemon status
+
+nightshift install                # Auto-detect launchd, systemd, or cron
+nightshift install launchd        # macOS LaunchAgent
+nightshift install systemd        # Linux user service + timer
+nightshift install cron           # Managed crontab entry
+nightshift uninstall              # Remove the installed service
+```
+
+`nightshift install` uses the configured schedule when available and falls back to a daily 2 AM run when no config exists.
+
+## Analysis Commands
+
+```bash
+nightshift busfactor
+nightshift busfactor ~/code/myapp
+nightshift busfactor --path ~/code/myapp --json
+nightshift busfactor --since 2026-01-01 --until 2026-05-01
+nightshift busfactor --file internal/orchestrator --save
+nightshift busfactor --db ~/.local/share/nightshift/nightshift.db
+```
+
+`busfactor` requires a Git repository. It reports contributor concentration, Herfindahl index, Gini coefficient, and risk level.
+
+## Help and Completion
+
+Nightshift includes Cobra's built-in help and completion commands:
+
+```bash
+nightshift --help
+nightshift run --help
+nightshift help task run
+nightshift --version
+
+nightshift completion bash
+nightshift completion zsh
+nightshift completion fish
+nightshift completion powershell
+```
+
 ## Global Flags
 
 | Flag | Description |
 |------|-------------|
 | `--verbose` | Verbose output |
-| `--provider` | Select provider (claude, codex) |
-| `--timeout` | Execution timeout (default 30m) |
+| `--help`, `-h` | Show help for a command |
+| `--version`, `-v` | Print the Nightshift version |
+
+Provider and timeout flags are command-specific. For example, `--provider` and `--timeout` are used by `nightshift task run`.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,7 +15,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Reference',
-      items: ['cli-reference', 'integrations'],
+      items: ['cli-reference', 'integrations', 'troubleshooting'],
     },
   ],
 };


### PR DESCRIPTION
## Summary
- Backfills CLI reference coverage for init, config, report/logs/stats, service install/uninstall, busfactor, and Cobra help/completion commands.
- Corrects README links that pointed at missing local docs and keeps README pointed at the canonical website docs.
- Adds the existing troubleshooting page to the docs sidebar for discoverability.

## Assumptions
- Scope is user-facing CLI documentation/navigation only; no code behavior changes.
- `website/docs/cli-reference.md` remains the canonical CLI reference.

## Verification
- `git diff --check`
- `go test ./...`
- `npm --prefix website run build`
- pre-commit hook: `go vet`, `go build`
