### PR TITLE
feat(busfactor): per-directory breakdown and knowledge silo detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to nightshift are documented in this file.
 
+## [v0.3.4] - 2026-02-28
+
+### Features
+- **Configurable agent timeouts** — add `--timeout` to `nightshift run` and `nightshift daemon`, with daemon re-exec forwarding the flag (#27)
+- **Expanded PII scanner guidance** — add detailed instructions for detecting hardcoded PII, leaked env files, unsafe storage, and related exposure patterns in the built-in task (#34)
+
+### Fixes
+- **Timeout handling and diagnostics** — preserve partial output on timeout, terminate full process groups, and surface partial logs from failed plan/implement/review steps (#33)
+- **Copilot CLI integration** — improve binary resolution, permission gating, and CLI flag handling for Copilot runs (#39)
+- **Provider config YAML serialization** — write provider settings with the correct YAML keys during setup (#43)
+- **Configured run limits and budget fallback** — honor `schedule.max_projects` and `schedule.max_tasks`, improve budget calibration at day and week boundaries, and preserve Codex fallback permissions in headless runs (#42)
+
+### Other
+- **Task reference docs** — add a comprehensive reference page for all 59 built-in tasks and refresh related task documentation (#30)
+- **Docs cleanup** — remove auto-generated implementation docs from the repository (#40)
+- **Low-risk cleanup** — resolve Copilot helper lint warnings and replace `WriteString(fmt.Sprintf(...))` patterns with `fmt.Fprintf` in reporting and setup code (#38, #41)
+
 ## [v0.3.3] - 2026-02-19
 
 ### Features

--- a/cmd/nightshift/commands/busfactor.go
+++ b/cmd/nightshift/commands/busfactor.go
@@ -52,8 +52,10 @@ Metrics:
 		filePath, _ := cmd.Flags().GetString("file")
 		saveReport, _ := cmd.Flags().GetBool("save")
 		dbPath, _ := cmd.Flags().GetString("db")
+		perDirectory, _ := cmd.Flags().GetBool("per-directory")
+		roots, _ := cmd.Flags().GetStringSlice("roots")
 
-		return runBusFactor(path, jsonOutput, since, until, filePath, saveReport, dbPath)
+		return runBusFactor(path, jsonOutput, since, until, filePath, saveReport, dbPath, perDirectory, roots)
 	},
 }
 
@@ -65,10 +67,12 @@ func init() {
 	busFactorCmd.Flags().StringP("file", "f", "", "Analyze specific file or pattern")
 	busFactorCmd.Flags().Bool("save", false, "Save results to database")
 	busFactorCmd.Flags().String("db", "", "Database path (uses config if not set)")
+	busFactorCmd.Flags().Bool("per-directory", false, "Include per-component bus-factor breakdown and flag knowledge silos")
+	busFactorCmd.Flags().StringSlice("roots", []string{"cmd", "internal"}, "Top-level directories whose subdirectories form components (used with --per-directory)")
 	rootCmd.AddCommand(busFactorCmd)
 }
 
-func runBusFactor(path string, jsonOutput bool, since, until, filePath string, saveReport bool, dbPath string) error {
+func runBusFactor(path string, jsonOutput bool, since, until, filePath string, saveReport bool, dbPath string, perDirectory bool, roots []string) error {
 	logger := logging.Component("busfactor")
 
 	// Resolve path
@@ -124,6 +128,14 @@ func runBusFactor(path string, jsonOutput bool, since, until, filePath string, s
 	gen := analysis.NewReportGenerator()
 	component := filepath.Base(absPath)
 	report := gen.Generate(component, authors, metrics)
+
+	if perDirectory {
+		breakdown, err := analysis.AnalyzeComponents(absPath, roots, opts)
+		if err != nil {
+			return fmt.Errorf("analyzing components: %w", err)
+		}
+		report.ComponentBreakdown = breakdown
+	}
 
 	// Output results
 	if jsonOutput {

--- a/internal/analysis/analyzer.go
+++ b/internal/analysis/analyzer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -101,4 +103,38 @@ func RepositoryExists(path string) bool {
 	gitDir := strings.TrimSpace(path) + "/.git"
 	_, err := os.Stat(gitDir)
 	return err == nil
+}
+
+// ListComponentPaths returns the immediate subdirectories of each provided
+// root relative to repoPath, sorted alphabetically. Missing roots are silently
+// skipped so callers can pass an aspirational list (e.g. "cmd", "internal").
+// Paths are returned with forward slashes regardless of OS so they round-trip
+// cleanly through git pathspecs.
+func ListComponentPaths(repoPath string, roots []string) ([]string, error) {
+	var components []string
+	for _, root := range roots {
+		root = strings.Trim(strings.TrimSpace(root), "/")
+		if root == "" {
+			continue
+		}
+		entries, err := os.ReadDir(filepath.Join(repoPath, root))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("reading root %q: %w", root, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if strings.HasPrefix(name, ".") {
+				continue
+			}
+			components = append(components, root+"/"+name)
+		}
+	}
+	sort.Strings(components)
+	return components, nil
 }

--- a/internal/analysis/busfactor_components_test.go
+++ b/internal/analysis/busfactor_components_test.go
@@ -1,0 +1,172 @@
+package analysis
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListComponentPaths(t *testing.T) {
+	dir := t.TempDir()
+	for _, p := range []string{
+		"cmd/alpha",
+		"cmd/beta",
+		"internal/one",
+		"internal/two",
+		"internal/.hidden",
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+	// File at a root level — should be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "cmd", "README.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, err := ListComponentPaths(dir, []string{"cmd", "internal", "missing"})
+	if err != nil {
+		t.Fatalf("ListComponentPaths: %v", err)
+	}
+
+	want := []string{"cmd/alpha", "cmd/beta", "internal/one", "internal/two"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("index %d: want %q got %q", i, w, got[i])
+		}
+	}
+}
+
+func TestAnalyzeComponentsSortAndSilo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_DATE=2024-01-01T00:00:00Z",
+			"GIT_COMMITTER_DATE=2024-01-01T00:00:00Z",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	commit := func(name, email, path, content string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		runGit("add", path)
+		cmd := exec.Command("git",
+			"-c", "user.name="+name,
+			"-c", "user.email="+email,
+			"commit", "-m", "change "+path)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_DATE=2024-01-01T00:00:00Z",
+			"GIT_COMMITTER_DATE=2024-01-01T00:00:00Z",
+			"GIT_AUTHOR_NAME="+name,
+			"GIT_AUTHOR_EMAIL="+email,
+			"GIT_COMMITTER_NAME="+name,
+			"GIT_COMMITTER_EMAIL="+email,
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("commit: %v\n%s", err, out)
+		}
+	}
+
+	runGit("init", "-q", "-b", "main")
+
+	// internal/solo: single contributor → critical, knowledge silo.
+	commit("Solo", "solo@example.com", "internal/solo/file1.go", "package solo\n")
+	commit("Solo", "solo@example.com", "internal/solo/file2.go", "package solo\n")
+
+	// internal/shared: three contributors evenly distributed → bus factor 2.
+	commit("Alice", "alice@example.com", "internal/shared/a.go", "package shared\n")
+	commit("Bob", "bob@example.com", "internal/shared/b.go", "package shared\n")
+	commit("Carol", "carol@example.com", "internal/shared/c.go", "package shared\n")
+
+	results, err := AnalyzeComponents(dir, []string{"internal"}, ParseOptions{})
+	if err != nil {
+		t.Fatalf("AnalyzeComponents: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 components, got %d: %+v", len(results), results)
+	}
+
+	// Riskiest (solo) must come first.
+	if results[0].Path != "internal/solo" {
+		t.Errorf("expected internal/solo first, got %s", results[0].Path)
+	}
+	if !results[0].KnowledgeSilo {
+		t.Errorf("internal/solo should be flagged as knowledge silo")
+	}
+	if results[0].Metrics.RiskLevel != "critical" {
+		t.Errorf("internal/solo expected critical, got %s", results[0].Metrics.RiskLevel)
+	}
+
+	if results[1].Path != "internal/shared" {
+		t.Errorf("expected internal/shared second, got %s", results[1].Path)
+	}
+	if results[1].KnowledgeSilo {
+		t.Errorf("internal/shared should not be a silo (bus factor > 1)")
+	}
+}
+
+func TestRenderMarkdownWithComponentBreakdown(t *testing.T) {
+	authors := []CommitAuthor{
+		{Name: "Alice", Email: "alice@example.com", Commits: 60},
+		{Name: "Bob", Email: "bob@example.com", Commits: 40},
+	}
+	gen := NewReportGenerator()
+	report := gen.Generate("repo", authors, CalculateMetrics(authors))
+
+	soloAuthors := []CommitAuthor{{Name: "Solo", Email: "solo@example.com", Commits: 5}}
+	report.ComponentBreakdown = []ComponentMetrics{
+		{
+			Path:          "internal/solo",
+			Authors:       soloAuthors,
+			Metrics:       CalculateMetrics(soloAuthors),
+			KnowledgeSilo: true,
+		},
+		{
+			Path:          "internal/shared",
+			Authors:       authors,
+			Metrics:       CalculateMetrics(authors),
+			KnowledgeSilo: false,
+		},
+	}
+
+	md := gen.RenderMarkdown(report)
+	if !strings.Contains(md, "## Per-Component Bus Factor") {
+		t.Errorf("missing per-component section: %s", md)
+	}
+	if !strings.Contains(md, "`internal/solo`") {
+		t.Errorf("missing internal/solo row")
+	}
+	if !strings.Contains(md, "Knowledge silos detected: 1") {
+		t.Errorf("missing silo summary in: %s", md)
+	}
+
+	// Section must be absent when breakdown empty.
+	report2 := gen.Generate("repo", authors, CalculateMetrics(authors))
+	md2 := gen.RenderMarkdown(report2)
+	if strings.Contains(md2, "Per-Component Bus Factor") {
+		t.Errorf("per-component section should not appear when breakdown empty")
+	}
+}

--- a/internal/analysis/metrics.go
+++ b/internal/analysis/metrics.go
@@ -165,6 +165,66 @@ func assessRiskLevel(hIndex float64, top1Percent float64, numContributors int) s
 	return "low"
 }
 
+// ComponentMetrics summarizes ownership concentration for a single component
+// (typically a directory). It carries the calculated metrics, the authors used
+// to derive them, and a derived KnowledgeSilo flag set when a single
+// contributor would unilaterally take the component down.
+type ComponentMetrics struct {
+	Path          string            `json:"path"`
+	Authors       []CommitAuthor    `json:"authors,omitempty"`
+	Metrics       *OwnershipMetrics `json:"metrics"`
+	KnowledgeSilo bool              `json:"knowledge_silo"`
+}
+
+// AnalyzeComponents walks each immediate subdirectory of the supplied roots
+// (defaulting to "cmd" and "internal" when roots is empty) and computes
+// bus-factor metrics scoped to that directory's git history. Components with
+// no commits are skipped. The result is sorted by descending risk so the
+// caller can present the riskiest knowledge silos first.
+func AnalyzeComponents(repoPath string, roots []string, opts ParseOptions) ([]ComponentMetrics, error) {
+	if len(roots) == 0 {
+		roots = []string{"cmd", "internal"}
+	}
+	components, err := ListComponentPaths(repoPath, roots)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := NewGitParser(repoPath)
+	results := make([]ComponentMetrics, 0, len(components))
+	for _, comp := range components {
+		compOpts := opts
+		compOpts.FilePath = comp
+		authors, err := parser.ParseAuthors(compOpts)
+		if err != nil {
+			return nil, fmt.Errorf("analyzing %s: %w", comp, err)
+		}
+		if len(authors) == 0 {
+			continue
+		}
+		m := CalculateMetrics(authors)
+		results = append(results, ComponentMetrics{
+			Path:          comp,
+			Authors:       authors,
+			Metrics:       m,
+			KnowledgeSilo: m.BusFactor <= 1,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		ri := RiskLevelScore(results[i].Metrics.RiskLevel)
+		rj := RiskLevelScore(results[j].Metrics.RiskLevel)
+		if ri != rj {
+			return ri > rj
+		}
+		if results[i].Metrics.BusFactor != results[j].Metrics.BusFactor {
+			return results[i].Metrics.BusFactor < results[j].Metrics.BusFactor
+		}
+		return results[i].Path < results[j].Path
+	})
+	return results, nil
+}
+
 // RiskLevelScore returns a numeric score (0-100) for the risk level.
 func RiskLevelScore(level string) int {
 	switch level {

--- a/internal/analysis/report.go
+++ b/internal/analysis/report.go
@@ -9,12 +9,13 @@ import (
 
 // Report represents a bus-factor analysis report for a codebase or component.
 type Report struct {
-	Timestamp       time.Time         `json:"timestamp"`
-	Component       string            `json:"component"` // "overall", "dir/path", etc
-	Metrics         *OwnershipMetrics `json:"metrics"`
-	Contributors    []CommitAuthor    `json:"contributors"`
-	Recommendations []string          `json:"recommendations"`
-	ReportedAt      string            `json:"reported_at"`
+	Timestamp          time.Time          `json:"timestamp"`
+	Component          string             `json:"component"` // "overall", "dir/path", etc
+	Metrics            *OwnershipMetrics  `json:"metrics"`
+	Contributors       []CommitAuthor     `json:"contributors"`
+	Recommendations    []string           `json:"recommendations"`
+	ReportedAt         string             `json:"reported_at"`
+	ComponentBreakdown []ComponentMetrics `json:"component_breakdown,omitempty"`
 }
 
 // ReportGenerator creates formatted reports from analysis results.
@@ -141,6 +142,36 @@ func (rg *ReportGenerator) RenderMarkdown(report *Report) string {
 			}
 		}
 		buf.WriteString("\n")
+	}
+
+	// Per-component breakdown (only when populated)
+	if len(report.ComponentBreakdown) > 0 {
+		buf.WriteString("## Per-Component Bus Factor\n\n")
+		buf.WriteString("| Component | Contributors | Bus Factor | Top 1 % | Risk | Silo |\n")
+		buf.WriteString("|-----------|-------------:|-----------:|--------:|------|:----:|\n")
+		siloCount := 0
+		for _, c := range report.ComponentBreakdown {
+			if c.Metrics == nil {
+				continue
+			}
+			silo := ""
+			if c.KnowledgeSilo {
+				silo = "yes"
+				siloCount++
+			}
+			fmt.Fprintf(&buf, "| `%s` | %d | %d | %.1f%% | %s | %s |\n",
+				c.Path,
+				c.Metrics.TotalContributors,
+				c.Metrics.BusFactor,
+				c.Metrics.Top1Percent,
+				c.Metrics.RiskLevel,
+				silo,
+			)
+		}
+		buf.WriteString("\n")
+		if siloCount > 0 {
+			fmt.Fprintf(&buf, "**Knowledge silos detected: %d component(s) with bus factor of 1.**\n\n", siloCount)
+		}
 	}
 
 	// Risk explanation


### PR DESCRIPTION
## Summary
- Added `--per-directory` (and `--roots`, defaulting to `cmd,internal`) to `nightshift busfactor`. When set, the command walks each immediate subdirectory of the configured roots and computes ownership metrics scoped to that component's git history.
- Components with a bus factor of 1 are flagged as **knowledge silos** in both the markdown table and the JSON `component_breakdown` field, sorted with the riskiest entries first.
- Implementation lives in `internal/analysis` (new `ListComponentPaths`, `ComponentMetrics`, `AnalyzeComponents`) and `internal/analysis/report.go` (new `## Per-Component Bus Factor` table); only emitted when the breakdown is populated.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./internal/analysis/... ./cmd/nightshift/...`
- [x] `go run ./cmd/nightshift busfactor --per-directory .` — confirms 23 silos in this repo
- [x] `go run ./cmd/nightshift busfactor --per-directory --json .` — confirms `component_breakdown` is populated


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: bus-factor:/Users/marcus/code/nightshift
task-type: bus-factor
task-title: Bus-Factor Analyzer
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
branch: codex/lint-fix-linter-fixes
iterations: 1
duration: 7m13s
run-started: 2026-05-15T02:28:00-07:00
nightshift:metadata -->
