### PR TITLE
chore: fix govet reflect.Ptr lint findings in config command

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -370,7 +370,7 @@ func printStruct(v reflect.Value, indent int) {
 		case reflect.Struct:
 			fmt.Printf("%s%s:\n", prefix, tag)
 			printStruct(value, indent+1)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !value.IsNil() {
 				if value.Elem().Kind() == reflect.Struct {
 					fmt.Printf("%s%s:\n", prefix, tag)
@@ -408,7 +408,7 @@ func printStruct(v reflect.Value, indent int) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0


### PR DESCRIPTION
## Summary

Minimal-scope lint fix. `golangci-lint run ./...` on `origin/main` reported 2 govet `inline` findings in `cmd/nightshift/commands/config.go`, both flagging the deprecated `reflect.Ptr`. Replaced both occurrences with the modern `reflect.Pointer` alias (identical behavior; `reflect.Ptr` is a deprecated alias kept only for compatibility).

After the change: `golangci-lint` reports **0 issues**, `go build ./...` and `make test` pass.

## Scope note

This PR addresses exactly the findings present on `origin/main`. The plan mentioned 2 additional `errcheck` findings in `commit.go` (`fmt.Fprintln(os.Stdout, normalized)`), but that file does not exist on `origin/main` — it is introduced by a separate, unmerged feature commit (`feat(commits): add Conventional Commits message normalizer`, c26c5fd). Bundling that feature here would violate the minimal-scope / no-behavior-changes intent of this lint-fix task, so it is excluded.

## Changes
- `cmd/nightshift/commands/config.go`: `reflect.Ptr` → `reflect.Pointer` (2 sites)

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:.
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 0.4
cost-tier: Low (10-50k)
iterations: 1
duration: 27m38s
run-started: 2026-07-24T02:00:03+02:00
nightshift:metadata -->
