### PR TITLE
Fix reflect pointer lint findings

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -370,7 +370,7 @@ func printStruct(v reflect.Value, indent int) {
 		case reflect.Struct:
 			fmt.Printf("%s%s:\n", prefix, tag)
 			printStruct(value, indent+1)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !value.IsNil() {
 				if value.Elem().Kind() == reflect.Struct {
 					fmt.Printf("%s%s:\n", prefix, tag)
@@ -408,7 +408,7 @@ func printStruct(v reflect.Value, indent int) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0


### PR DESCRIPTION
## Summary

- replace the deprecated `reflect.Ptr` alias with `reflect.Pointer` in config rendering and zero-value checks
- resolve the two `govet` inline diagnostics reported by golangci-lint v2.12.2

## Impact

No behavior changes. Both constants identify the same reflection kind; this updates the code to the canonical constant expected by the current analyzer.

## Validation

- `gofmt -l` (no output)
- `golangci-lint v2.12.2 run` (0 issues)
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `git diff --check`
