### PR TITLE
chore(tasks): standardize commit guidance

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -24,6 +24,7 @@ import (
 const (
 	DefaultMaxIterations = 3
 	DefaultAgentTimeout  = 30 * time.Minute
+	nightshiftRef        = "https://github.com/marcus/nightshift"
 )
 
 // TaskStatus represents the outcome of task execution.
@@ -711,6 +712,10 @@ func (o *Orchestrator) PlanPrompt(task *tasks.Task) string {
 	return o.buildPlanPrompt(task)
 }
 
+func commitMessageGuidance(taskType tasks.TaskType) string {
+	return fmt.Sprintf("write a concise, imperative subject. Use the repo's existing convention, including `type(scope): summary` when supported. Add an optional body only when rationale is useful. Include these required trailers:\n   Nightshift-Task: %s\n   Nightshift-Ref: %s", taskType, nightshiftRef)
+}
+
 func (o *Orchestrator) buildPlanPrompt(task *tasks.Task) string {
 	branchInstruction := ""
 	if o.runMeta != nil && o.runMeta.Branch != "" {
@@ -728,9 +733,7 @@ Description: %s
 0. You are running autonomously. If the task is broad or ambiguous, choose a concrete, minimal scope that delivers value and state any assumptions in the description.
 1. Work on a new branch and plan to submit a PR. Never work directly on the primary branch.%s
 2. Before creating your branch, record the current branch name and plan to switch back after the PR is opened.
-3. If you create commits, include a concise message with these git trailers:
-   Nightshift-Task: %s
-   Nightshift-Ref: https://github.com/marcus/nightshift
+3. If you create commits, %s
 4. Analyze the task requirements
 5. Identify files that need to be modified
 6. Create step-by-step implementation plan
@@ -741,7 +744,7 @@ Description: %s
   "files": ["file1.go", "file2.go", ...],
   "description": "overall approach"
 }
-`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, branchInstruction, commitMessageGuidance(task.Type))
 }
 
 func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, iteration int) string {
@@ -771,9 +774,7 @@ Description: %s
 ## Instructions
 0. Before creating your branch, record the current branch name. Create and work on a new branch. Never modify or commit directly to the primary branch.%s
    When finished, open a PR. After the PR is submitted, switch back to the original branch. If you cannot open a PR, leave the branch and explain next steps.
-1. If you create commits, include a concise message with these git trailers:
-   Nightshift-Task: %s
-   Nightshift-Ref: https://github.com/marcus/nightshift
+1. If you create commits, %s
 2. Implement the plan step by step
 3. Make all necessary code changes
 4. Ensure tests pass
@@ -783,7 +784,7 @@ Description: %s
   "files_modified": ["file1.go", ...],
   "summary": "what was done"
 }
-`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, commitMessageGuidance(task.Type))
 }
 
 func (o *Orchestrator) buildReviewPrompt(task *tasks.Task, impl *ImplementOutput) string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -430,6 +430,7 @@ func TestBuildPrompts(t *testing.T) {
 		ID:          "prompt-test",
 		Title:       "Build Prompts",
 		Description: "Test prompt generation",
+		Type:        tasks.TaskCommitNormalize,
 	}
 
 	// Test plan prompt
@@ -440,6 +441,7 @@ func TestBuildPrompts(t *testing.T) {
 	if !containsIgnoreCase(planPrompt, "prompt-test") {
 		t.Error("plan prompt should contain task ID")
 	}
+	assertCommitMessageGuidance(t, planPrompt, task.Type)
 
 	// Test implement prompt
 	plan := &PlanOutput{
@@ -450,6 +452,7 @@ func TestBuildPrompts(t *testing.T) {
 	if !containsIgnoreCase(implPrompt, "implementation") {
 		t.Error("implement prompt should mention implementation")
 	}
+	assertCommitMessageGuidance(t, implPrompt, task.Type)
 
 	// Test implement prompt iteration 2
 	implPrompt2 := o.buildImplementPrompt(task, plan, 2)
@@ -465,6 +468,69 @@ func TestBuildPrompts(t *testing.T) {
 	reviewPrompt := o.buildReviewPrompt(task, impl)
 	if !containsIgnoreCase(reviewPrompt, "review") {
 		t.Error("review prompt should mention review")
+	}
+}
+
+func TestPromptsIncludeCommitGuidanceWithBranchMetadata(t *testing.T) {
+	o := New()
+	o.SetRunMetadata(&RunMetadata{Branch: "develop"})
+
+	task := &tasks.Task{
+		ID:          "commit-normalize:/repo",
+		Title:       "Commit Message Normalizer",
+		Description: "Standardize commit message format",
+		Type:        tasks.TaskCommitNormalize,
+	}
+	plan := &PlanOutput{
+		Steps:       []string{"inspect history", "update prompts"},
+		Description: "Normalize future Nightshift-generated commit guidance",
+	}
+
+	tests := []struct {
+		name       string
+		prompt     string
+		branchWant string
+	}{
+		{
+			name:       "plan",
+			prompt:     o.buildPlanPrompt(task),
+			branchWant: "Create your feature branch from `develop`.",
+		},
+		{
+			name:       "implement",
+			prompt:     o.buildImplementPrompt(task, plan, 1),
+			branchWant: "Checkout `develop` before creating your feature branch.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(tt.prompt, tt.branchWant) {
+				t.Errorf("prompt missing branch instruction %q\nGot:\n%s", tt.branchWant, tt.prompt)
+			}
+			assertCommitMessageGuidance(t, tt.prompt, task.Type)
+		})
+	}
+}
+
+func assertCommitMessageGuidance(t *testing.T, prompt string, taskType tasks.TaskType) {
+	t.Helper()
+
+	if !strings.Contains(prompt, commitMessageGuidance(taskType)) {
+		t.Errorf("prompt missing shared commit guidance\nGot:\n%s", prompt)
+	}
+
+	for _, want := range []string{
+		"concise, imperative subject",
+		"repo's existing convention",
+		"`type(scope): summary`",
+		"optional body",
+		"Nightshift-Task: " + string(taskType),
+		"Nightshift-Ref: https://github.com/marcus/nightshift",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\nGot:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -329,10 +329,13 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		DefaultInterval: 168 * time.Hour,
 	},
 	TaskCommitNormalize: {
-		Type:            TaskCommitNormalize,
-		Category:        CategoryPR,
-		Name:            "Commit Message Normalizer",
-		Description:     "Standardize commit message format",
+		Type:     TaskCommitNormalize,
+		Category: CategoryPR,
+		Name:     "Commit Message Normalizer",
+		Description: `Audit recent git history to infer the repository's commit message conventions.
+Document or align commit tooling and agent guidance when appropriate.
+Do not rewrite existing history unless explicitly requested.
+Ensure any new commits use the standard format, including required Nightshift trailers when Nightshift creates the commit.`,
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 24 * time.Hour,

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -240,6 +241,38 @@ func TestTaskDefinitionEstimatedTokens(t *testing.T) {
 	min, max := def.EstimatedTokens()
 	if min != 10_000 || max != 50_000 {
 		t.Errorf("TaskDefinition.EstimatedTokens() = (%d, %d), want (10000, 50000)", min, max)
+	}
+}
+
+func TestCommitNormalizeDefinition(t *testing.T) {
+	def, err := GetDefinition(TaskCommitNormalize)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskCommitNormalize) error: %v", err)
+	}
+
+	if def.Category != CategoryPR {
+		t.Errorf("Category = %d, want %d", def.Category, CategoryPR)
+	}
+	if def.CostTier != CostLow {
+		t.Errorf("CostTier = %d, want %d", def.CostTier, CostLow)
+	}
+	if def.RiskLevel != RiskLow {
+		t.Errorf("RiskLevel = %d, want %d", def.RiskLevel, RiskLow)
+	}
+	if def.DefaultInterval != 24*time.Hour {
+		t.Errorf("DefaultInterval = %v, want 24h", def.DefaultInterval)
+	}
+
+	for _, want := range []string{
+		"recent git history",
+		"commit message conventions",
+		"Document or align commit tooling and agent guidance",
+		"Do not rewrite existing history unless explicitly requested",
+		"required Nightshift trailers",
+	} {
+		if !strings.Contains(def.Description, want) {
+			t.Errorf("Description missing %q\nGot:\n%s", want, def.Description)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Centralize Nightshift commit-message guidance for planning and implementation prompts.
- Clarify commit-normalize metadata to audit recent history, align tooling/guidance, avoid history rewrites, and require trailers on new Nightshift commits.
- Add focused prompt and registry tests.

## Tests
- go test ./internal/orchestrator
- go test ./internal/tasks
- go test ./...

## Assumption
This standardizes future Nightshift-generated commit guidance and task metadata; it does not rewrite existing git history.


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/nightshift
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.4
cost-tier: Low (10-50k)
branch: codex/lint-fix-linter-fixes
iterations: 1
duration: 6m29s
run-started: 2026-05-06T03:01:36-07:00
nightshift:metadata -->
