### PR TITLE
docs: backfill README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Everything lands as a branch or PR. It never writes directly to your primary bra
 
 Full guide: [Installation docs](https://nightshift.haplab.com/docs/installation)
 
+Prerequisites:
+
+- macOS or Linux on Intel or ARM
+- Git and at least one local Git repository for Nightshift to inspect
+- At least one supported agent CLI (Claude Code, Codex, or GitHub Copilot), installed and authenticated
+- Go 1.24 or later only when installing from source
+
 ```bash
 brew install marcus/tap/nightshift
 ```


### PR DESCRIPTION
## Summary

- add concise README prerequisites for supported platforms, Git repositories, and provider CLIs
- clarify that Go 1.24+ is needed only for source installs
- keep onboarding details delegated to the existing installation, quick-start, and CLI guides

## Documentation gap

The README moved directly into installation without telling new users which platforms and local tools Nightshift expects. This backfill makes those requirements visible before the first install command.

## Validation

- built the CLI in a temporary directory
- exercised `--version`, core help commands, `nightshift init`, `nightshift config validate`, and `nightshift preview --json` in a disposable Git repository
- `go test ./...`
- `golangci-lint run`
- Docusaurus production build to a temporary output directory
- `git diff --check`
- verified every external README link resolves
