### PR TITLE
[codex] Align CI Go version with go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Download dependencies
         run: go mod download
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
## Summary
- switch both CI `actions/setup-go` steps to `go-version-file: 'go.mod'`
- remove the stale hardcoded Go 1.23 pin so CI tracks the module's declared Go version

## Root cause
`go.mod` now requires Go 1.24.0, but `.github/workflows/ci.yml` still configured Go 1.23. Reproducing with a 1.23 toolchain fails immediately during dependency resolution because the module requires a newer Go version.

## Validation
- `make lint`
- `gofmt -l $(git ls-files '*.go')`
- `go test ./...`


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/
task-type: lint-fix
task-title: Linter Fixes
provider: codex
score: 0.1
cost-tier: Low (10-50k)
iterations: 1
duration: 13m51s
run-started: 2026-05-25T02:00:02-04:00
nightshift:metadata -->
