### PR TITLE
feat(commits): Conventional Commits normalizer + commit-msg hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,13 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git hooks (pre-commit + commit-msg)"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git hooks (pre-commit + commit-msg)
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+	@chmod +x scripts/commit-msg.sh
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/cmd/nightshift/commands/commit.go
+++ b/cmd/nightshift/commands/commit.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/marcus/nightshift/internal/commits"
+	"github.com/spf13/cobra"
+)
+
+var commitCmd = &cobra.Command{
+	Use:   "commit",
+	Short: "Conventional Commits helpers",
+	Long: `Tools for working with Conventional Commits messages.
+
+Use "commit normalize" to validate and reformat a commit message so it
+follows the project's rules (type prefix, lowercase type, subject length,
+and wrapped body).`,
+}
+
+var commitNormalizeCmd = &cobra.Command{
+	Use:   "normalize [MESSAGE]",
+	Short: "Normalize a commit message to Conventional Commits format",
+	Long: `Validate and rewrite a commit message into canonical Conventional
+Commits form.
+
+The message is read from a positional argument, from a file passed via
+--file (typically .git/COMMIT_EDITMSG by a commit-msg hook), or from stdin
+when no argument and no --file are given.
+
+  nightshift commit normalize "feat: add login"
+  nightshift commit normalize --file .git/COMMIT_EDITMSG
+  git log -1 --pretty=%B | nightshift commit normalize
+
+By default the normalized message is written to stdout. Pass --check to
+validate only: nothing is written to stdout, and the exit code is non-zero
+when the message does not conform.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		check, _ := cmd.Flags().GetBool("check")
+		file, _ := cmd.Flags().GetString("file")
+
+		raw, err := readCommitMessage(args, file)
+		if err != nil {
+			return err
+		}
+
+		normalized, err := commits.Normalize(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return err
+		}
+
+		if check {
+			// Validate only: do not rewrite or emit the message. A single
+			// confirmation line on stdout keeps the success path observable
+			// for callers that do not capture stderr.
+			fmt.Fprintln(os.Stdout, "ok")
+			return nil
+		}
+		fmt.Fprintln(os.Stdout, normalized)
+		return nil
+	},
+}
+
+func init() {
+	commitNormalizeCmd.Flags().BoolP("check", "c", false, "Only validate; do not rewrite (nothing is written to stdout)")
+	commitNormalizeCmd.Flags().StringP("file", "f", "", "Read the message from this file (used by the commit-msg hook)")
+	commitCmd.AddCommand(commitNormalizeCmd)
+	rootCmd.AddCommand(commitCmd)
+}
+
+// readCommitMessage resolves the message source in order: positional arg,
+// --file, then stdin.
+func readCommitMessage(args []string, file string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	if file != "" {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", file, err)
+		}
+		return string(b), nil
+	}
+	b, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(b), nil
+}

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -1,0 +1,56 @@
+# Commit Messages
+
+Nightshift uses [Conventional Commits](https://www.conventionalcommits.org/)
+for all commit messages. This keeps the history readable and lets tooling
+derive changelogs automatically.
+
+## Format
+
+```
+<type>[(<scope>)][!]: <subject>
+
+<body>
+```
+
+- **type** — one of `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
+  `chore`, `perf`, `build`, `ci`.
+- **scope** — optional, e.g. `fix(api): ...`.
+- **!** — optional breaking-change marker, placed immediately before the colon,
+  e.g. `feat!:` or `feat(api)!:` (Conventional Commits 1.0.0).
+- **subject** — lowercase, imperative mood, no trailing period, max 72 chars.
+- **body** — optional, wrapped at 72 columns, separated from the subject by a
+  blank line.
+
+## The `commit normalize` command
+
+Validate and reformat a message:
+
+```sh
+nightshift commit normalize "feat: add login screen"
+nightshift commit normalize --file .git/COMMIT_EDITMSG
+git log -1 --pretty=%B | nightshift commit normalize
+```
+
+By default the normalized message is written to stdout. Add `--check` to
+**validate only**: nothing is written to stdout (besides an `ok` confirmation),
+and the command exits non-zero when a message cannot be normalized (missing or
+unknown type, capitalized or overlong subject).
+
+```sh
+# non-zero exit if the message does not conform
+nightshift commit normalize --check --file .git/COMMIT_EDITMSG
+```
+
+## commit-msg hook
+
+To enforce the rules locally, install the hook:
+
+```sh
+make install-hooks
+# or manually:
+ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+```
+
+The hook normalizes your message file in place before the commit is created and
+rejects messages that cannot be fixed automatically. Bypass it with
+`git commit --no-verify`.

--- a/internal/commits/normalizer.go
+++ b/internal/commits/normalizer.go
@@ -1,0 +1,277 @@
+// Package commits implements Conventional Commits message normalization and
+// validation. It exposes pure, well-tested functions used by the CLI and by the
+// commit-msg git hook to keep the project's history consistent.
+//
+// The supported format follows the Conventional Commits 1.0.0 specification:
+//
+//	<type>[(<scope>)][!]: <subject>
+//
+//	<body>
+//
+// The optional trailing "!" before the colon marks a breaking change, as
+// defined by the specification (e.g. "feat!: ..." or "feat(api)!: ...").
+//
+// The normalizer is intentionally strict but constructive: rather than silently
+// accepting malformed input it fixes the trivially fixable (whitespace, type
+// casing, trailing punctuation, body wrapping) and rejects anything that needs
+// a human decision (missing type, unknown type, missing subject).
+package commits
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// MaxSubjectLength is the maximum number of runes allowed in a commit subject.
+const MaxSubjectLength = 72
+
+// BodyWrapWidth is the column at which the commit body is wrapped.
+const BodyWrapWidth = 72
+
+// allowedTypes is the set of Conventional Commit types this project accepts.
+var allowedTypes = map[string]struct{}{
+	"feat":     {},
+	"fix":      {},
+	"docs":     {},
+	"style":    {},
+	"refactor": {},
+	"test":     {},
+	"chore":    {},
+	"perf":     {},
+	"build":    {},
+	"ci":       {},
+}
+
+// Errors returned by the normalizer. They are wrapped so callers can match on
+// the underlying cause with errors.Is.
+var (
+	// ErrEmptyMessage is returned when the message contains no non-comment,
+	// non-whitespace content.
+	ErrEmptyMessage = errors.New("commit message is empty")
+	// ErrMissingType is returned when the subject line is not a Conventional
+	// Commit (no type prefix before the colon).
+	ErrMissingType = errors.New("commit message must start with a conventional commit type")
+	// ErrUnknownType is returned when the type prefix is not in the allowed set.
+	ErrUnknownType = errors.New("commit type is not in the allowed set")
+	// ErrMissingSubject is returned when the type prefix is present but no
+	// subject text follows the colon.
+	ErrMissingSubject = errors.New("commit subject is missing")
+	// ErrSubjectTooLong is returned when the subject exceeds MaxSubjectLength.
+	ErrSubjectTooLong = fmt.Errorf("commit subject exceeds %d characters", MaxSubjectLength)
+	// ErrSubjectCapitalized is returned when the subject starts with an
+	// uppercase letter (the rule is "do not capitalize the subject").
+	ErrSubjectCapitalized = errors.New("commit subject must not be capitalized")
+)
+
+// Normalize parses, validates, and rewrites a raw commit message so that it
+// conforms to the project's Conventional Commits rules. It returns the
+// canonical form and a non-nil error describing the first unrecoverable
+// problem when the message cannot be normalized.
+//
+// Normalization is idempotent: Normalize(Normalize(m)) == Normalize(m).
+func Normalize(msg string) (string, error) {
+	lines := stripComments(msg)
+	if len(lines) == 0 {
+		return "", ErrEmptyMessage
+	}
+
+	header := lines[0]
+	body := lines[1:]
+
+	typ, scope, breaking, subject, err := parseHeader(header)
+	if err != nil {
+		return "", err
+	}
+
+	subject = cleanSubject(subject)
+
+	var b strings.Builder
+	b.WriteString(formatHeader(typ, scope, breaking, subject))
+
+	wrapped := wrapBody(body, BodyWrapWidth)
+	if wrapped != "" {
+		b.WriteString("\n\n")
+		b.WriteString(wrapped)
+	}
+
+	return b.String(), nil
+}
+
+// stripComments removes git's commented-out lines (those beginning with "#"),
+// trims trailing whitespace from every line, and drops leading/trailing blank
+// lines. It returns the meaningful lines of the message.
+func stripComments(msg string) []string {
+	rawLines := strings.Split(msg, "\n")
+	out := make([]string, 0, len(rawLines))
+	for _, l := range rawLines {
+		l = strings.TrimRight(l, " \t\r")
+		if strings.HasPrefix(strings.TrimSpace(l), "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	// Drop leading and trailing blank lines.
+	for len(out) > 0 && strings.TrimSpace(out[0]) == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// parseHeader splits the first line into its Conventional Commit components and
+// validates them. The returned type is lower-cased to match the allowed set,
+// and the optional breaking-change "!" marker is detected and reported.
+func parseHeader(header string) (typ, scope string, breaking bool, subject string, err error) {
+	header = strings.TrimSpace(header)
+	colon := strings.Index(header, ":")
+	if colon <= 0 {
+		return "", "", false, "", ErrMissingType
+	}
+	prefix := header[:colon]
+	subject = strings.TrimSpace(header[colon+1:])
+
+	// A leading "(" with no type is not a valid conventional header.
+	prefix = strings.TrimSpace(prefix)
+	if strings.HasPrefix(prefix, "(") {
+		return "", "", false, "", ErrMissingType
+	}
+
+	// Detect the optional "!" breaking-change marker that immediately precedes
+	// the colon (Conventional Commits 1.0.0): "feat!:" or "feat(api)!:".
+	if strings.HasSuffix(prefix, "!") {
+		breaking = true
+		prefix = strings.TrimSuffix(prefix, "!")
+	}
+
+	// Split an optional "(scope)" from the type.
+	if open := strings.Index(prefix, "("); open > 0 && strings.HasSuffix(prefix, ")") {
+		typ = prefix[:open]
+		scope = prefix[open+1 : len(prefix)-1]
+	} else {
+		typ = prefix
+	}
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	scope = strings.TrimSpace(scope)
+
+	if typ == "" {
+		return "", "", false, "", ErrMissingType
+	}
+	if !isAllowedType(typ) {
+		return "", "", false, "", fmt.Errorf("%w: %q", ErrUnknownType, typ)
+	}
+	if strings.TrimSpace(subject) == "" {
+		return "", "", false, "", ErrMissingSubject
+	}
+	if utf8.RuneCountInString(subject) > MaxSubjectLength {
+		return "", "", false, "", ErrSubjectTooLong
+	}
+	if startsUpper(subject) {
+		return "", "", false, "", ErrSubjectCapitalized
+	}
+	return typ, scope, breaking, subject, nil
+}
+
+// cleanSubject normalizes the subject text. A leading uppercase letter is *not*
+// lower-cased here (capitalization is a hard error, not a fix); surrounding
+// whitespace and a trailing period are removed.
+func cleanSubject(subject string) string {
+	s := strings.TrimSpace(subject)
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+// formatHeader reassembles a canonical header line from its components,
+// re-emitting the breaking-change "!" marker when present.
+func formatHeader(typ, scope string, breaking bool, subject string) string {
+	var b strings.Builder
+	b.WriteString(typ)
+	if scope != "" {
+		b.WriteString("(")
+		b.WriteString(scope)
+		b.WriteString(")")
+	}
+	if breaking {
+		b.WriteString("!")
+	}
+	b.WriteString(": ")
+	b.WriteString(subject)
+	return b.String()
+}
+
+// wrapBody collapses runs of blank lines, preserves non-blank paragraphs, and
+// hard-wraps each paragraph line to width. Paragraph breaks (a single blank
+// line) are preserved.
+func wrapBody(body []string, width int) string {
+	var paragraphs [][]string
+	var cur []string
+	for _, l := range body {
+		if strings.TrimSpace(l) == "" {
+			if len(cur) > 0 {
+				paragraphs = append(paragraphs, cur)
+				cur = nil
+			}
+			continue
+		}
+		cur = append(cur, strings.TrimSpace(l))
+	}
+	if len(cur) > 0 {
+		paragraphs = append(paragraphs, cur)
+	}
+
+	var b strings.Builder
+	for i, p := range paragraphs {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(wrapParagraph(strings.Join(p, " "), width))
+	}
+	return b.String()
+}
+
+// wrapParagraph hard-wraps a single-line paragraph at width, breaking on word
+// boundaries. A word longer than width is left intact rather than split.
+func wrapParagraph(text string, width int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	lineLen := 0
+	for i, w := range words {
+		if i == 0 {
+			b.WriteString(w)
+			lineLen = utf8.RuneCountInString(w)
+			continue
+		}
+		if lineLen+1+utf8.RuneCountInString(w) <= width {
+			b.WriteByte(' ')
+			b.WriteString(w)
+			lineLen += 1 + utf8.RuneCountInString(w)
+		} else {
+			b.WriteByte('\n')
+			b.WriteString(w)
+			lineLen = utf8.RuneCountInString(w)
+		}
+	}
+	return b.String()
+}
+
+// isAllowedType reports whether typ is one of the accepted Conventional Commit
+// types.
+func isAllowedType(typ string) bool {
+	_, ok := allowedTypes[typ]
+	return ok
+}
+
+// startsUpper reports whether the first rune of s is an ASCII uppercase letter.
+func startsUpper(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return r >= 'A' && r <= 'Z'
+}

--- a/internal/commits/normalizer_test.go
+++ b/internal/commits/normalizer_test.go
@@ -1,0 +1,155 @@
+package commits
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "valid simple feat",
+			in:   "feat: add login screen",
+			want: "feat: add login screen",
+		},
+		{
+			name: "valid with scope",
+			in:   "fix(api): handle nil response",
+			want: "fix(api): handle nil response",
+		},
+		{
+			name: "breaking-change marker without scope",
+			in:   "feat!: redesign the public API",
+			want: "feat!: redesign the public API",
+		},
+		{
+			name: "breaking-change marker with scope",
+			in:   "feat(api)!: redesign the public API",
+			want: "feat(api)!: redesign the public API",
+		},
+		{
+			name: "breaking-change marker preserved with fix type",
+			in:   "fix!: stop crashing on nil input",
+			want: "fix!: stop crashing on nil input",
+		},
+		{
+			name: "trims surrounding whitespace and trailing period",
+			in:   "  docs: update README.  ",
+			want: "docs: update README",
+		},
+		{
+			name: "lowercases an uppercased type",
+			in:   "FEAT(ui): render button",
+			want: "feat(ui): render button",
+		},
+		{
+			name: "preserves body and wraps long lines",
+			in:   "feat: add thing\n\nthis is a body paragraph that is intentionally far longer than the configured wrap width so it must be hard wrapped onto multiple lines by the normalizer function",
+			want: "feat: add thing\n\n" +
+				"this is a body paragraph that is intentionally far longer than the\n" +
+				"configured wrap width so it must be hard wrapped onto multiple lines by\n" +
+				"the normalizer function",
+		},
+		{
+			name: "strips git comment lines",
+			in:   "chore: tidy\n# please enter the commit message\n\nbody here",
+			want: "chore: tidy\n\nbody here",
+		},
+		{
+			name:    "missing type rejected",
+			in:      "just a plain message",
+			wantErr: ErrMissingType,
+		},
+		{
+			name:    "unknown type rejected",
+			in:      "wip: halfway done",
+			wantErr: ErrUnknownType,
+		},
+		{
+			name:    "missing subject rejected",
+			in:      "feat:",
+			wantErr: ErrMissingSubject,
+		},
+		{
+			name:    "capitalized subject rejected",
+			in:      "feat: Add login screen",
+			wantErr: ErrSubjectCapitalized,
+		},
+		{
+			name:    "overlong subject rejected",
+			in:      "feat: " + strings.Repeat("a", MaxSubjectLength+1),
+			wantErr: ErrSubjectTooLong,
+		},
+		{
+			name:    "empty message rejected",
+			in:      "\n\n# only comments\n  \n",
+			wantErr: ErrEmptyMessage,
+		},
+		{
+			name:    "breaking marker with unknown type still rejected",
+			in:      "wip!: not allowed",
+			wantErr: ErrUnknownType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("Normalize(%q): expected error %v, got nil (result %q)", tc.in, tc.wantErr, got)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Normalize(%q): expected error to wrap %v, got %v", tc.in, tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Normalize(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeIdempotent(t *testing.T) {
+	cases := []string{
+		"feat: add login screen",
+		"feat!: redesign the public API",
+		"fix(api)!: handle nil response",
+		"fix(api): handle nil response\n\nLong body that explains the fix in more detail than the subject alone can manage so that we exercise the wrapping path too and then some more words here.",
+		"docs: update README\n\nfirst paragraph\n\nsecond paragraph stays separate",
+	}
+	for _, in := range cases {
+		once, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("first Normalize(%q) errored: %v", in, err)
+		}
+		twice, err := Normalize(once)
+		if err != nil {
+			t.Fatalf("second Normalize(%q) errored: %v", once, err)
+		}
+		if once != twice {
+			t.Errorf("not idempotent for %q\n once:  %q\n twice: %q", in, once, twice)
+		}
+	}
+}
+
+func TestAllowedTypes(t *testing.T) {
+	for _, typ := range []string{"feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"} {
+		if !isAllowedType(typ) {
+			t.Errorf("expected %q to be an allowed type", typ)
+		}
+	}
+	if isAllowedType("wip") {
+		t.Error("did not expect wip to be allowed")
+	}
+}

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+#
+# Enforces Conventional Commits on every commit message and rewrites the
+# message file into canonical form before the commit is created. Messages that
+# cannot be normalized (missing/unknown type, capitalized or overlong subject)
+# are rejected with a non-zero exit so the commit is aborted.
+#
+# Install:
+#   make install-hooks
+#   # or manually:
+#   ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+#   chmod +x scripts/commit-msg.sh
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: commit-msg <message-file>" >&2
+  exit 1
+fi
+
+MSG_FILE="$1"
+
+# Capture the normalizer's stderr in a private, unpredictable temp file so
+# concurrent commits cannot collide.
+ERR_FILE="$(mktemp -t nightshift-commit-msg.err.XXXXXX)"
+trap 'rm -f "$ERR_FILE"' EXIT
+
+# Resolve the nightshift binary: prefer the one on $PATH, fall back to
+# building the current source tree.
+NIGHTSHIFT="$(command -v nightshift || true)"
+if [[ -z "$NIGHTSHIFT" ]]; then
+  NIGHTSHIFT="go run github.com/marcus/nightshift/cmd/nightshift"
+fi
+
+NORMALIZED="$($NIGHTSHIFT commit normalize --file "$MSG_FILE" 2>"$ERR_FILE")"
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "🪡 commit-msg: message does not follow Conventional Commits" >&2
+  sed 's/^/    /' "$ERR_FILE" >&2 || true
+  echo "" >&2
+  echo "    Expected format: <type>(<scope>): <subject>" >&2
+  echo "    Types: feat fix docs style refactor test chore perf build ci" >&2
+  echo "    (rewrite your message, or bypass with: git commit --no-verify)" >&2
+  exit 1
+fi
+
+# Rewrite the message file into canonical form.
+printf '%s\n' "$NORMALIZED" > "$MSG_FILE"
+echo "🪡 commit-msg: normalized"
+exit 0


### PR DESCRIPTION
## Summary

Adds a reusable, dependency-free Conventional Commits message normalizer, exposed as `nightshift commit normalize` and backed by an installable `commit-msg` git hook.

This is iteration 2 of the commit-normalize task. It fixes the two defects found in review of the prior attempt:

1. **`--check` is no longer a no-op.** `--check` now validates only — it prints an `ok` confirmation instead of the rewritten message, and exits non-zero on validation failure. The default (no flag) path still prints the normalized message.
2. **Conventional Commits 1.0.0 breaking-change markers are accepted.** `feat!:` and `feat(api)!:` now parse, validate, and re-emit correctly instead of failing with "commit type is not in the allowed set".

## Changes

- `internal/commits/normalizer.go` — pure `Normalize` with table-driven validation (type set, scope, `!` marker, subject length/capitalization, comment stripping, trailing whitespace/period, 72-col body wrapping).
- `internal/commits/normalizer_test.go` — table-driven tests + idempotency, including the breaking-change marker cases.
- `cmd/nightshift/commands/commit.go` — `nightshift commit normalize [--check] [--file FILE] [MSG]`.
- `scripts/commit-msg.sh` — installable hook (rewrites the message file; rejects unfixable messages; uses `mktemp` for its scratch file).
- `docs/commit-messages.md` and `Makefile` (`install-hooks`) — docs + install wiring.

## Verification

- \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all pass; \`gofmt\` clean.
- Behavioral checks:
  - \`feat!: redesign api\` and \`feat(api)!: redesign api\` → normalized and preserved.
  - \`--check\` prints \`ok\` (exit 0); default prints the normalized message.
  - Invalid messages exit non-zero in both modes.

Closes the commit-normalize task.