### PR TITLE
fix: inline deprecated reflect.Ptr as reflect.Pointer

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -370,7 +370,7 @@ func printStruct(v reflect.Value, indent int) {
 		case reflect.Struct:
 			fmt.Printf("%s%s:\n", prefix, tag)
 			printStruct(value, indent+1)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !value.IsNil() {
 				if value.Elem().Kind() == reflect.Struct {
 					fmt.Printf("%s%s:\n", prefix, tag)
@@ -408,7 +408,7 @@ func printStruct(v reflect.Value, indent int) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0


### PR DESCRIPTION
## Summary

Automated linter fix from \`golangci-lint run --fix\` (govet \`inline\` analyzer).

- Replaces the deprecated \`reflect.Ptr\` constant with \`reflect.Pointer\` in \`cmd/nightshift/commands/config.go\` (2 occurrences).

## Scope

Minimal, safe, auto-fix-only. No manual logic changes; the two constants are the same value (one is the deprecated alias), so behavior is identical.

## Verification

- \`golangci-lint run\` → **0 issues** (was 2: govet \`inline\`)
- \`gofmt -l .\` → clean
- \`go build ./...\` → pass
- \`go test ./...\` → all packages pass

## Changed files

- \`cmd/nightshift/commands/config.go\`

---
Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift