### PR TITLE
docs: draft release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to nightshift are documented in this file.
 
+## [Unreleased]
+
+### Fixes
+- **Daily task selection limits** — apply `--max-projects` after filtering projects already processed today, so eligible projects are not skipped prematurely (#45)
+- **Mobile website navigation** — keep the mobile navbar sidebar above the secondary panel so navigation remains accessible (#46)
+
+### Other
+- **Pre-commit verification hook** — add a local hook and Makefile target for running gofmt, vet, and build checks before commits (#44)
+
 ## [v0.3.4] - 2026-02-28
 
 ### Features


### PR DESCRIPTION
Summary:
- Add an Unreleased changelog section for post-v0.3.4 changes.
- Preserve existing changelog style and PR references.

Validation:
- git diff --check
- commit pre-commit hook: go vet, go build

Notes:
- Docs-only CHANGELOG.md update; Go tests were skipped per plan because no non-doc files were touched.


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/marcus/code/nightshift
task-type: release-notes
task-title: Release Note Drafter
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: codex/lint-fix-linter-fixes
iterations: 1
duration: 6m41s
run-started: 2026-05-08T03:13:18-07:00
nightshift:metadata -->
