### PR TITLE
Clarify commit normalizer task

### DIFF
--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -332,7 +332,7 @@ Apply safe updates directly, and leave concise follow-ups for anything uncertain
 		Type:            TaskCommitNormalize,
 		Category:        CategoryPR,
 		Name:            "Commit Message Normalizer",
-		Description:     "Standardize commit message format",
+		Description:     "Infer the repository's existing commit convention, then document or enforce it with lightweight repo-local configuration when appropriate. Avoid rewriting published history; only normalize recent local commit messages when it is safe.",
 		CostTier:        CostLow,
 		RiskLevel:       RiskLow,
 		DefaultInterval: 24 * time.Hour,

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -240,6 +241,42 @@ func TestTaskDefinitionEstimatedTokens(t *testing.T) {
 	min, max := def.EstimatedTokens()
 	if min != 10_000 || max != 50_000 {
 		t.Errorf("TaskDefinition.EstimatedTokens() = (%d, %d), want (10000, 50000)", min, max)
+	}
+}
+
+func TestCommitNormalizeDefinition(t *testing.T) {
+	def, err := GetDefinition(TaskCommitNormalize)
+	if err != nil {
+		t.Fatalf("GetDefinition(TaskCommitNormalize) error: %v", err)
+	}
+
+	if def.Type != TaskCommitNormalize {
+		t.Errorf("Type = %q, want %q", def.Type, TaskCommitNormalize)
+	}
+	if def.Category != CategoryPR {
+		t.Errorf("Category = %d, want %d", def.Category, CategoryPR)
+	}
+	if def.CostTier != CostLow {
+		t.Errorf("CostTier = %d, want %d", def.CostTier, CostLow)
+	}
+	if def.RiskLevel != RiskLow {
+		t.Errorf("RiskLevel = %d, want %d", def.RiskLevel, RiskLow)
+	}
+	if def.DefaultInterval != 24*time.Hour {
+		t.Errorf("DefaultInterval = %v, want 24h", def.DefaultInterval)
+	}
+
+	requiredText := []string{
+		"existing commit convention",
+		"document or enforce",
+		"lightweight repo-local configuration",
+		"Avoid rewriting published history",
+		"only normalize recent local commit messages when it is safe",
+	}
+	for _, text := range requiredText {
+		if !strings.Contains(def.Description, text) {
+			t.Errorf("Description missing %q: %q", text, def.Description)
+		}
 	}
 }
 

--- a/website/docs/task-reference.md
+++ b/website/docs/task-reference.md
@@ -23,7 +23,7 @@ Fully formed, review-ready artifacts. These tasks create branches and open pull 
 | `backward-compat` | Backward-Compatibility Checks | Check and ensure backward compatibility | Medium | Low | 7d |
 | `build-optimize` | Build Time Optimization | Optimize build configuration for faster builds | High | Medium | 7d |
 | `docs-backfill` | Documentation Backfiller | Generate missing documentation | Low | Low | 7d |
-| `commit-normalize` | Commit Message Normalizer | Standardize commit message format | Low | Low | 24h |
+| `commit-normalize` | Commit Message Normalizer | Infer the repo's commit convention, document or lightly enforce it, and avoid unsafe history rewrites | Low | Low | 24h |
 | `changelog-synth` | Changelog Synthesizer | Generate changelog from commits | Low | Low | 7d |
 | `release-notes` | Release Note Drafter | Draft release notes from changes | Low | Low | 7d |
 | `adr-draft` | ADR Drafter | Draft Architecture Decision Records | Medium | Low | 7d |


### PR DESCRIPTION
## Summary
- Clarify the built-in commit-normalize task scope so agents infer the existing convention, use lightweight repo-local docs/config, and avoid unsafe history rewrites.
- Add focused registry coverage for commit-normalize metadata and required behavior text.
- Update task reference docs to match the clarified user-facing scope.

## Tests
- go test ./internal/tasks
- go test ./cmd/nightshift/commands -run 'Test.*Task'
- go test ./...


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 3.0
cost-tier: Low (10-50k)
iterations: 1
duration: 8m10s
run-started: 2026-05-09T02:00:02-04:00
nightshift:metadata -->
