### PR TITLE
docs: groom nightshift-release skill to match current codebase

### DIFF
--- a/.claude/skills/nightshift-release/SKILL.md
+++ b/.claude/skills/nightshift-release/SKILL.md
@@ -62,12 +62,26 @@ gh run watch           # watch the most recent run
 gh release view vX.Y.Z
 ```
 
+For a quick automated check, run the bundled helper — it confirms the
+release exists, all expected artifacts are present, and the latest
+release workflow run succeeded:
+
+```bash
+scripts/verify_release.sh vX.Y.Z
+```
+
 Check that:
 - The GitHub Actions run completed successfully.
 - The release on GitHub lists all expected artifacts (tar.gz for each OS/arch + checksums.txt).
 - The changelog was auto-generated and excludes docs/test/ci/chore commits.
 
-If the homebrew cask was configured, also verify `gh api repos/marcus/homebrew-tap/contents/Casks/nightshift.rb` returns the updated cask.
+The Homebrew formula is **not** published by goreleaser — `.goreleaser.yml`
+has no `brews`/`casks` section. The formula is manually maintained in
+`marcus/homebrew-tap` at `Formula/nightshift.rb` (it builds from source to
+avoid Gatekeeper warnings on macOS), and users install it via
+`brew install marcus/tap/nightshift`. After a release, update that formula
+by hand and confirm with
+`gh api repos/marcus/homebrew-tap/contents/Formula/nightshift.rb`.
 
 ### Troubleshooting
 
@@ -76,4 +90,4 @@ If the homebrew cask was configured, also verify `gh api repos/marcus/homebrew-t
 | `goreleaser check` fails | Fix `.goreleaser.yml` syntax per error message |
 | Snapshot builds but CI fails | Compare local Go version (`go version`) with `go.mod`; ensure `CGO_ENABLED=0` |
 | Release exists but missing artifacts | Re-run: delete the release (`gh release delete vX.Y.Z`), delete the tag (`git push --delete origin vX.Y.Z && git tag -d vX.Y.Z`), re-tag and push |
-| Homebrew tap not updated | Check `HOMEBREW_TAP_TOKEN` secret is set in repo settings |
+| Homebrew formula stale after release | The formula is not auto-published; manually update `Formula/nightshift.rb` in `marcus/homebrew-tap` |


### PR DESCRIPTION
## Summary

Audit of project-local agent skills, validating SKILL.md frontmatter and naming against the [Agent Skills spec](https://agentskills.io/specification.md) and cross-checking every file/script/path reference against the current codebase.

### Inventory
- `.claude/skills/` — one skill: `nightshift-release/` (SKILL.md + `scripts/verify_release.sh`)
- `.codex/skills/` — does not exist; nothing to groom there.

### Validated clean (no change)
- Frontmatter: `name: nightshift-release` is valid kebab-case, ≤64 chars, matches the directory; `description` present and well within 1024 chars; no disallowed keys.
- References: `cmd/nightshift/commands/root.go` `Version` var (currently `0.3.4`), `.goreleaser.yml`, `.github/workflows/release.yml`, and the `goreleaser check` / `release --snapshot --clean` commands all check out.

### Safe fixes applied
1. **Homebrew section corrected.** The skill described a "homebrew cask" at `Casks/nightshift.rb` auto-updated via `HOMEBREW_TAP_TOKEN`. `.goreleaser.yml` has no `brews`/`casks` section and explicitly notes the formula is manually maintained in `marcus/homebrew-tap` to build from source; README installs via `brew install marcus/tap/nightshift` (a formula). Updated the wording, the verification step, and the troubleshooting row to reflect a manually-maintained `Formula/nightshift.rb`.
2. **`scripts/verify_release.sh` wired in.** The bundled helper existed but was never referenced in the skill body — added it to the "Verify release" section.

### Follow-up (not changed — out of scope for skill grooming)
- `.github/workflows/release.yml` still passes `HOMEBREW_TAP_TOKEN` to goreleaser even though `.goreleaser.yml` no longer publishes to the tap. This looks like dead config; the maintainer should confirm and remove it if so. Left the workflow untouched.

Nightshift-Task: skill-groom
Nightshift-Ref: https://github.com/marcus/nightshift