### PR TITLE
chore(lint): reduce 'make lint' to zero findings

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -370,7 +370,7 @@ func printStruct(v reflect.Value, indent int) {
 		case reflect.Struct:
 			fmt.Printf("%s%s:\n", prefix, tag)
 			printStruct(value, indent+1)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !value.IsNil() {
 				if value.Elem().Kind() == reflect.Struct {
 					fmt.Printf("%s%s:\n", prefix, tag)
@@ -408,7 +408,7 @@ func printStruct(v reflect.Value, indent int) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/marcus/nightshift/internal/budget"
 	"github.com/marcus/nightshift/internal/calibrator"
 	"github.com/marcus/nightshift/internal/config"
@@ -26,7 +28,6 @@ import (
 	"github.com/marcus/nightshift/internal/tasks"
 	"github.com/marcus/nightshift/internal/tmux"
 	"github.com/marcus/nightshift/internal/trends"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/nightshift/commands/init.go
+++ b/cmd/nightshift/commands/init.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/marcus/nightshift/internal/config"
 	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/config"
 )
 
 // ANSI color codes for terminal output

--- a/cmd/nightshift/commands/install.go
+++ b/cmd/nightshift/commands/install.go
@@ -8,8 +8,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/marcus/nightshift/internal/config"
 	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/config"
 )
 
 // Service type constants

--- a/cmd/nightshift/commands/logs.go
+++ b/cmd/nightshift/commands/logs.go
@@ -13,9 +13,10 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fsnotify/fsnotify"
-	"github.com/marcus/nightshift/internal/config"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/config"
 )
 
 var logsCmd = &cobra.Command{

--- a/cmd/nightshift/commands/preview_output.go
+++ b/cmd/nightshift/commands/preview_output.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+
 	"github.com/marcus/nightshift/internal/budget"
 )
 

--- a/cmd/nightshift/commands/report.go
+++ b/cmd/nightshift/commands/report.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/marcus/nightshift/internal/config"
-	"github.com/marcus/nightshift/internal/reporting"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+
+	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/reporting"
 )
 
 type reportOptions struct {

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -15,6 +15,10 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-isatty"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
+
 	"github.com/marcus/nightshift/internal/agents"
 	"github.com/marcus/nightshift/internal/budget"
 	"github.com/marcus/nightshift/internal/calibrator"
@@ -27,9 +31,6 @@ import (
 	"github.com/marcus/nightshift/internal/state"
 	"github.com/marcus/nightshift/internal/tasks"
 	"github.com/marcus/nightshift/internal/trends"
-	"github.com/mattn/go-isatty"
-	"github.com/muesli/termenv"
-	"github.com/spf13/cobra"
 )
 
 // isInteractive reports whether stdout is a terminal. Override in tests.

--- a/cmd/nightshift/commands/run_output.go
+++ b/cmd/nightshift/commands/run_output.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+
 	"github.com/marcus/nightshift/internal/budget"
 	"github.com/marcus/nightshift/internal/orchestrator"
 	"github.com/marcus/nightshift/internal/tasks"

--- a/cmd/nightshift/commands/task.go
+++ b/cmd/nightshift/commands/task.go
@@ -11,11 +11,12 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/marcus/nightshift/internal/logging"
 	"github.com/marcus/nightshift/internal/orchestrator"
 	"github.com/marcus/nightshift/internal/security"
 	"github.com/marcus/nightshift/internal/tasks"
-	"github.com/spf13/cobra"
 )
 
 var taskCmd = &cobra.Command{

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/marcus/nightshift/internal/config"
 	"github.com/marcus/nightshift/internal/state"
-	"github.com/spf13/viper"
 )
 
 // Project represents a resolved project with merged configuration.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,8 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/marcus/nightshift/internal/config"
 	"github.com/robfig/cron/v3"
+
+	"github.com/marcus/nightshift/internal/config"
 )
 
 // Errors for scheduler operations.


### PR DESCRIPTION
## Summary
Reduces `make lint` (`golangci-lint run`) to **0 issues** on the nightshift module via an autofix-first approach. No behavioral changes.

## What changed
- **govet (inline):** replaced the deprecated `reflect.Ptr` constant with `reflect.Pointer` (Go 1.18+ alias) in `cmd/nightshift/commands/config.go` (2 occurrences).
- **goimports:** normalized import grouping (`-local github.com/marcus/nightshift`) across the touched command/internal packages.

## Categories of lint issues fixed
- Deprecated/renamed APIs (govet `inline`) — 2 findings in `config.go`.
- Import ordering / formatting — 12 files normalized by `goimports`/`gofmt`.

## Verification
- `make lint` → `0 issues` (exit 0)
- `go build ./...` → clean
- `go vet ./...` → clean
- `go test ./...` → all packages pass

```
Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift
```