### PR TITLE
feat: add commit message normalizer (library + commit-normalize subcommand)

### DIFF
--- a/cmd/nightshift/commands/commit_normalize.go
+++ b/cmd/nightshift/commands/commit_normalize.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/normalizer"
+)
+
+var commitNormalizeCmd = &cobra.Command{
+	Use:   "commit-normalize",
+	Short: "Normalize a commit message",
+	Long: `Standardize a Conventional Commits message.
+
+Reads a commit message from a file path argument, --file, or stdin and
+prints the normalized message. The subject is lowercased, trailing periods
+are stripped, a blank line separates the subject and body, the type(scope):
+shape is enforced, and body paragraphs are wrapped at 100 columns.
+
+Warnings (e.g. an oversized or untyped subject) are printed to stderr.
+Exits non-zero if the input is empty or cannot be read.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fileFlag, _ := cmd.Flags().GetString("file")
+		return runCommitNormalize(cmd, args, fileFlag)
+	},
+}
+
+func init() {
+	commitNormalizeCmd.Flags().String("file", "", "Read the commit message from a file (use - for stdin)")
+	rootCmd.AddCommand(commitNormalizeCmd)
+}
+
+func runCommitNormalize(cmd *cobra.Command, args []string, fileFlag string) error {
+	data, err := readCommitMessage(args, fileFlag)
+	if err != nil {
+		return err
+	}
+
+	result, err := normalizer.Normalize(string(data))
+	if err != nil {
+		return err
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), result.Message)
+	return nil
+}
+
+// readCommitMessage resolves the message source: a positional file path takes
+// precedence, then --file, then stdin when no source is given.
+func readCommitMessage(args []string, fileFlag string) ([]byte, error) {
+	switch {
+	case len(args) == 1:
+		return readMessageSource(args[0])
+	case fileFlag != "":
+		return readMessageSource(fileFlag)
+	default:
+		return io.ReadAll(os.Stdin)
+	}
+}
+
+// readMessageSource reads from path, or from stdin when path is "-".
+func readMessageSource(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading commit message %s: %w", path, err)
+	}
+	return data, nil
+}

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -1,0 +1,195 @@
+// Package normalizer standardizes Conventional Commits messages.
+//
+// A normalized message has the shape:
+//
+//	type(scope): subject
+//
+//	<body paragraphs wrapped at 100 columns>
+//
+//	Footer-Key: value
+//
+// Normalization lowercases the subject line, strips trailing periods, collapses
+// stray whitespace, guarantees a single blank line between the subject and the
+// body, enforces the "type(scope)!?: subject" shape, and wraps body paragraphs
+// to at most 100 columns.
+package normalizer
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// SubjectLimit is the recommended maximum length of the subject line.
+	SubjectLimit = 72
+	// WrapLimit is the maximum column width for body paragraphs.
+	WrapLimit = 100
+)
+
+var (
+	// prefixRe captures a Conventional Commits type prefix — type, type(scope),
+	// type!, or type(scope)! — immediately followed by a colon.
+	prefixRe = regexp.MustCompile(`^([a-z]+)(?:\(([^)]+)\))?(!)?:`)
+	// footerRe matches a footer line: "Token: value" or "Token #123".
+	footerRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*:(?:\s.*)?$|^[A-Za-z][A-Za-z0-9_-]*\s#\d+$`)
+)
+
+// Result is a normalized commit message together with any non-fatal diagnostics.
+type Result struct {
+	// Message is the normalized commit message.
+	Message string
+	// Warnings describes non-fatal issues such as an oversized or untyped subject.
+	Warnings []string
+}
+
+// Normalize standardizes a Conventional Commits message. It returns an error
+// only when the input is empty; structural problems are reported as warnings so
+// callers can still emit the cleaned message.
+func Normalize(input string) (Result, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return Result{}, errors.New("commit message is empty")
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	subject, warnings := normalizeSubject(strings.TrimSpace(lines[0]))
+
+	body, footers := splitBody(strings.Join(lines[1:], "\n"))
+	body = wrapBody(body)
+
+	sections := []string{subject}
+	if body != "" {
+		sections = append(sections, body)
+	}
+	if footers != "" {
+		sections = append(sections, footers)
+	}
+
+	return Result{
+		Message:  strings.Join(sections, "\n\n"),
+		Warnings: warnings,
+	}, nil
+}
+
+// normalizeSubject lowercases the subject, strips trailing periods, and
+// normalizes the type(scope)!? shape. It returns the cleaned subject and any
+// warnings.
+func normalizeSubject(raw string) (string, []string) {
+	var warnings []string
+
+	// Lowercase the entire subject line per the normalization rules.
+	subject := strings.ToLower(strings.TrimSpace(raw))
+
+	if m := prefixRe.FindStringSubmatch(subject); m != nil {
+		// Rebuild a canonical "type(scope)!?: description".
+		typ, scope, breaking := m[1], m[2], m[3]
+		desc := strings.TrimRight(strings.TrimSpace(strings.TrimPrefix(subject, m[0])), ".")
+		subject = typ
+		if scope != "" {
+			subject += "(" + scope + ")"
+		}
+		subject += breaking + ":"
+		if desc != "" {
+			subject += " " + desc
+		}
+	} else {
+		warnings = append(warnings, `subject is missing a Conventional Commits type prefix (expected "type(scope): ...")`)
+		subject = strings.TrimRight(subject, ".")
+	}
+
+	if n := width(subject); n > SubjectLimit {
+		warnings = append(warnings, fmt.Sprintf("subject exceeds %d characters (got %d)", SubjectLimit, n))
+	}
+
+	return subject, warnings
+}
+
+// splitBody separates the body region into body paragraphs and a trailing footer
+// block. Footers ("Token: value" / "Token #123") are returned verbatim; the body
+// is returned as blank-line-separated paragraphs for later wrapping.
+func splitBody(region string) (body, footers string) {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return "", ""
+	}
+
+	paragraphs := splitParagraphs(region)
+
+	// A footer block is a contiguous run of trailing paragraphs whose lines all
+	// look like trailers.
+	i := len(paragraphs)
+	for i > 0 && allFooters(paragraphs[i-1]) {
+		i--
+	}
+
+	return strings.Join(paragraphs[:i], "\n\n"), strings.Join(paragraphs[i:], "\n\n")
+}
+
+// wrapBody word-wraps each blank-line-separated paragraph to WrapLimit columns.
+func wrapBody(body string) string {
+	if body == "" {
+		return ""
+	}
+	paragraphs := splitParagraphs(body)
+	wrapped := make([]string, 0, len(paragraphs))
+	for _, p := range paragraphs {
+		wrapped = append(wrapped, strings.Join(wrap(p, WrapLimit), "\n"))
+	}
+	return strings.Join(wrapped, "\n\n")
+}
+
+// wrap performs greedy word wrapping of text to at most limit columns.
+func wrap(text string, limit int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	lines := []string{words[0]}
+	for _, w := range words[1:] {
+		cur := lines[len(lines)-1]
+		if width(cur)+1+width(w) <= limit {
+			lines[len(lines)-1] = cur + " " + w
+		} else {
+			lines = append(lines, w)
+		}
+	}
+	return lines
+}
+
+// splitParagraphs splits text into paragraphs on blank lines, trimming trailing
+// whitespace from each line.
+func splitParagraphs(text string) []string {
+	var paragraphs, current []string
+	flush := func() {
+		if len(current) > 0 {
+			paragraphs = append(paragraphs, strings.Join(current, "\n"))
+			current = nil
+		}
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		current = append(current, strings.TrimRight(line, " \t\r"))
+	}
+	flush()
+	return paragraphs
+}
+
+// allFooters reports whether every non-blank line in paragraph matches footerRe.
+func allFooters(paragraph string) bool {
+	for _, line := range strings.Split(paragraph, "\n") {
+		if line = strings.TrimSpace(line); line != "" && !footerRe.MatchString(line) {
+			return false
+		}
+	}
+	return true
+}
+
+// width returns the rune count of s, the conventional measure of commit length.
+func width(s string) int {
+	return len([]rune(s))
+}

--- a/internal/normalizer/normalizer_test.go
+++ b/internal/normalizer/normalizer_test.go
@@ -1,0 +1,157 @@
+package normalizer
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantMsg  string
+		wantWarn []string // each substring must appear in some warning
+		wantErr  bool
+	}{
+		{
+			name:    "clean already-normalized message",
+			input:   "feat: add login",
+			wantMsg: "feat: add login",
+		},
+		{
+			name:    "lowercase subject and strip trailing period",
+			input:   "Fix: Add login.",
+			wantMsg: "fix: add login",
+		},
+		{
+			name:    "normalize scope and breaking marker",
+			input:   "Feat(Auth): Add OAuth support.",
+			wantMsg: "feat(auth): add oauth support",
+		},
+		{
+			name:     "missing type prefix warns and lowercases",
+			input:    "Update the README",
+			wantMsg:  "update the readme",
+			wantWarn: []string{"missing a Conventional Commits type prefix"},
+		},
+		{
+			name: "oversized subject warns",
+			input: "feat: this is an intentionally very long subject that obviously " +
+				"exceeds the seventy-two character guideline by a wide margin",
+			wantMsg: "feat: this is an intentionally very long subject that obviously " +
+				"exceeds the seventy-two character guideline by a wide margin",
+			wantWarn: []string{"subject exceeds 72 characters"},
+		},
+		{
+			name:    "trim trailing whitespace and blank lines",
+			input:   "Fix: Trim me.   \n\n  \n",
+			wantMsg: "fix: trim me",
+		},
+		{
+			name:    "insert blank line between subject and body",
+			input:   "feat: add login\nmore detail here\nand more",
+			wantMsg: "feat: add login\n\nmore detail here and more",
+		},
+		{
+			name:    "preserve subject, body, and footer",
+			input:   "fix: handle nil pointer in scheduler\n\nThe scheduler panicked when a run had no tasks.\n\nFixes #123",
+			wantMsg: "fix: handle nil pointer in scheduler\n\nThe scheduler panicked when a run had no tasks.\n\nFixes #123",
+		},
+		{
+			name:    "empty input errors",
+			input:   "   \n",
+			wantErr: true,
+		},
+		{
+			name:    "blank-only input errors",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Normalize(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Normalize(%q) error = nil, want error", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q) unexpected error: %v", tc.input, err)
+			}
+			if res.Message != tc.wantMsg {
+				t.Errorf("Normalize(%q) message =\n%q\nwant\n%q", tc.input, res.Message, tc.wantMsg)
+			}
+			for _, want := range tc.wantWarn {
+				if !warnContains(res.Warnings, want) {
+					t.Errorf("Normalize(%q) warnings %q, want one containing %q", tc.input, res.Warnings, want)
+				}
+			}
+			// Absence of expected warnings must be exact too.
+			if len(tc.wantWarn) == 0 && len(res.Warnings) != 0 {
+				t.Errorf("Normalize(%q) warnings = %q, want none", tc.input, res.Warnings)
+			}
+		})
+	}
+}
+
+// TestNormalizeWrapsBody verifies body paragraphs are wrapped to at most WrapLimit
+// columns while preserving every word.
+func TestNormalizeWrapsBody(t *testing.T) {
+	paragraph := strings.Repeat("word ", 40) // a single 200-character run
+	res, err := Normalize("docs: rewrite readme\n\n" + paragraph)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(res.Message, "\n")
+	if lines[0] != "docs: rewrite readme" {
+		t.Fatalf("subject = %q, want %q", lines[0], "docs: rewrite readme")
+	}
+	if lines[1] != "" {
+		t.Fatalf("expected a blank line after the subject, got %q", lines[1])
+	}
+	for i, line := range lines[2:] {
+		if n := utf8.RuneCountInString(line); n > WrapLimit {
+			t.Errorf("body line %d is %d runes, want <= %d", i, n, WrapLimit)
+		}
+	}
+	if got := strings.Count(res.Message, "word"); got != 40 {
+		t.Errorf("preserved %d words, want 40", got)
+	}
+}
+
+// TestNormalizePreservesFooters verifies footer lines are not wrapped and remain
+// separated from the body by a blank line.
+func TestNormalizePreservesFooters(t *testing.T) {
+	footer := "Signed-off-by: A User with a Very Long Display Name <alongaddress@example.com>"
+	res, err := Normalize("chore: bump deps\n\n" + footer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(res.Message, "\n")
+	// Lines: [0] subject, [1] "", [2] footer (single line, not wrapped).
+	if len(lines) != 3 {
+		t.Fatalf("message has %d lines, want 3:\n%s", len(lines), res.Message)
+	}
+	if lines[1] != "" {
+		t.Errorf("expected blank line before footer, got %q", lines[1])
+	}
+	if lines[2] != footer {
+		t.Errorf("footer = %q, want %q", lines[2], footer)
+	}
+}
+
+// warnContains reports whether any warning contains substr.
+func warnContains(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds a Conventional Commits commit-message normalizer, exposed both as a reusable Go library (`internal/normalizer`) and as a `nightshift commit-normalize` subcommand.

## Normalization rules

- **Lowercase** the subject line.
- **Strip trailing periods** from the subject.
- **Trim** leading/trailing whitespace (overall and per line).
- **Separate subject and body** with exactly one blank line (inserted if missing).
- **Enforce the `type(scope)!?: subject` shape** — lowercases the type/scope, normalizes the colon-space and `!` breaking marker.
- **Wrap body paragraphs to <=100 columns** (greedy word wrap); footer lines (`Token: value` / `Token #123`) are left verbatim.
- **Warn** when the subject exceeds 72 characters or lacks a type prefix.

## CLI

`nightshift commit-normalize` reads a message from a positional file path, `--file`, or stdin, prints the normalized message to stdout, emits any warnings to stderr, and exits non-zero on empty/invalid input.

```
$ echo 'Fix: Add OAuth.' | nightshift commit-normalize
fix: add oauth
```

## Tests

Table-driven tests in `internal/normalizer/normalizer_test.go` cover: clean input, lowercase + period stripping, scope/breaking-marker normalization, missing type prefix, oversized subject, trailing-whitespace trimming, blank-line insertion, subject/body/footer structure, and empty-input errors. Additional tests assert body wrapping stays <=100 columns and that footers are not wrapped. `go build ./...`, `go vet`, and `go test ./...` all pass.

## Assumptions / notes

- The plan assumed the repo was empty and would be bootstrapped from scratch. In practice `marcus/nightshift` already contains a Go module, so this integrates into the existing module (`github.com/marcus/nightshift`) and follows the established cobra command pattern rather than running `go mod init` or rewriting `main.go`.
- "Lowercase the subject" is implemented literally: the entire subject line (type, scope, and description) is lowercased. If the project prefers to lowercase only the `type(scope)` prefix and preserve the description's casing, that is a one-line change.
- The 72-char subject limit and 100-col body wrap are exposed as `SubjectLimit` / `WrapLimit` constants.

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift
