### PR TITLE
fix(lint): replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -370,7 +370,7 @@ func printStruct(v reflect.Value, indent int) {
 		case reflect.Struct:
 			fmt.Printf("%s%s:\n", prefix, tag)
 			printStruct(value, indent+1)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !value.IsNil() {
 				if value.Elem().Kind() == reflect.Struct {
 					fmt.Printf("%s%s:\n", prefix, tag)
@@ -408,7 +408,7 @@ func printStruct(v reflect.Value, indent int) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0


### PR DESCRIPTION
## Summary

Resolves the two `govet` `inline` findings reported by `golangci-lint` by replacing the deprecated `reflect.Ptr` (deprecated since Go 1.18) with its identical-semantics successor `reflect.Pointer`.

Purely mechanical, no behavior change.

## Changes

Single file, two call sites in `cmd/nightshift/commands/config.go`:

- line 373: `case reflect.Ptr:` → `case reflect.Pointer:`
- line 411: `case reflect.Ptr, reflect.Interface:` → `case reflect.Pointer, reflect.Interface:`

`reflect.Ptr` cannot be autofixed by `golangci-lint --fix`, so these edits are manual.

## Before / after

| Check | Before | After |
| --- | --- | --- |
| `golangci-lint run ./...` | 2 issues (govet/inline) | **0 issues** |
| `gofmt -l .` | clean | clean |
| `go vet ./...` | clean | clean |
| `go build ./...` | pass | pass |
| `go test ./...` | pass | pass |

---
Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:.
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 3.0
cost-tier: Low (10-50k)
iterations: 1
duration: 20m36s
run-started: 2026-06-22T02:00:00+02:00
nightshift:metadata -->
