### PR TITLE
docs: backfill user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ After installing, run the guided setup:
 nightshift setup
 ```
 
-This walks you through provider configuration, project selection, budget calibration, and daemon setup. Once complete you can preview what nightshift will do:
+This walks you through provider configuration, project selection, budget calibration, and daemon setup. It covers Claude, Codex, and Copilot, and checks for the provider CLIs on `PATH`. If you want a manual flow instead, use `nightshift init` for a project config, `nightshift init --global` for `~/.config/nightshift/config.yaml`, and `nightshift config validate` to verify the result.
+
+Once complete you can preview what nightshift will do:
 
 ```bash
 nightshift preview
@@ -72,6 +74,14 @@ nightshift preview --write ./nightshift-prompts
 # Guided global setup
 nightshift setup
 
+# Bootstrap or inspect config
+nightshift init
+nightshift init --global
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 15
+nightshift config validate
+
 # Check environment and config health
 nightshift doctor
 
@@ -95,6 +105,18 @@ nightshift task show lint-fix --prompt-only
 nightshift task run lint-fix --provider claude
 nightshift task run skill-groom --provider codex --dry-run
 nightshift task run lint-fix --provider codex --dry-run
+
+# Manage the scheduler and service lifecycle
+nightshift daemon start
+nightshift daemon start --foreground
+nightshift daemon start --timeout 45m
+nightshift daemon status
+nightshift daemon stop
+nightshift install
+nightshift install launchd
+nightshift install systemd
+nightshift install cron
+nightshift uninstall
 ```
 
 If `gum` is available, preview output is shown through the gum pager. Use `--plain` to disable.
@@ -115,6 +137,8 @@ daemon, CI) confirmation is auto-skipped.
 | `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
 | `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
 | `--ignore-budget` | `false` | Bypass budget checks (use with caution) |
+| `--branch`, `-b` | _(current branch)_ | Base branch for new feature branches |
+| `--timeout` | `30m` | Per-agent execution timeout |
 | `--yes`, `-y` | `false` | Skip the confirmation prompt |
 
 ```bash
@@ -138,6 +162,12 @@ nightshift run --ignore-budget
 
 # Target a specific project and task directly
 nightshift run -p ./my-project -t lint-fix
+
+# Base new branches off develop
+nightshift run --branch develop
+
+# Give agents more time
+nightshift run --timeout 45m
 ```
 
 Other useful flags:
@@ -146,20 +176,24 @@ Other useful flags:
 - `--category` — filter tasks by category (pr, analysis, options, safe, map, emergency)
 - `--cost` — filter by cost tier (low, medium, high, veryhigh)
 - `--prompt-only` — output just the raw prompt text for piping
-- `--provider` — required for `task run`, choose claude or codex
+- `--provider` — required for `task run`, choose claude, codex, or copilot
 - `--dry-run` — preview the prompt without executing
 - `--timeout` — execution timeout (default 30m)
 
-## Authentication (Subscriptions)
+## Provider Setup
 
 Nightshift supports three AI providers:
 - **Claude Code** - Anthropic's Claude via local CLI
-- **Codex** - OpenAI's GPT via local CLI  
-- **GitHub Copilot** - GitHub's Copilot via GitHub CLI
+- **Codex** - OpenAI's Codex via local CLI
+- **GitHub Copilot** - GitHub's Copilot via the standalone `copilot` binary or `gh copilot`
 
 ### Claude Code
 
 ```bash
+# Install (Node.js 18+)
+npm install -g @anthropic-ai/claude-code
+
+# Start Claude Code and complete the login flow
 claude
 /login
 ```
@@ -169,7 +203,14 @@ Supports Claude.ai subscriptions or Anthropic Console credentials.
 ### Codex
 
 ```bash
-codex --login
+# Install
+npm install -g @openai/codex
+
+# Sign in with ChatGPT in the browser
+codex login
+
+# Or use an OpenAI API key
+printenv OPENAI_API_KEY | codex login --with-api-key
 ```
 
 Supports signing in with ChatGPT or an API key.
@@ -177,13 +218,18 @@ Supports signing in with ChatGPT or an API key.
 ### GitHub Copilot
 
 ```bash
-# Install Copilot CLI
+# Standalone binary
 npm install -g @github/copilot
-# or
-curl -fsSL https://gh.io/copilot-install | bash
+copilot login
+
+# GitHub CLI route: authenticate, then let current gh install/run Copilot CLI
+gh auth login
+gh copilot -- --version
 ```
 
-Requires GitHub Copilot subscription. See [docs/COPILOT_INTEGRATION.md](docs/COPILOT_INTEGRATION.md) for details.
+Nightshift prefers the standalone `copilot` binary when it exists, otherwise it falls back to `gh copilot`. In this release the `gh` availability check expects `gh extension list` to contain `gh-copilot`; because GitHub retired that legacy extension, install the standalone CLI for reliable Nightshift execution. See the [installation guide](https://nightshift.haplab.com/docs/installation) for the compatibility details.
+
+If you use `gh copilot`, authenticate with `gh auth login` first.
 
 If you prefer API-based usage, you can authenticate Claude and Codex CLIs with API keys instead.
 
@@ -198,15 +244,17 @@ Nightshift uses YAML config files to define:
 - Task priorities
 - Schedule preferences
 
-Run `nightshift setup` to create/update the global config at `~/.config/nightshift/config.yaml`.
+Use `nightshift setup` for guided onboarding. Use `nightshift init` to create a project config in the current directory, or `nightshift init --global` to create `~/.config/nightshift/config.yaml`. `nightshift config` shows the merged configuration, `nightshift config get KEY` reads a value, `nightshift config set KEY VALUE` writes a value, and `nightshift config validate` checks both the global and project files.
 
-See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) or [SPEC.md](docs/SPEC.md) for detailed options.
+See the [full configuration docs](https://nightshift.haplab.com/docs/configuration) for detailed options.
 
 Minimal example:
 
 ```yaml
 schedule:
   cron: "0 2 * * *"
+  max_projects: 1
+  max_tasks: 1
 
 budget:
   mode: daily
@@ -219,20 +267,20 @@ budget:
 providers:
   preference:
     - claude
-    - codex
   claude:
     enabled: true
     data_path: "~/.claude"
-    dangerously_skip_permissions: true
+    dangerously_skip_permissions: false
   codex:
-    enabled: true
-    data_path: "~/.codex"
-    dangerously_bypass_approvals_and_sandbox: true
+    enabled: false
+  copilot:
+    enabled: false
 
 projects:
   - path: ~/code/sidecar
-  - path: ~/code/td
 ```
+
+Default provider order is `claude -> codex -> copilot`. For `nightshift run`, Nightshift walks that list and selects the first enabled provider whose CLI is discoverable and whose calculated allowance is positive. `nightshift task run` instead requires an explicit `--provider` and does not apply budget gating.
 
 Task selection:
 

--- a/website/docs/budget.md
+++ b/website/docs/budget.md
@@ -5,68 +5,107 @@ title: Budget
 
 # Budget Management
 
-Nightshift is designed to use tokens you'd otherwise waste. It tracks your remaining budget and never exceeds your configured limits.
-
-## Check Budget
+Nightshift converts provider usage into an allowance for each run. Use `nightshift budget` to see the resolved budget source, current usage, reserve deductions, predicted daytime use, and final allowance.
 
 ```bash
 nightshift budget
 nightshift budget --provider claude
 nightshift budget --provider codex
+nightshift budget --provider copilot
 ```
 
-## Configuration Options
+## Configuration
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `budget.mode` | string | `daily` | `daily` or `weekly` usage model |
-| `budget.max_percent` | int | `75` | Max % of budget per run |
-| `budget.reserve_percent` | int | `5` | Always keep this % in reserve |
-| `budget.billing_mode` | string | `subscription` | `subscription` or `api` |
-| `budget.calibrate_enabled` | bool | `true` | Enable subscription calibration via snapshots |
-| `budget.snapshot_interval` | duration | `30m` | Automatic snapshot cadence |
-| `budget.snapshot_retention_days` | int | `90` | Snapshot retention window |
-| `budget.week_start_day` | string | `monday` | Week boundary for calibration |
-| `budget.db_path` | string | `~/.local/share/nightshift/nightshift.db` | Override DB path |
+| Option | Default | Implemented behavior |
+|--------|---------|----------------------|
+| `budget.mode` | `daily` | `daily` or `weekly` allowance calculation |
+| `budget.max_percent` | `75` | Percentage applied to the available base; validation accepts `0` through `100`, and `0` is normalized back to `75` during calculation |
+| `budget.reserve_percent` | `5` | Percentage subtracted after applying `max_percent`; accepts `0` through `100` |
+| `budget.weekly_tokens` | `700000` | Fallback weekly token budget |
+| `budget.per_provider` | none | Provider-specific value replacing `weekly_tokens` |
+| `budget.aggressive_end_of_week` | `false` | Enables the weekly-mode end-of-period multiplier |
+| `budget.billing_mode` | `subscription` | `subscription` uses calibration when available; `api` uses configured values |
+| `budget.calibrate_enabled` | `true` | Enables tmux scraping and calibrated estimates for subscription mode |
+| `budget.snapshot_interval` | `30m` | Daemon snapshot cadence; an invalid or non-positive duration disables the loop with a warning |
+| `budget.snapshot_retention_days` | `90` | Prune age; `0` disables pruning |
+| `budget.week_start_day` | `monday` | Groups calibration snapshots by Monday or Sunday week start |
+| `budget.db_path` | `~/.local/share/nightshift/nightshift.db` | Snapshot, state, and report database |
 
-## Budget Modes
+## Allowance Calculations
 
-### Daily Mode (recommended)
+Nightshift first resolves a weekly budget from API/config values or calibration, then asks the provider for its used percentage.
 
-Each night uses up to `max_percent` of your daily budget (weekly / 7). Consistent, predictable usage.
+### Daily mode
 
-### Weekly Mode
+```text
+daily_budget = weekly_budget / 7
+available_today = daily_budget * (1 - used_percent / 100)
+pre_reserve_allowance = available_today * max_percent / 100
+reserve = daily_budget * reserve_percent / 100
+allowance = max(0, pre_reserve_allowance - reserve - predicted_daytime_usage)
+```
 
-Uses `max_percent` of *remaining* weekly budget. With `aggressive_end_of_week: true`, spends more near week's end to avoid waste.
+The percent is applied to what remains today, not to the entire weekly budget. Integer conversion truncates fractional tokens.
 
-## Calibration
+### Weekly mode
 
-Nightshift infers subscription budgets by correlating local token counts with provider usage percentages.
+```text
+remaining_weekly = weekly_budget * (1 - used_percent / 100)
+pre_reserve_allowance = (remaining_weekly / remaining_days)
+                        * max_percent / 100
+                        * end_of_period_multiplier
+reserve = remaining_weekly * reserve_percent / 100
+allowance = max(0, pre_reserve_allowance - reserve - predicted_daytime_usage)
+```
 
-Formula: `inferred_budget = local_tokens / (scraped_pct / 100)`
+For Claude, `remaining_days` assumes a Sunday reset (Sunday itself returns seven days). Codex uses the secondary rate-limit reset timestamp when present and otherwise falls back to seven days. Copilot uses its next monthly reset and otherwise falls back to 30 days.
 
-Confidence levels:
-- **low**: 1–2 samples or high variance
-- **medium**: stable signal across several snapshots
-- **high**: consistent signal across a week or more
+With `aggressive_end_of_week: true`, the current multiplier is `1x` when two days remain and `2x` when one day remains. It does not increase the allowance earlier in the week.
+
+### Reserve and daytime forecast
+
+`reserve_percent` is a deduction from the mode's current budget base on every calculation; it is not a separately tracked account balance. After that deduction, Nightshift estimates remaining daytime usage from hourly snapshot averages and subtracts the estimate. The lookback uses `snapshot_retention_days`, capped at 30 days; a non-positive value falls back to 14 days. With no usable snapshot history, the daytime deduction is zero.
+
+An allowance at or below zero causes automatic provider selection to try the next provider, then skip the run if none remain. `nightshift run --ignore-budget` is the explicit manual override. Direct `nightshift task run ... --provider ...` does not consult the budget manager.
+
+## Provider Usage Sources
+
+- Claude daily and weekly percentages use local `stats-cache.json` token totals, falling back to session JSONL scanning. The daily denominator is the resolved weekly budget divided by seven.
+- Codex daily mode prefers today's local billable-token total and falls back to the primary (five-hour) rate limit. Weekly mode prefers the secondary rate-limit percentage and falls back to local weekly tokens.
+- Copilot uses a local request-counter model. Both modes are estimates, and the current agent execution path does not increment the counter automatically; see [Integrations](/docs/integrations).
+
+## Subscription Calibration
+
+Snapshots combine local usage with a provider percentage scraped from an interactive CLI inside tmux:
+
+```text
+inferred_weekly_budget = local_weekly_usage / (scraped_percent / 100)
+```
 
 ```bash
+nightshift budget snapshot
+nightshift budget snapshot --provider claude
+nightshift budget snapshot --local-only
+nightshift budget history -n 10
 nightshift budget calibrate
 ```
 
-Enable auto-calibration in config:
+`budget snapshot` can collect Claude, Codex, or Copilot local data. tmux scraping exists only for Claude and Codex; Copilot snapshots are local-only. The daemon takes an immediate snapshot and then repeats at `snapshot_interval`, but its automatic loop currently covers only enabled Claude and Codex providers.
 
-```yaml
-budget:
-  calibrate_enabled: true
-  snapshot_interval: 30m
-```
+Calibration uses samples from the configured week with local usage greater than zero and scraped percentages from 10% through 95%. It removes median-absolute-deviation outliers when at least three samples exist, takes the median inferred budget, and rounds to the nearest 1,000 tokens. If the current week has no samples, it tries the previous week before falling back to config.
 
-> Calibration uses tmux to scrape usage percentages. If tmux is unavailable, snapshots are local-only and budgets fall back to config values.
+Confidence is:
+
+- `none`: no usable calibrated samples
+- `low`: one or two samples, or higher variance
+- `medium`: three to five samples with coefficient of variation at most 15%, or more samples at most 15%
+- `high`: more than five samples with coefficient of variation at most 10%
+
+If tmux is absent or scraping fails, the snapshot is still stored as local-only and cannot contribute a percentage-based calibration sample. Install tmux and authenticate the provider CLI, or use API mode with explicit values.
 
 ## API Billing
 
-For API-billed accounts, set explicit token limits:
+API mode disables calibration after configuration is loaded and treats configured budgets as authoritative:
 
 ```yaml
 budget:
@@ -77,23 +116,8 @@ budget:
     codex: 500000
 ```
 
-`weekly_tokens` and `per_provider` are authoritative for `billing_mode: api`. For subscription users, they act as a fallback until calibration has enough snapshots.
+`per_provider` wins for a matching provider; otherwise `weekly_tokens` is used. API mode does not fetch provider billing limits from a remote API.
 
-## Budget History
+## History and Reports
 
-View past budget snapshots:
-
-```bash
-nightshift budget history -n 10
-nightshift budget snapshot --local-only
-```
-
-## Morning Summary
-
-After each run, Nightshift generates a summary at `~/.local/share/nightshift/summaries/nightshift-YYYY-MM-DD.md` covering budget usage, tasks completed, and suggested next steps.
-
-## Safety
-
-- `max_percent` (default 75%) caps how much budget a single run can use
-- `reserve_percent` (default 5%) always keeps some budget available for your daytime work
-- If budget is exhausted, Nightshift skips remaining tasks gracefully
+`nightshift budget history` reads stored snapshots (20 per provider by default). `snapshot_retention_days` controls the daemon's daily prune job. A run summary is written to `~/.local/share/nightshift/summaries/summary-YYYY-MM-DD.md`; structured per-run reports are under `~/.local/share/nightshift/reports/`.

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -5,12 +5,14 @@ title: CLI Reference
 
 # CLI Reference
 
-## Core Commands
+## Top-Level Commands
 
 | Command | Description |
 |---------|-------------|
-| `nightshift setup` | Guided global configuration |
-| `nightshift run` | Execute scheduled tasks |
+| `nightshift setup` | Guided end-to-end onboarding |
+| `nightshift init` | Create a global or project config file |
+| `nightshift config` | Show, edit, or validate config files |
+| `nightshift run` | Execute configured tasks now |
 | `nightshift preview` | Show upcoming runs |
 | `nightshift budget` | Check token budget status |
 | `nightshift task` | Browse and run tasks |
@@ -18,75 +20,253 @@ title: CLI Reference
 | `nightshift status` | View run history |
 | `nightshift logs` | Stream or export logs |
 | `nightshift stats` | Token usage statistics |
-| `nightshift daemon` | Background scheduler |
+| `nightshift report` | Read run reports |
+| `nightshift busfactor` | Analyze ownership concentration |
+| `nightshift daemon` | Manage the background daemon lifecycle |
+| `nightshift install` | Install a launchd/systemd/cron service |
+| `nightshift uninstall` | Remove the installed service |
+| `nightshift completion` | Generate shell completion for bash, fish, PowerShell, or zsh |
+| `nightshift help [command]` | Show command help |
+
+## Bootstrap and Config
+
+`nightshift setup` walks through provider setup, project selection, budget calibration, PATH setup, and daemon installation.
+
+```bash
+nightshift setup
+```
+
+`nightshift init` creates `nightshift.yaml` in the current directory by default. Use `--global` to create `~/.config/nightshift/config.yaml`, and `--force` to overwrite an existing file without prompting.
+
+```bash
+nightshift init
+nightshift init --global
+nightshift init --force
+```
+
+`nightshift config` shows the merged configuration from global and project files, plus environment overrides. `nightshift config set` writes to the project config when one exists, otherwise to the global config. Use `--global` to force the global file.
+
+```bash
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 15
+nightshift config set --global logging.level debug
+nightshift config validate
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `config` | Show merged config and source paths |
+| `config get KEY` | Read a nested value by key path |
+| `config set KEY VALUE` | Update a value; use `--global` to force global config |
+| `config validate` | Validate global, project, and merged config |
+
+`nightshift config set` accepts booleans, integers, floats, and strings. It writes the value before validating the merged configuration; a validation warning does not roll the edit back.
 
 ## Run Options
 
-`nightshift run` shows a preflight summary before executing, then prompts for confirmation in interactive terminals.
+`nightshift run` shows a preflight summary, then prompts for confirmation in interactive terminals. Non-TTY contexts skip the prompt automatically.
 
 ```bash
-nightshift run                          # Preflight + confirm + execute (1 project, 1 task)
-nightshift run --yes                    # Skip confirmation
-nightshift run --dry-run                # Show preflight, don't execute
-nightshift run --max-projects 3         # Process up to 3 projects
-nightshift run --max-tasks 2            # Run up to 2 tasks per project
-nightshift run --random-task            # Pick a random eligible task
-nightshift run --ignore-budget          # Bypass budget limits (use with caution)
-nightshift run --project ~/code/myapp   # Target specific project (ignores --max-projects)
-nightshift run --task lint-fix          # Run specific task (ignores --max-tasks)
+nightshift run                              # Preflight + confirm + execute
+nightshift run --yes                        # Skip confirmation
+nightshift run --dry-run                    # Show preflight summary and exit
+nightshift run --project ~/code/myapp       # Target a single project
+nightshift run --task lint-fix              # Run a specific task
+nightshift run --max-projects 3             # Process up to 3 projects
+nightshift run --max-tasks 2                # Run up to 2 tasks per project
+nightshift run --random-task                # Pick a random eligible task
+nightshift run --ignore-budget              # Bypass budget checks
+nightshift run --branch develop             # Base new feature branches on develop
+nightshift run --timeout 45m                # Increase per-agent timeout
+nightshift run --no-color                   # Disable ANSI colors
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--dry-run` | `false` | Show preflight summary and exit without executing |
-| `--yes`, `-y` | `false` | Skip confirmation prompt |
-| `--max-projects` | `1` | Max projects to process (ignored when `--project` is set) |
-| `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
-| `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
+| `--dry-run` | `false` | Show the preflight summary and exit without executing |
+| `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| `--project`, `-p` | _(all configured)_ | Target a single project directory |
+| `--task`, `-t` | _(auto-select)_ | Run a specific task by name |
+| `--max-projects` | `1` | Max projects to process when `--project` is not set |
+| `--max-tasks` | `1` | Max tasks per project when `--task` is not set |
+| `--random-task` | `false` | Pick one random eligible task instead of the highest-scored task |
 | `--ignore-budget` | `false` | Bypass budget checks with a warning |
-| `--project`, `-p` | | Target a specific project directory |
-| `--task`, `-t` | | Run a specific task by name |
+| `--branch`, `-b` | _(current branch)_ | Base branch for new feature branches |
+| `--timeout` | `30m` | Per-agent execution timeout |
+| `--no-color` | `false` | Disable colored output |
 
-Non-interactive contexts (daemon, cron, piped output) skip the confirmation prompt automatically.
+`--random-task` and `--task` are mutually exclusive. When `--max-projects` or `--max-tasks` is omitted, a positive `schedule.max_projects` or `schedule.max_tasks` value replaces the flag's default. `--project` loads that directory's project config and targets only that directory. A manual run ignores the configured schedule and window.
 
-## Preview Options
+## Daemon and Services
+
+`nightshift daemon` manages the persistent scheduler loop. `daemon start` backgrounds the process by default, `--foreground` keeps it in the current terminal, and `--timeout` defaults to 30m per agent.
+
+```bash
+nightshift daemon start
+nightshift daemon start --foreground
+nightshift daemon start --timeout 45m
+nightshift daemon status
+nightshift daemon stop
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `daemon start` | Start the scheduler in the background by default |
+| `daemon start --foreground` | Run the scheduler in the current terminal |
+| `daemon start --timeout 45m` | Set the per-agent execution timeout |
+| `daemon status` | Show whether the daemon is running |
+| `daemon stop` | Stop the running daemon |
+
+`nightshift install` installs a scheduled system job. If you do not pass an init system, Nightshift auto-detects one from the current platform.
+
+```bash
+nightshift install
+nightshift install launchd
+nightshift install systemd
+nightshift install cron
+nightshift uninstall
+```
+
+`launchd` targets macOS, `systemd` targets Linux, and `cron` works everywhere. `nightshift uninstall` removes the matching service entry if one is installed.
+
+Installed services execute `nightshift run` directly; they are separate from the persistent daemon. See [Scheduling](/docs/scheduling) for schedule-conversion limitations.
+
+## Preview
 
 ```bash
 nightshift preview                # Default view
 nightshift preview -n 3           # Next 3 runs
-nightshift preview --long         # Detailed view
-nightshift preview --explain      # With prompt previews
-nightshift preview --plain        # No pager
+nightshift preview --long          # Detailed prompts
+nightshift preview --explain       # Budget and cooldown explanations
+nightshift preview --plain         # Disable pager output
 nightshift preview --json         # JSON output
-nightshift preview --write ./dir  # Write prompts to files
+nightshift preview --write ./dir   # Write prompts to files
 ```
 
-## Task Commands
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--runs`, `-n` | `3` | Number of upcoming runs; must be positive |
+| `--project`, `-p` | configured projects/current directory | Preview one project and load its project config |
+| `--task`, `-t` | auto-select | Preview one task type |
+| `--long` | `false` | Show full prompts instead of the 400-character preview |
+| `--write DIR` | none | Write full prompts to files in `DIR` |
+| `--explain` | `false` | Include budget and task-filter diagnostics |
+| `--plain` | `false` | Do not use the optional gum pager |
+| `--json` | `false` | Emit structured output with full prompts and diagnostics |
+
+Preview requires a schedule and at least one project. It does not run tasks or update task state, although `--write` creates files.
+
+## Budget
+
+Budget commands accept `--provider` values of `claude`, `codex`, or `copilot`.
 
 ```bash
-nightshift task list              # All tasks
+nightshift budget
+nightshift budget --provider claude
+nightshift budget --provider copilot
+nightshift budget snapshot --local-only
+nightshift budget snapshot --provider codex
+nightshift budget history -n 10
+nightshift budget calibrate
+```
+
+| Command | Notes |
+|---------|-------|
+| `budget` | Show current budget status |
+| `budget snapshot` | Capture a usage snapshot for calibration |
+| `budget history` | Show recent snapshots |
+| `budget calibrate` | Show inferred calibration status |
+
+`budget snapshot` accepts `--provider`, `-p` and `--local-only`. `budget history` accepts `--provider`, `-p` and `--n`, `-n` (default 20). `budget calibrate` accepts `--provider`, `-p`. Without a provider filter, each command processes all enabled providers.
+
+## Tasks
+
+Task commands also accept `--provider` values of `claude`, `codex`, or `copilot` when running tasks.
+
+```bash
+nightshift task list
 nightshift task list --category pr
 nightshift task list --cost low --json
 nightshift task show lint-fix
 nightshift task show lint-fix --prompt-only
 nightshift task run lint-fix --provider claude
-nightshift task run lint-fix --provider codex --dry-run
+nightshift task run lint-fix --provider copilot --dry-run
+nightshift task run lint-fix --provider codex --timeout 45m
+nightshift task run lint-fix --provider claude -p ~/code/myapp --branch develop
 ```
 
-## Budget Commands
+`nightshift task run` requires `--provider`. It accepts `--project`, `--dry-run`, `--timeout` (default 30m), and `--branch` for new feature branches.
+
+| Command | Flags |
+|---------|-------|
+| `task list` | `--category` (`pr`, `analysis`, `options`, `safe`, `map`, `emergency`), `--cost` (`low`, `medium`, `high`, `veryhigh`), `--json` |
+| `task show TASK` | `--project`, `-p`; `--prompt-only`; `--json` |
+| `task run TASK` | required `--provider`; `--project`, `-p`; `--dry-run`; `--timeout` (30m); `--branch`, `-b` |
+
+Direct task execution validates the project path and provider CLI but does not check the budget allowance or scheduled cooldown.
+
+## Reports, Logs, Status, and Statistics
 
 ```bash
-nightshift budget                 # Current status
-nightshift budget --provider claude
-nightshift budget snapshot --local-only
-nightshift budget history -n 10
-nightshift budget calibrate
+nightshift status --today
+nightshift logs --follow
+nightshift stats
+nightshift report --period last-night
+nightshift budget snapshot --provider claude
+nightshift busfactor .
+nightshift doctor
 ```
 
-## Global Flags
+### `report`
 
-| Flag | Description |
-|------|-------------|
-| `--verbose` | Verbose output |
-| `--provider` | Select provider (claude, codex) |
-| `--timeout` | Execution timeout (default 30m) |
+| Flag | Default | Values/meaning |
+|------|---------|----------------|
+| `--report`, `-r` | `overview` | `overview`, `tasks`, `projects`, `budget`, or `raw` |
+| `--period`, `-p` | `last-night` | `last-night`, `last-run`, `last-24h`, `last-7d`, `today`, `yesterday`, or `all` |
+| `--runs`, `-n` | `3` | Maximum runs; `0` means all |
+| `--since` / `--until` | none | `YYYY-MM-DD`, `YYYY-MM-DD HH:MM`, or RFC3339 bounds |
+| `--format` | `fancy` | `fancy`, `plain`, `markdown`, or `json` |
+| `--no-color` | `false` | Disable ANSI colors |
+| `--paths` | `false` | Include report and log paths |
+| `--max-items` | `5` | Highlights shown per run |
+
+### `logs`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tail`, `-n` | `50` | Recent matching lines |
+| `--follow`, `-f` | `false` | Continue streaming |
+| `--export`, `-e` | none | Write selected logs to a file |
+| `--since` / `--until` | none | Time bounds in the report date formats |
+| `--level` | none | Minimum `debug`, `info`, `warn`, or `error` level |
+| `--component` | none | Component substring filter |
+| `--match` | none | Message substring filter |
+| `--summary` | `false` | Print counts only |
+| `--raw` | `false` | Print stored lines without formatting |
+| `--no-color` | `false` | Disable ANSI colors |
+| `--path` | configured log path | Override the log directory |
+
+### `status` and `stats`
+
+`status --last N` (`-n`, default 5) shows recent run records; `status --today` switches to today's activity summary. `stats --period` (`-p`) accepts `all`, `last-7d`, `last-30d`, or `last-night`; `stats --json` produces machine-readable output.
+
+### `busfactor`
+
+`busfactor [path]` analyzes a Git repository, defaulting to the current directory. `--path`, `-p` is the flag equivalent. Use `--since`/`--until` with RFC3339 or `YYYY-MM-DD`, `--file`/`-f` for a path or pattern, `--json` for structured output, `--save` to store the result, and `--db` to override the configured database.
+
+`doctor` has no command-specific flags. It checks config, schedule, provider paths and binaries, database health, snapshots, tmux, and budget readiness.
+
+## Setup, Init, and Completion
+
+- `setup` runs the interactive end-to-end wizard and has no command-specific flags.
+- `init` creates `./nightshift.yaml`; `--global` targets the global path and `--force`, `-f` overwrites without prompting.
+- `completion bash|fish|powershell|zsh` emits Cobra's completion script. Run the selected subcommand's `--help` for shell-specific installation instructions.
+
+## Shared Flags
+
+| Flag | Scope | Description |
+|------|-------|-------------|
+| `--verbose` | Root command | Verbose output |
+| `--version`, `-v` | Root command | Print the Nightshift version |
+| `--help`, `-h` | Any command | Print contextual help |

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -61,7 +61,7 @@ nightshift config validate
 | `config set KEY VALUE` | Update a value; use `--global` to force global config |
 | `config validate` | Validate global, project, and merged config |
 
-`nightshift config set` accepts booleans, integers, floats, and strings. It writes the value before validating the merged configuration; a validation warning does not roll the edit back.
+For supported configuration fields, `nightshift config set` accepts booleans, integers, and strings. It does not type-check the key against the configuration schema before writing, and the current schema has no floating-point fields. The command writes the value before validating the merged configuration; a validation warning does not roll the edit back.
 
 ## Run Options
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -28,7 +28,7 @@ nightshift config validate
 - `nightshift config set` writes to the project config when one exists, otherwise to the global config. Use `--global` to force the global file.
 - `nightshift config validate` checks the global file, project file, and merged config.
 
-`nightshift config set` accepts booleans, integers, floats, and strings. For example, `true`, `15`, `12.5`, and `debug` are all parsed correctly.
+For supported configuration fields, pass booleans, integers, or strings to `nightshift config set`, such as `true`, `15`, or `debug`. The command does not type-check a key against the configuration schema before writing it, so use the field type documented on this page; the current schema has no floating-point fields.
 
 ## Config Sources
 
@@ -40,7 +40,7 @@ Nightshift loads and merges config in this order, from lowest to highest precede
 
 Project config values override global config values, and environment variables override both. The currently bound variables are `NIGHTSHIFT_BUDGET_MAX_PERCENT`, `NIGHTSHIFT_BUDGET_MODE`, `NIGHTSHIFT_LOG_LEVEL`, and `NIGHTSHIFT_LOG_PATH`. Other `NIGHTSHIFT_*` names are not guaranteed to unmarshal into the config struct.
 
-When a command accepts `--project`, Nightshift loads `nightshift.yaml` from that directory. Otherwise it uses the current working directory. `nightshift config set` updates the current directory's project file only when that file already exists; otherwise it writes the global file. It writes first and then warns if the merged result fails validation, so review the file after a warning.
+`nightshift run --project`, `nightshift preview --project`, and `nightshift task run --project` load `nightshift.yaml` from the supplied directory. Without that flag, they use the current working directory. `nightshift task show --project` is different: it uses the path only as prompt context and does not load configuration. `nightshift config set` updates the current directory's project file only when that file already exists; otherwise it writes the global file. It writes first and then warns if the merged result fails validation, so review the file after a warning.
 
 ## Config Locations
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -5,18 +5,57 @@ title: Configuration
 
 # Configuration
 
-Nightshift uses YAML config files. Run `nightshift setup` for an interactive setup, or edit directly.
+Nightshift uses YAML config files. Use `nightshift setup` for guided bootstrap, `nightshift init` or `nightshift init --global` to create a config file, and `nightshift config` to inspect or edit the merged view.
 
-## Config Location
+## Bootstrap Workflow
 
-- **Global:** `~/.config/nightshift/config.yaml`
-- **Per-project:** `nightshift.yaml` or `.nightshift.yaml` in the repo root
+```bash
+nightshift setup
+nightshift init
+nightshift init --global
+nightshift config
+nightshift config get budget.max_percent
+nightshift config set budget.max_percent 15
+nightshift config set --global logging.level debug
+nightshift config validate
+```
+
+- `nightshift setup` walks through provider setup, projects, budget, schedule, PATH, and daemon installation.
+- `nightshift init` creates `nightshift.yaml` in the current directory.
+- `nightshift init --global` creates `~/.config/nightshift/config.yaml`.
+- `nightshift config` shows the merged config plus the source paths.
+- `nightshift config get` reads a nested value by key path.
+- `nightshift config set` writes to the project config when one exists, otherwise to the global config. Use `--global` to force the global file.
+- `nightshift config validate` checks the global file, project file, and merged config.
+
+`nightshift config set` accepts booleans, integers, floats, and strings. For example, `true`, `15`, `12.5`, and `debug` are all parsed correctly.
+
+## Config Sources
+
+Nightshift loads and merges config in this order, from lowest to highest precedence:
+
+1. Global config: `~/.config/nightshift/config.yaml`
+2. Project config: `nightshift.yaml` in the current project directory
+3. Bound environment overrides
+
+Project config values override global config values, and environment variables override both. The currently bound variables are `NIGHTSHIFT_BUDGET_MAX_PERCENT`, `NIGHTSHIFT_BUDGET_MODE`, `NIGHTSHIFT_LOG_LEVEL`, and `NIGHTSHIFT_LOG_PATH`. Other `NIGHTSHIFT_*` names are not guaranteed to unmarshal into the config struct.
+
+When a command accepts `--project`, Nightshift loads `nightshift.yaml` from that directory. Otherwise it uses the current working directory. `nightshift config set` updates the current directory's project file only when that file already exists; otherwise it writes the global file. It writes first and then warns if the merged result fails validation, so review the file after a warning.
+
+## Config Locations
+
+| Type | Location |
+|------|----------|
+| Global | `~/.config/nightshift/config.yaml` |
+| Project | `nightshift.yaml` |
 
 ## Minimal Config
 
 ```yaml
 schedule:
   cron: "0 2 * * *"
+  max_projects: 1
+  max_tasks: 1
 
 budget:
   mode: daily
@@ -29,46 +68,108 @@ budget:
 providers:
   preference:
     - claude
-    - codex
   claude:
     enabled: true
     data_path: "~/.claude"
-    dangerously_skip_permissions: true
+    dangerously_skip_permissions: false
   codex:
-    enabled: true
-    data_path: "~/.codex"
-    dangerously_bypass_approvals_and_sandbox: true
+    enabled: false
+  copilot:
+    enabled: false
 
 projects:
   - path: ~/code/sidecar
-  - path: ~/code/td
 ```
 
 ## Schedule
 
-Use cron syntax or interval-based scheduling:
+Use either cron or interval scheduling. Nightshift rejects configs that set both.
 
 ```yaml
 schedule:
   cron: "0 2 * * *"        # Every night at 2am
   # interval: "8h"         # Or run every 8 hours
+  window:
+    start: "22:00"
+    end: "06:00"
+    timezone: "America/Denver"
+  max_projects: 1
+  max_tasks: 1
 ```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cron` | - | Cron expression for scheduled runs |
+| `interval` | - | Duration string for repeated runs |
+| `window` | none | Optional execution-window object; both start and end must be valid `HH:MM` values when present |
+| `window.start` | - | Inclusive start of the allowed execution window |
+| `window.end` | - | Exclusive end; an earlier end spans midnight |
+| `window.timezone` | local time | IANA time zone for the window |
+| `max_projects` | `0` | Positive values replace the manual `run` default when its flag is omitted; `0` leaves the CLI default of 1 |
+| `max_tasks` | `0` | Positive values replace the manual `run` default when its flag is omitted; `0` leaves the CLI default of 1 |
+
+The config validator rejects cron plus interval, but it permits both to be empty. `preview` and `daemon start` then report that no schedule is configured. Cron is five fields; interval uses a positive Go duration.
 
 ## Budget
 
-Control how much of your token budget Nightshift uses:
+Control how much of your token budget Nightshift uses.
 
 | Field | Default | Description |
 |-------|---------|-------------|
 | `mode` | `daily` | `daily` or `weekly` |
-| `max_percent` | `75` | Max budget % to use per run |
-| `reserve_percent` | `5` | Always keep this % available |
+| `max_percent` | `75` | Max budget % to use per run; validation accepts `0`-`100`, and calculation treats `0` as the default `75` |
+| `reserve_percent` | `5` | Deduct this % of the current budget base after applying `max_percent` |
 | `billing_mode` | `subscription` | `subscription` or `api` |
-| `calibrate_enabled` | `true` | Auto-calibrate from local CLI data |
+| `calibrate_enabled` | `true` | Enable subscription calibration via snapshots |
+| `snapshot_interval` | `30m` | Automatic snapshot cadence |
+| `snapshot_retention_days` | `90` | Snapshot retention window |
+| `weekly_tokens` | `700000` | Fallback weekly budget |
+| `per_provider` | - | Provider-specific weekly budgets |
+| `week_start_day` | `monday` | Week boundary for calibration |
+| `db_path` | `~/.local/share/nightshift/nightshift.db` | Override database path |
+| `aggressive_end_of_week` | `false` | Weekly mode multiplier: currently 1x with two days left and 2x with one day left |
+
+If `billing_mode: api`, Nightshift turns calibration off after loading and uses the explicit token budgets in `weekly_tokens` and `per_provider`. See [Budget Management](/docs/budget) for the exact daily/weekly formulas and provider-specific usage sources.
+
+## Providers
+
+Nightshift supports Claude Code, Codex, and GitHub Copilot. It uses the providers listed in `providers.preference` order.
+
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+    - copilot
+  copilot:
+    enabled: true
+    data_path: "~/.copilot"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `providers.preference` | `["claude", "codex", "copilot"]` | Provider priority order |
+| `providers.claude.enabled` | `true` | Enable Claude provider |
+| `providers.claude.data_path` | `~/.claude` | Claude Code data directory |
+| `providers.claude.dangerously_skip_permissions` | `false` | Skip Claude permission prompts |
+| `providers.codex.enabled` | `true` | Enable Codex provider |
+| `providers.codex.data_path` | `~/.codex` | Codex data directory |
+| `providers.codex.dangerously_bypass_approvals_and_sandbox` | `false` | Bypass Codex approvals and sandboxing |
+| `providers.copilot.enabled` | `true` | Enable Copilot provider |
+| `providers.copilot.data_path` | `~/.copilot` | Copilot request-tracking directory |
+| `providers.copilot.dangerously_skip_permissions` | `false` | Allow Copilot to run with broader tool access |
+
+Every provider entry is decoded through the same struct, so YAML may contain both dangerous keys under any provider. Execution currently reads only Claude's `dangerously_skip_permissions`, Codex's `dangerously_bypass_approvals_and_sandbox`, and Copilot's `dangerously_skip_permissions`; the other combinations have no effect.
+
+For automatic runs, provider preference is filtered by enabled status, CLI discovery, and positive allowance. The first remaining entry wins. Direct `task run` requires an explicit provider.
+
+The safety fields default to false in configuration. Claude and Copilot pass their dangerous flags only when enabled. Codex is an exception in this release: its headless agent defaults the approval/sandbox bypass on, and a false config value preserves that agent default because unset and explicit false are indistinguishable. Disable Codex entirely if that behavior is not acceptable.
+
+Copilot's usage model is request-based rather than token-based, but the execution path currently does not increment its local counter. The standalone `copilot` binary is preferred; see [Integrations](/docs/integrations) for fallback details and limitations.
 
 ## Task Selection
 
-Enable/disable tasks and set priorities:
+Enable and prioritize built-in tasks, disable specific tasks, or define custom tasks.
 
 ```yaml
 tasks:
@@ -82,9 +183,46 @@ tasks:
   intervals:
     lint-fix: "24h"
     docs-backfill: "168h"
+  custom:
+    - type: pr-review
+      name: "PR Review Session"
+      description: |
+        Review open PRs and check for regressions.
+        Create follow-up tasks for anything that needs attention.
+      category: pr
+      cost_tier: high
+      risk_level: medium
+      interval: "72h"
 ```
 
-Each task has a default cooldown interval to prevent the same task from running too frequently on a project.
+- `tasks.enabled` restricts the built-in tasks Nightshift may run.
+- `tasks.disabled` explicitly blocks a task even if it is enabled elsewhere.
+- `tasks.intervals` overrides cooldowns per task.
+- `tasks.custom` defines user-authored tasks. `type`, `name`, and `description` are required.
+
+An empty `tasks.enabled` means all tasks except definitions marked disabled-by-default are eligible. `tasks.disabled` always wins. Custom `type` values must match `[a-z0-9][a-z0-9-]*` and be unique. Optional categories are `pr`, `analysis`, `options`, `safe`, `map`, and `emergency`; cost tiers are `low`, `medium`, `high`, and `very-high`; risks are `low`, `medium`, and `high`. Empty optional fields default to analysis, medium cost, low risk, and the category's standard cooldown.
+
+`run`, `preview`, and the setup wizard register configured custom tasks. The current persistent daemon and direct `task list`, `task show`, and `task run` command paths do not load them, so use `nightshift run --task CUSTOM_TYPE` for direct custom-task execution.
+
+## Integrations
+
+```yaml
+integrations:
+  claude_md: true
+  agents_md: true
+  task_sources:
+    - td:
+        enabled: true
+        teach_agent: true
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `integrations.claude_md` | `true` | Read `CLAUDE.md` or `claude.md` for context |
+| `integrations.agents_md` | `true` | Read `AGENTS.md` for context |
+| `integrations.task_sources` | - | Reader configuration for td, GitHub issues, or a file field |
+
+The readers are implemented, but current run/daemon/preview paths do not invoke their manager, and the file source has no reader. See [Integrations](/docs/integrations) before relying on these fields for scheduling.
 
 ## Multi-Project Setup
 
@@ -93,25 +231,58 @@ projects:
   - path: ~/code/project1
     priority: 1                # Higher priority = processed first
     tasks:
-      - lint
-      - docs
+      - lint-fix
+      - docs-backfill
   - path: ~/code/project2
     priority: 2
-
-  # Or use glob patterns
   - pattern: ~/code/oss/*
     exclude:
       - ~/code/oss/archived
 ```
 
+The schema includes `path`, `priority`, `tasks`, `config`, `pattern`, and `exclude`. The reusable project resolver implements explicit paths, non-recursive filesystem globs, exact/subtree exclusions, priority ordering, and a limited per-project merge.
+
+The current CLI execution paths do not use that resolver: `run`, `daemon`, and `preview` read only `projects[].path`, silently skip missing paths, and preserve declaration order. `pattern`, `exclude`, `priority`, per-project `tasks`, and `config` do not currently affect those commands. Expand patterns into explicit `path` entries for production configuration.
+
+## Logging and Reporting
+
+```yaml
+logging:
+  level: info
+  path: ~/.local/share/nightshift/logs
+  format: json
+
+reporting:
+  morning_summary: true
+  # email: user@example.com
+  # slack_webhook: https://hooks.slack.com/...
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `logging.level` | `info` | `debug`, `info`, `warn`, or `error` |
+| `logging.path` | `~/.local/share/nightshift/logs` | Daily log directory; `~` is expanded |
+| `logging.format` | `json` | `json` or plain console-style `text` |
+| `reporting.morning_summary` | `true` | Write the dated Markdown summary after runs |
+| `reporting.email` | none | Notification address; requires `NIGHTSHIFT_SMTP_HOST` and optionally SMTP port/user/pass/from environment values |
+| `reporting.slack_webhook` | none | POST the generated summary to this Slack webhook |
+
+Nightshift retains its dated structured log files for seven days; that retention is not currently configurable through the main schema.
+
 ## Safe Defaults
 
 | Feature | Default | Override |
 |---------|---------|----------|
-| Read-only first run | Yes | `--enable-writes` |
-| Max budget per run | 75% | `budget.max_percent` |
-| Auto-push to remote | No | Manual only |
-| Reserve budget | 5% | `budget.reserve_percent` |
+| Confirmation prompt in TTY | Yes | `--yes` |
+| Confirmation prompt in non-TTY | Auto-skip | `--yes` or interactive terminal |
+| Max projects per run | `1` | `--max-projects` or `schedule.max_projects` |
+| Max tasks per project | `1` | `--max-tasks` or `schedule.max_tasks` |
+| Max budget per run | `75%` | `budget.max_percent` |
+| Reserve budget | `5%` | `budget.reserve_percent` |
+| Claude permission bypass | Off | `providers.claude.dangerously_skip_permissions` |
+| Copilot broad tool/URL access | Off | `providers.copilot.dangerously_skip_permissions` |
+
+These per-run limits describe `nightshift run` and service installations, which invoke that command. The persistent daemon currently processes every explicit project path and selects up to five tasks per project instead of using the schedule limit fields.
 
 ## File Locations
 
@@ -124,7 +295,3 @@ projects:
 | PID file | `~/.local/share/nightshift/nightshift.pid` |
 
 If `state/state.json` exists from older versions, Nightshift migrates it to the SQLite database and renames the file to `state.json.migrated`.
-
-## Providers
-
-Nightshift supports Claude Code and Codex as execution providers. It will use whichever has budget remaining, in the order specified by `preference`.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -5,6 +5,8 @@ title: Installation
 
 # Installation
 
+Nightshift runs local AI-provider CLIs, so install and authenticate at least one provider before the first real run. Git is required for project work. `tmux` is optional but required for subscription-usage scraping and calibration snapshots.
+
 ## Homebrew (Recommended)
 
 ```bash
@@ -17,7 +19,7 @@ Pre-built binaries are available on the [GitHub releases page](https://github.co
 
 ## From Source
 
-Requires Go 1.24+:
+Requires Go 1.24 or newer:
 
 ```bash
 go install github.com/marcus/nightshift/cmd/nightshift@latest
@@ -39,16 +41,82 @@ nightshift --version
 nightshift --help
 ```
 
-## Prerequisites
+## Provider Prerequisites
 
-- **Claude Code CLI** (`claude`) and/or **Codex CLI** (`codex`) installed
-- Authenticated via subscription login or API keys:
+Nightshift can use Claude Code, Codex, and GitHub Copilot. Install and authenticate any provider you enable before running `nightshift setup` or `nightshift run`. Provider binaries must be on `PATH`.
+
+### Claude Code
 
 ```bash
-# Claude Code
+# Node.js 18+ installation
+npm install -g @anthropic-ai/claude-code
+
+# Start the interactive client, then choose an Anthropic Console,
+# Claude Pro/Max, Bedrock, or Vertex authentication path.
 claude
 /login
-
-# Codex
-codex --login
 ```
+
+Claude's current setup options are documented in [Set up Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started). Nightshift executes `claude --print`; `providers.claude.data_path` defaults to `~/.claude` for local usage data.
+
+### Codex
+
+```bash
+npm install -g @openai/codex
+
+# ChatGPT subscription sign-in
+codex login
+
+# API-key sign-in (usage is billed through the API account)
+printenv OPENAI_API_KEY | codex login --with-api-key
+
+# Verify the saved method
+codex login status
+```
+
+Nightshift executes `codex exec`. The browser-based `codex login` flow uses ChatGPT access; piping a key with `--with-api-key` uses API billing. Local session data defaults to `~/.codex`.
+
+### GitHub Copilot
+
+The standalone agentic CLI is the recommended path. It requires an eligible Copilot account; npm installation currently requires Node.js 22 or newer.
+
+```bash
+npm install -g @github/copilot
+copilot login
+```
+
+GitHub also supports installing/running the current Copilot CLI through recent GitHub CLI releases:
+
+```bash
+gh auth login
+gh copilot -- --version
+```
+
+Nightshift prefers a `copilot` executable and otherwise constructs a `gh copilot -- ...` command. However, this release's availability probe for the `gh` path checks `gh extension list` for `gh-copilot`. GitHub [retired the legacy extension](https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/) in October 2025, so a current built-in `gh copilot` command alone may not pass that probe. Use the standalone `copilot` executable for reliable operation until Nightshift's probe is updated.
+
+See GitHub's [Copilot CLI installation](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli) and [authentication](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli) guides. Nightshift's usage provider reads `~/.copilot/nightshift-usage.json` by default, but the current execution path does not increment that request counter automatically.
+
+## Guided Setup
+
+Run the onboarding wizard after provider authentication:
+
+```bash
+nightshift setup
+```
+
+The wizard creates or updates the global config, selects projects and tasks, configures budget and safety choices, takes an initial snapshot, previews the schedule, and can install the service.
+
+## Manual Setup
+
+Create either a project config in the current directory or the global config, then inspect and validate the merged result:
+
+```bash
+nightshift init --global       # ~/.config/nightshift/config.yaml
+# or: nightshift init          # ./nightshift.yaml
+nightshift config
+nightshift config validate
+nightshift doctor
+nightshift preview
+```
+
+`preview` and the daemon require either `schedule.cron` or `schedule.interval`. A manual `nightshift run` does not require a schedule.

--- a/website/docs/integrations.md
+++ b/website/docs/integrations.md
@@ -5,9 +5,21 @@ title: Integrations
 
 # Integrations
 
-Nightshift integrates with your existing development workflow.
+Nightshift integrates with local provider CLIs and includes readers for repository instructions and external task sources.
 
-## Claude Code
+## AI Providers
+
+Nightshift supports three execution providers. For an ordinary `nightshift run`, it walks `providers.preference` (default `claude -> codex -> copilot`) and selects the first provider that is enabled, has a discoverable CLI, and has a positive calculated allowance. Missing or exhausted providers are skipped. `--ignore-budget` keeps the order but permits an exhausted provider; `nightshift task run` requires an explicit provider and does not perform this budget selection.
+
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+    - copilot
+```
+
+### Claude Code
 
 Nightshift uses the Claude Code CLI to execute tasks. Authenticate via subscription or API key:
 
@@ -16,21 +28,65 @@ claude
 /login
 ```
 
-## Codex
+Nightshift looks for the `claude` binary on `PATH`.
+
+Relevant config keys:
+
+- `providers.claude.enabled`
+- `providers.claude.data_path`
+- `providers.claude.dangerously_skip_permissions`
+
+When the last key is true, Nightshift adds Claude's `--dangerously-skip-permissions` flag. The configured default is false.
+
+### Codex
 
 Nightshift supports OpenAI's Codex CLI as an alternative provider:
 
 ```bash
-codex --login
+codex login
 ```
 
-## GitHub
+Nightshift looks for the `codex` binary on `PATH`.
 
-All output is PR-based. Nightshift creates branches and pull requests for its findings.
+Relevant config keys:
+
+- `providers.codex.enabled`
+- `providers.codex.data_path`
+- `providers.codex.dangerously_bypass_approvals_and_sandbox`
+
+Nightshift runs Codex through `codex exec`. Although the config default for the dangerous bypass key is false, the current headless Codex agent preserves its own bypass-enabled default when the key is false because the config cannot distinguish "unset" from an explicit false. Disable the Codex provider if that execution mode is unacceptable.
+
+### GitHub Copilot
+
+Nightshift supports GitHub Copilot through either the standalone `copilot` binary or `gh copilot`.
+
+```bash
+# Recommended standalone binary
+npm install -g @github/copilot
+copilot login
+
+# GitHub CLI route
+gh auth login
+gh copilot -- --version
+```
+
+Nightshift prefers the standalone `copilot` binary when it is available and otherwise constructs `gh copilot -- ...`. Its current `gh` availability probe also requires `gh extension list` to contain `gh-copilot`. GitHub has [retired the legacy extension](https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/), so use the standalone binary for reliable operation with this release.
+
+Copilot's usage provider models usage as request counts rather than tokens and reads `providers.copilot.data_path/nightshift-usage.json` (default `~/.copilot/nightshift-usage.json`). The counter resets on the first of the month at 00:00 UTC, and budget code approximates the configured weekly value as a monthly request limit by multiplying it by four. The current execution path does not call the counter's increment method, so this file is not an authoritative record of Nightshift or external Copilot use and normally remains empty unless another caller updates it.
+
+If you use `gh copilot`, authenticate with `gh auth login` first.
+
+Relevant config keys:
+
+- `providers.copilot.enabled`
+- `providers.copilot.data_path`
+- `providers.copilot.dangerously_skip_permissions`
+
+When the last key is true, Nightshift adds `--allow-all-tools --allow-all-urls`. The configured default is false.
 
 ## td (Task Management)
 
-Nightshift can source tasks from [td](https://td.haplab.com) — task management for AI-assisted development. Tasks tagged with `nightshift` in td will be picked up automatically.
+Nightshift's td reader runs `td list --format json` in the project directory. It accepts either a top-level JSON array or an object containing `tasks`, imports every returned record without status or label filtering, and maps subject, description, labels, owner, status, and priority into Nightshift's integration model. Text priorities map to 100 (`critical`/`urgent`), 75 (`high`), 50 (`medium`/`normal` or unknown), and 25 (`low`). Numeric strings are preserved as integers.
 
 ```yaml
 integrations:
@@ -40,17 +96,30 @@ integrations:
         teach_agent: true   # Include td usage + core workflow in prompts
 ```
 
+If `td` is missing, not configured for the repository, or returns an error, the reader quietly produces no result. When `teach_agent` is enabled, its aggregated context includes assign/complete workflow notes.
+
 ## CLAUDE.md / AGENTS.md
 
-Nightshift reads project-level instruction files to understand context when executing tasks. Place a `CLAUDE.md` or `AGENTS.md` in your repo root to give Nightshift project-specific guidance. Tasks mentioned in these files get a priority bonus (+2).
+The instruction readers look only in the project root. Claude candidates are `claude.md`, `CLAUDE.md`, then `.claude.md`; agent candidates are `AGENTS.md`, `agents.md`, then `.agents.md`. They return the full file as context and classify bullets under recognized headings as hints.
 
 ## GitHub Issues
 
-Source tasks from GitHub issues labeled with `nightshift`:
+Source tasks from GitHub issues by enabling the GitHub task source:
 
 ```yaml
 integrations:
-  github_issues:
-    enabled: true
-    label: "nightshift"
+  task_sources:
+    - github_issues: true
 ```
+
+The GitHub reader first requires `gh` on `PATH` and an `origin` remote whose URL contains `github.com`. It then runs:
+
+```bash
+gh issue list --label nightshift --json number,title,body,labels,state --state open
+```
+
+Only open issues with the hard-coded `nightshift` label are imported. Issue IDs become `gh-NUMBER`; title, body, state, and labels are retained. Priority is inferred from labels containing `critical`/`urgent` or `p0` (100), `high` or `p1` (75), `medium` or `p2` (50), and `low` or `p3` (25), defaulting to 50. Authentication or query failures are treated as no result. The label is not configurable in the current schema.
+
+## Current Wiring Limitation
+
+These readers and their aggregation model are implemented, but the current `run`, `daemon`, and `preview` command paths do not call the integration manager. Enabling td, GitHub issues, `CLAUDE.md`, or `AGENTS.md` therefore does not currently add external work items or scoring bonuses to scheduled CLI task selection. The `file` task-source field is present in the config schema but has no reader. Treat these settings as forward-compatible until the execution path is wired to them.

--- a/website/docs/scheduling.md
+++ b/website/docs/scheduling.md
@@ -5,30 +5,58 @@ title: Scheduling
 
 # Scheduling
 
-Nightshift can run automatically on a schedule.
+Nightshift can run automatically on a schedule or be triggered manually when you want immediate execution.
 
-## Cron-Based
+## Schedule Configuration
+
+Use cron or interval scheduling. Configuration validation rejects a file that sets both. It does not reject a file that sets neither, but `preview` and `daemon start` do because the scheduler requires one.
 
 ```yaml
 schedule:
   cron: "0 2 * * *"  # Every night at 2am
+  # interval: "8h"   # Or run every 8 hours
+  window:
+    start: "22:00"
+    end: "06:00"
+    timezone: "America/Denver"
+  max_projects: 1
+  max_tasks: 1
 ```
+
+- `cron` is a standard five-field expression (`minute hour day-of-month month day-of-week`); seconds are not accepted.
+- `interval` is a positive Go duration such as `30m`, `8h`, or `24h`.
+- `window` restricts the persistent scheduler to a time range. Start is inclusive and end is exclusive; a start later than end spans midnight.
+- `window.timezone` must be an IANA name such as `America/Denver`. An empty value uses the machine's local zone.
+- `max_projects` and `max_tasks` override the `nightshift run` defaults only when they are positive and the corresponding CLI flag was not passed.
+
+If you want to bootstrap a schedule from scratch, run `nightshift setup` for the guided path, or `nightshift init` / `nightshift init --global` for a manual path. After editing the schedule, run `nightshift config validate` and `nightshift preview`.
+
+For the interval scheduler, an occurrence outside the window is delayed to the next window start. Cron jobs still fire only at their cron times; a cron trigger outside the window is skipped rather than replayed later. `preview` adjusts displayed out-of-window candidates to the next window start, so use a cron expression that already falls inside the window when you need preview and daemon timing to agree exactly.
 
 ## Daemon Mode
 
-Run as a persistent background process:
+Run Nightshift as a persistent background process:
 
 ```bash
 nightshift daemon start
 nightshift daemon start --foreground  # For debugging
+nightshift daemon start --timeout 45m
+nightshift daemon status
 nightshift daemon stop
 ```
 
-## System Service
+`nightshift daemon start` backgrounds the scheduler by spawning the same command with `--foreground`. `--foreground` keeps it in the current terminal, and `--timeout` defaults to 30m per agent. The daemon requires a configured schedule, writes `~/.local/share/nightshift/nightshift.pid`, removes a stale PID file on `daemon stop`, and escalates from SIGTERM to SIGKILL after ten seconds if necessary.
 
-Install as a system service for automatic startup:
+The persistent daemon resolves only `projects[].path` entries, processes every resolved project not already processed that day, and currently selects up to five tasks per project. It does not apply `schedule.max_projects` or `schedule.max_tasks`. It also runs the automatic snapshot and retention loops described in [Budget Management](/docs/budget).
+
+## Service Lifecycle
+
+Install Nightshift as a system service for automatic startup:
 
 ```bash
+# Auto-detect the init system
+nightshift install
+
 # macOS (launchd)
 nightshift install launchd
 
@@ -37,7 +65,34 @@ nightshift install systemd
 
 # Universal (cron)
 nightshift install cron
+
+# Remove the installed service
+nightshift uninstall
 ```
+
+- `nightshift install` auto-detects launchd on macOS, systemd on Linux when `systemctl` is present, and cron otherwise.
+- All three installers schedule `nightshift run` directly; they do not start the persistent daemon. This means configured execution windows are not enforced by installed service jobs.
+- launchd extracts only literal minute/hour values from `schedule.cron`; without a cron value it uses 02:00. It captures the current `PATH` and writes stdout/stderr under `~/.local/share/nightshift/logs/`.
+- systemd creates a user oneshot service and timer. Its cron conversion ignores day-of-week, and its interval conversion is only suitable for simple minute values such as `30m`.
+- cron installs the configured cron expression or `0 2 * * *` if none exists. It does not translate `schedule.interval`.
+- `nightshift uninstall` checks and removes launchd, systemd, and cron installations; it returns an error if none are found.
+
+Because service generators accept a narrower schedule subset than the persistent scheduler, prefer `daemon start` when intervals, windows, or complex cron expressions matter. Inspect generated service behavior after installation.
+
+## Preview Scheduled Work
+
+```bash
+nightshift preview
+nightshift preview --runs 5
+nightshift preview --project ~/code/myproject
+nightshift preview --task lint-fix
+nightshift preview --long
+nightshift preview --explain
+nightshift preview --json
+nightshift preview --write ./nightshift-prompts
+```
+
+Preview requires a schedule and at least one project (the current directory is the fallback). It does not execute tasks or mark state, although `--write` creates prompt files. It simulates cooldowns across the requested future runs. Provider display uses the first enabled provider in the fixed order Claude, Codex, Copilot; unlike real execution, it does not use `providers.preference` or CLI availability.
 
 ## Manual Runs
 
@@ -45,12 +100,20 @@ Skip the scheduler and run immediately:
 
 ```bash
 nightshift run                          # Preflight summary + confirm + execute
-nightshift run --dry-run                # Show preflight summary, don't execute
+nightshift run --dry-run                # Show preflight summary and exit
 nightshift run --yes                    # Skip confirmation prompt
 nightshift run --project ~/code/myproject
 nightshift run --task lint-fix
 nightshift run --max-projects 3 --max-tasks 2  # Process more projects/tasks
+nightshift run --random-task            # Pick a random eligible task
 nightshift run --ignore-budget          # Bypass budget limits
+nightshift run --branch develop         # Base new branches on develop
+nightshift run --timeout 45m            # Increase per-agent timeout
+nightshift run --no-color               # Disable ANSI colors
 ```
 
-In interactive terminals, `nightshift run` shows a preflight summary and asks for confirmation before executing. Use `--yes` to skip the prompt (e.g., in scripts). Non-TTY contexts auto-skip confirmation.
+`nightshift run` shows a preflight summary before executing. In interactive terminals you get a confirmation prompt; `--yes` skips it. Non-TTY contexts such as cron, daemons, and CI skip confirmation automatically.
+
+`--random-task` is mutually exclusive with `--task`. When `--max-projects` or `--max-tasks` is omitted, Nightshift falls back to the values in `schedule.max_projects` and `schedule.max_tasks`. `--branch` defaults to the current branch, and `--timeout` defaults to 30m.
+
+Manual runs ignore `schedule.cron`, `schedule.interval`, and `schedule.window`. `--project` targets exactly one directory and ignores `--max-projects`; `--task` targets exactly one task and ignores `--max-tasks`. `--ignore-budget` bypasses provider allowance checks. Direct `nightshift task run TASK --provider PROVIDER` also runs immediately and does not consult the budget manager.

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -8,33 +8,78 @@ title: Troubleshooting
 ## Common Issues
 
 **"Something feels off"**
-- Run `nightshift doctor` to check config, schedule, and provider health
+- Run `nightshift doctor` to check config, schedule, provider, and budget health
 
 **"No config file found"**
 ```bash
-nightshift init           # Create project config
-nightshift init --global  # Create global config
+nightshift setup          # Guided bootstrap with provider and daemon checks
+nightshift init           # Create nightshift.yaml in the current directory
+nightshift init --global  # Create ~/.config/nightshift/config.yaml
+nightshift config         # Show source paths and merged defaults
+nightshift config validate
 ```
+
+Nightshift can load built-in defaults without either file, so `config` or a manual `run` may still work. A project config is discovered only in the current directory, or in the directory passed with a command's `--project` flag.
+
+**"No schedule configured"**
+- Set either `schedule.cron` or `schedule.interval` in config
+- Use `nightshift setup` or `nightshift init` if you want the bootstrap flow
+- Re-run `nightshift config validate` and `nightshift preview` after editing the schedule
+
+`config validate` checks that cron and interval are not both set, but it currently permits both to be absent. `preview` and `daemon start` perform the missing-schedule check. A manual `nightshift run` intentionally does not require a schedule.
 
 **"Insufficient budget"**
 - Check current budget: `nightshift budget`
-- Increase `max_percent` in config
-- Wait for budget reset (check reset time in output)
+- Inspect the budget source, reserve, and daytime forecast in the output
+- Increase `budget.max_percent`, reduce `reserve_percent`, or correct `weekly_tokens` / `per_provider` if those values are intentional
+- Wait for budget reset (check the reset time in the output)
+- For a deliberate one-off override, use `nightshift run --ignore-budget`; the daemon has no equivalent override
+- A direct `nightshift task run TASK --provider PROVIDER` is not budget-gated
+
+Setting `max_percent: 0` does not disable spending; calculation treats zero as the default 75. Disable providers or remove eligible work if you need a hard stop.
 
 **"Calibration confidence is low"**
-- Run `nightshift budget snapshot` a few times to collect samples
-- Ensure tmux is installed so usage percentages are available
-- Keep snapshots running for at least a few days
+- Run `nightshift budget snapshot` several times across the week
+- Ensure `tmux` is installed so usage percentages are available
+- Confirm the provider CLI is authenticated and its `/usage` or `/status` display is available
+- Use `nightshift budget history` to confirm snapshots have both local usage and a scraped percentage
+
+Only samples with local usage greater than zero and percentages from 10% through 95% are calibrated. One or two usable samples always produce low confidence. If the current week is empty, Nightshift can reuse the previous week's samples.
 
 **"tmux not found"**
-- Install tmux or set `budget.billing_mode: api` if you pay per token
+- Install `tmux`, then retry `nightshift budget snapshot`
+- Use `--local-only` when you want history without calibration
+- Set `budget.billing_mode: api` and explicit token limits when you pay per token
+
+Missing tmux does not prevent task execution. It prevents Claude/Codex percentage scraping, so subscription calibration falls back to config until usable scraped snapshots exist.
 
 **"Week boundary looks wrong"**
 - Set `budget.week_start_day` to `monday` or `sunday`
 
+That setting changes snapshot/calibration grouping. Weekly allowance reset timing remains provider-specific: Claude assumes Sunday, Codex uses its reported secondary reset when available, and Copilot uses the next monthly reset.
+
 **"Provider not available"**
-- Ensure Claude/Codex CLI is installed and in PATH
-- Check API key environment variables are set
+- Run `nightshift doctor` and `command -v claude codex copilot gh`
+- Verify the provider's `enabled` key and its position in `providers.preference`
+- Authenticate the selected CLI and verify it directly before retrying Nightshift
+- `run` and `daemon` augment `PATH` with common user locations such as `~/.local/bin`, `~/go/bin`, `~/.cargo/bin`, `~/.npm-global/bin`, `/usr/local/bin`, and `/opt/homebrew/bin`; custom install directories still need to be exported
+- `task run` performs direct PATH discovery and does not add those common directories first
+
+**"Copilot is installed but Nightshift cannot find it"**
+
+```bash
+command -v copilot
+copilot login
+copilot --version
+```
+
+Use the standalone `copilot` executable when possible. Nightshift falls back to `gh`, but this release's availability probe requires `gh extension list` to contain `gh-copilot`. GitHub retired that legacy extension, so a current `gh copilot` wrapper may still be rejected by the probe. If standalone authentication fails, run `copilot login` (or `/login` inside Copilot), confirm the account has Copilot CLI access, and check organization policy.
+
+**"Installed service runs differently from preview"**
+- launchd, systemd, and cron installations execute `nightshift run` directly, not the persistent daemon
+- Service generators only translate a subset of schedule settings and do not enforce `schedule.window`
+- Use `nightshift daemon start --foreground` to debug full scheduler/window behavior
+- See [Scheduling](/docs/scheduling) for the exact service conversions
 
 ## Debug Mode
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -19,7 +19,7 @@ nightshift config         # Show source paths and merged defaults
 nightshift config validate
 ```
 
-Nightshift can load built-in defaults without either file, so `config` or a manual `run` may still work. A project config is discovered only in the current directory, or in the directory passed with a command's `--project` flag.
+Nightshift can load built-in defaults without either file, so `config` or a manual `run` may still work. A project config is discovered in the current directory. `run --project`, `preview --project`, and `task run --project` instead load it from the supplied directory. `task show --project` only uses that path as prompt context and does not load configuration.
 
 **"No schedule configured"**
 - Set either `schedule.cron` or `schedule.interval` in config


### PR DESCRIPTION
## Summary

- backfill README setup, configuration, execution, daemon, service, and provider guidance
- document every registered CLI command family and its implemented flags/defaults
- expand configuration, integration, budget, scheduling, and troubleshooting references around current source behavior and limitations
- remove stale references to nonexistent documents and correct provider authentication/safety examples

## Validation

- `go test ./...`
- `go build ./cmd/nightshift`
- generated `--help` checks for all documented command families and subcommands
- `npm ci` in `website`
- `npm run build` in `website`
- `git diff --check`

Documentation-only change; application behavior is unchanged.
