### PR TITLE
ci: optimize build configuration for faster CI and release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Download dependencies
         run: go mod download
@@ -44,9 +46,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache Go build and module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-release-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-release-
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,17 @@
 BINARY=nightshift
 PKG=./cmd/nightshift
 
+# Build flags (match .goreleaser.yml for reproducible, cache-friendly artifacts)
+GO_BUILD_FLAGS=-trimpath
+LDFLAGS=-s -w
+
 # Build the binary
 build:
-	go build -o $(BINARY) $(PKG)
+	go build $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o $(BINARY) $(PKG)
 
 # Install the binary to your Go bin directory
 install:
-	go install $(PKG)
+	go install $(GO_BUILD_FLAGS) -ldflags="$(LDFLAGS)" $(PKG)
 	@echo "Installed $(BINARY) to $$(if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else echo "$$(go env GOPATH)/bin"; fi)"
 
 # Run provider calibration comparison tool


### PR DESCRIPTION
## Summary

Config-only build time optimization — no source changes. The biggest wins are in CI, where the toolchain version mismatch and unpinned tooling caused cache misses and re-downloads on every run.

## Changes

- **`ci.yml`** — `test` and `lint` jobs now use `go-version-file: go.mod` instead of a hardcoded `1.23`, so the CI toolchain matches the module's `go 1.24.0` requirement (the mismatch previously forced toolchain re-downloads and invalidated caches).
- **`ci.yml`** — explicit `setup-go` module/build caching enabled (`cache: true`, `cache-dependency-path: go.sum`).
- **`ci.yml`** — `golangci-lint` pinned to `v1.64.8` instead of `latest` for reproducible, cache-friendly lint runs (matches the locally installed version).
- **`release.yml`** — added an `actions/cache` step for `~/.cache/go-build` and `~/go/pkg/mod` before GoReleaser, which otherwise recompiles all 4 platform targets from scratch.
- **`Makefile`** — `build`/`install` targets gain `-trimpath` and `-s -w` ldflags via `GO_BUILD_FLAGS`/`LDFLAGS` variables, matching `.goreleaser.yml` for reproducible, cache-friendly local artifacts.

## Testing

- `make build` ✓
- `make test` ✓
- `go vet ./...` ✓
- pre-commit hook ✓

Nightshift-Task: build-optimize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)