### PR TITLE
feat(commits): support breaking-change marker and preserve git footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ selected provider, budget status, projects, and planned tasks. In interactive
 terminals you are prompted for confirmation; in non-TTY environments (cron,
 daemon, CI) confirmation is auto-skipped.
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--dry-run` | `false` | Show preflight summary and exit without executing |
-| `--project`, `-p` | _(all configured)_ | Target a single project directory |
-| `--task`, `-t` | _(auto-select)_ | Run a specific task by name |
-| `--max-projects` | `1` | Max projects to process (ignored when `--project` is set) |
-| `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
-| `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
-| `--ignore-budget` | `false` | Bypass budget checks (use with caution) |
-| `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| Flag              | Default            | Description                                                              |
+| ----------------- | ------------------ | ------------------------------------------------------------------------ |
+| `--dry-run`       | `false`            | Show preflight summary and exit without executing                        |
+| `--project`, `-p` | _(all configured)_ | Target a single project directory                                        |
+| `--task`, `-t`    | _(auto-select)_    | Run a specific task by name                                              |
+| `--max-projects`  | `1`                | Max projects to process (ignored when `--project` is set)                |
+| `--max-tasks`     | `1`                | Max tasks per project (ignored when `--task` is set)                     |
+| `--random-task`   | `false`            | Pick a random task from eligible tasks instead of the highest-scored one |
+| `--ignore-budget` | `false`            | Bypass budget checks (use with caution)                                  |
+| `--yes`, `-y`     | `false`            | Skip the confirmation prompt                                             |
 
 ```bash
 # Interactive run with preflight summary + confirmation prompt
@@ -141,6 +141,7 @@ nightshift run -p ./my-project -t lint-fix
 ```
 
 Other useful flags:
+
 - `nightshift status --today` to see today's activity summary
 - `nightshift daemon start --foreground` for debug
 - `--category` — filter tasks by category (pr, analysis, options, safe, map, emergency)
@@ -153,8 +154,9 @@ Other useful flags:
 ## Authentication (Subscriptions)
 
 Nightshift supports three AI providers:
+
 - **Claude Code** - Anthropic's Claude via local CLI
-- **Codex** - OpenAI's GPT via local CLI  
+- **Codex** - OpenAI's GPT via local CLI
 - **GitHub Copilot** - GitHub's Copilot via GitHub CLI
 
 ### Claude Code
@@ -267,11 +269,54 @@ make install-hooks
 ```
 
 This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
 
 To bypass in a pinch: `git commit --no-verify`
+
+### Commit messages
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>)!: <subject>
+
+<body>
+
+<footer>
+```
+
+- **type** (required) — one of `feat`, `fix`, `docs`, `style`, `refactor`,
+  `test`, `chore`, `perf`, `build`, `ci`, `revert`.
+- **scope** (optional) — a lowercase noun in parentheses, e.g. `fix(api):`.
+- **`!`** (optional) — the breaking-change marker, placed after the type or
+  scope: `feat!:` or `feat(api)!:`. A `BREAKING CHANGE: <description>` footer
+  in the body documents the break.
+- **subject** (required) — a short, imperative, lowercase summary of at most
+  72 characters, with no trailing period.
+- **body** (optional) — wrapped at 72 columns; paragraphs are separated by a
+  blank line.
+- **footer** (optional) — git trailers such as `Fixes #123`,
+  `Reviewed-by: Alice`, or `Nightshift-Task: ...`. Footer blocks are preserved
+  verbatim (never reflowed) so structured metadata stays intact.
+
+The normalizer is available as a CLI command and is enforced by a `commit-msg`
+hook:
+
+```bash
+# Validate and rewrite a message into canonical form
+nightshift commit normalize "FEAT(api): rename endpoint"
+
+# Only validate (non-zero exit on violations)
+nightshift commit normalize --check --file .git/COMMIT_EDITMSG
+```
+
+`make install-hooks` also installs `scripts/commit-msg.sh`, which normalizes the
+message before the commit is created and rejects messages it cannot fix (missing
+or unknown type, capitalized or overlong subject). The same `--no-verify` bypass
+applies.
 
 ## Uninstalling
 

--- a/cmd/nightshift/commands/commit.go
+++ b/cmd/nightshift/commands/commit.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/marcus/nightshift/internal/commits"
+	"github.com/spf13/cobra"
+)
+
+var commitCmd = &cobra.Command{
+	Use:   "commit",
+	Short: "Conventional Commits helpers",
+	Long: `Tools for working with Conventional Commits messages.
+
+Use "commit normalize" to validate and reformat a commit message so it
+follows the project's rules (type prefix, lowercase type, subject length,
+and wrapped body).`,
+}
+
+var commitNormalizeCmd = &cobra.Command{
+	Use:   "normalize [MESSAGE]",
+	Short: "Normalize a commit message to Conventional Commits format",
+	Long: `Validate and rewrite a commit message into canonical Conventional
+Commits form.
+
+The message is read from a positional argument, from a file passed via
+--file (typically .git/COMMIT_EDITMSG by a commit-msg hook), or from stdin
+when no argument and no --file are given.
+
+  nightshift commit normalize "feat: add login"
+  nightshift commit normalize --file .git/COMMIT_EDITMSG
+  git log -1 --pretty=%B | nightshift commit normalize
+
+Use --check to only validate without rewriting; the exit code is non-zero
+when the message does not conform.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		check, _ := cmd.Flags().GetBool("check")
+		file, _ := cmd.Flags().GetString("file")
+
+		raw, err := readCommitMessage(args, file)
+		if err != nil {
+			return err
+		}
+
+		normalized, err := commits.Normalize(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return err
+		}
+
+		if check {
+			fmt.Fprintln(os.Stdout, normalized)
+			return nil
+		}
+		fmt.Fprintln(os.Stdout, normalized)
+		return nil
+	},
+}
+
+func init() {
+	commitNormalizeCmd.Flags().BoolP("check", "c", false, "Only validate; do not rewrite")
+	commitNormalizeCmd.Flags().StringP("file", "f", "", "Read the message from this file (use by the commit-msg hook)")
+	commitCmd.AddCommand(commitNormalizeCmd)
+	rootCmd.AddCommand(commitCmd)
+}
+
+// readCommitMessage resolves the message source in order: positional arg,
+// --file, then stdin.
+func readCommitMessage(args []string, file string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	if file != "" {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", file, err)
+		}
+		return string(b), nil
+	}
+	b, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(b), nil
+}

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -1,0 +1,47 @@
+# Commit Messages
+
+Nightshift uses [Conventional Commits](https://www.conventionalcommits.org/)
+for all commit messages. This keeps the history readable and lets tooling
+derive changelogs automatically.
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+- **type** — one of `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
+  `chore`, `perf`, `build`, `ci`.
+- **scope** — optional, e.g. `fix(api): ...`.
+- **subject** — lowercase, imperative mood, no trailing period, max 72 chars.
+- **body** — optional, wrapped at 72 columns, separated from the subject by a
+  blank line.
+
+## The `commit normalize` command
+
+Validate and reformat a message:
+
+```sh
+nightshift commit normalize "feat: add login screen"
+nightshift commit normalize --file .git/COMMIT_EDITMSG
+git log -1 --pretty=%B | nightshift commit normalize
+```
+
+Add `--check` to validate only. The command exits non-zero when a message
+cannot be normalized (missing/unknown type, capitalized or overlong subject).
+
+## commit-msg hook
+
+To enforce the rules locally, install the hook:
+
+```sh
+make install-hooks
+# or manually:
+ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+```
+
+The hook normalizes your message file in place before the commit is created and
+rejects messages that cannot be fixed automatically. Bypass it with
+`git commit --no-verify`.

--- a/internal/commits/normalizer.go
+++ b/internal/commits/normalizer.go
@@ -4,9 +4,12 @@
 //
 // The supported format follows the Conventional Commits 1.0.0 specification:
 //
-//	<type>(<scope>): <subject>
+//	<type>(<scope>)!: <subject>
 //
 //	<body>
+//
+// The optional "!" after the type (or scope) marks a breaking change, and the
+// special "BREAKING CHANGE:" footer in the body is preserved verbatim.
 //
 // The normalizer is intentionally strict but constructive: rather than silently
 // accepting malformed input it fixes the trivially fixable (whitespace, type
@@ -39,6 +42,7 @@ var allowedTypes = map[string]struct{}{
 	"perf":     {},
 	"build":    {},
 	"ci":       {},
+	"revert":   {},
 }
 
 // Errors returned by the normalizer. They are wrapped so callers can match on
@@ -77,7 +81,7 @@ func Normalize(msg string) (string, error) {
 	header := lines[0]
 	body := lines[1:]
 
-	typ, scope, subject, err := parseHeader(header)
+	typ, scope, subject, breaking, err := parseHeader(header)
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +89,7 @@ func Normalize(msg string) (string, error) {
 	subject = cleanSubject(subject)
 
 	var b strings.Builder
-	b.WriteString(formatHeader(typ, scope, subject))
+	b.WriteString(formatHeader(typ, scope, subject, breaking))
 
 	wrapped := wrapBody(body, BodyWrapWidth)
 	if wrapped != "" {
@@ -121,20 +125,30 @@ func stripComments(msg string) []string {
 
 // parseHeader splits the first line into its Conventional Commit components and
 // validates them. The returned type is lower-cased to match the allowed set.
-func parseHeader(header string) (typ, scope, subject string, err error) {
+// A trailing "!" on the type/scope (e.g. "feat!:" or "feat(scope)!:") is parsed
+// as the Conventional Commits breaking-change marker and reported via the
+// breaking return value.
+func parseHeader(header string) (typ, scope, subject string, breaking bool, err error) {
 	header = strings.TrimSpace(header)
 	colon := strings.Index(header, ":")
 	if colon <= 0 {
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
 	}
 	prefix := header[:colon]
 	subject = strings.TrimSpace(header[colon+1:])
 
-	// Split an optional "(scope)" from the type.
+	// Detect the breaking-change marker "!" that sits between the type/scope
+	// and the colon before any further parsing.
 	prefix = strings.TrimSpace(prefix)
+	if strings.HasSuffix(prefix, "!") {
+		breaking = true
+		prefix = prefix[:len(prefix)-1]
+	}
+
+	// Split an optional "(scope)" from the type.
 	if strings.HasPrefix(prefix, "(") {
 		// A leading "(" with no type is not a valid conventional header.
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
 	}
 	if open := strings.Index(prefix, "("); open > 0 && strings.HasSuffix(prefix, ")") {
 		typ = prefix[:open]
@@ -146,21 +160,21 @@ func parseHeader(header string) (typ, scope, subject string, err error) {
 	scope = strings.TrimSpace(scope)
 
 	if typ == "" {
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
 	}
 	if !isAllowedType(typ) {
-		return "", "", "", fmt.Errorf("%w: %q", ErrUnknownType, typ)
+		return "", "", "", false, fmt.Errorf("%w: %q", ErrUnknownType, typ)
 	}
 	if strings.TrimSpace(subject) == "" {
-		return "", "", "", ErrMissingSubject
+		return "", "", "", false, ErrMissingSubject
 	}
 	if utf8.RuneCountInString(subject) > MaxSubjectLength {
-		return "", "", "", ErrSubjectTooLong
+		return "", "", "", false, ErrSubjectTooLong
 	}
 	if startsUpper(subject) {
-		return "", "", "", ErrSubjectLowercase
+		return "", "", "", false, ErrSubjectLowercase
 	}
-	return typ, scope, subject, nil
+	return typ, scope, subject, breaking, nil
 }
 
 // cleanSubject normalizes the subject text: lowercases a leading uppercase
@@ -172,19 +186,49 @@ func cleanSubject(subject string) string {
 	return s
 }
 
-// formatHeader reassembles a canonical header line from its components.
-func formatHeader(typ, scope, subject string) string {
-	if scope != "" {
-		return typ + "(" + scope + "): " + subject
+// formatHeader reassembles a canonical header line from its components. A
+// breaking-change marker ("!") is emitted after the type or scope when set.
+func formatHeader(typ, scope, subject string, breaking bool) string {
+	bang := ""
+	if breaking {
+		bang = "!"
 	}
-	return typ + ": " + subject
+	if scope != "" {
+		return typ + "(" + scope + ")" + bang + ": " + subject
+	}
+	return typ + bang + ": " + subject
 }
 
 // wrapBody collapses runs of blank lines, preserves non-blank paragraphs, and
 // hard-wraps each paragraph line to width. Paragraph breaks (a single blank
-// line) are preserved.
+// line) are preserved. A trailing footer block — one or more paragraphs whose
+// every line is a git footer (a "<Key>: <value>" or "<Key>#<value>" line, or a
+// "BREAKING CHANGE:" line) — is emitted verbatim rather than reflowed, so that
+// structured metadata such as "Fixes #123", "BREAKING CHANGE: ...", and the
+// project's own trailers survive normalization untouched.
 func wrapBody(body []string, width int) string {
-	var paragraphs [][]string
+	paragraphs, footerStart := bodyParagraphs(body)
+
+	var b strings.Builder
+	for i, p := range paragraphs {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		if i >= footerStart {
+			// Footer block: preserve internal line breaks, do not reflow.
+			b.WriteString(strings.Join(p, "\n"))
+		} else {
+			b.WriteString(wrapParagraph(strings.Join(p, " "), width))
+		}
+	}
+	return b.String()
+}
+
+// bodyParagraphs splits the body into paragraphs (maximal runs of non-blank
+// lines). It also returns footerStart, the index of the first paragraph of a
+// trailing contiguous footer block; it equals len(paragraphs) when the body has
+// no footer block.
+func bodyParagraphs(body []string) (paragraphs [][]string, footerStart int) {
 	var cur []string
 	for _, l := range body {
 		if strings.TrimSpace(l) == "" {
@@ -200,14 +244,68 @@ func wrapBody(body []string, width int) string {
 		paragraphs = append(paragraphs, cur)
 	}
 
-	var b strings.Builder
-	for i, p := range paragraphs {
-		if i > 0 {
-			b.WriteString("\n\n")
+	footerStart = len(paragraphs)
+	for i := len(paragraphs) - 1; i >= 0; i-- {
+		if isFooterParagraph(paragraphs[i]) {
+			footerStart = i
+		} else {
+			break
 		}
-		b.WriteString(wrapParagraph(strings.Join(p, " "), width))
 	}
-	return b.String()
+	return paragraphs, footerStart
+}
+
+// isFooterParagraph reports whether every line in the paragraph is a git footer
+// line. A footer paragraph is emitted verbatim rather than reflowed.
+func isFooterParagraph(lines []string) bool {
+	if len(lines) == 0 {
+		return false
+	}
+	for _, l := range lines {
+		if !isFooterLine(l) {
+			return false
+		}
+	}
+	return true
+}
+
+// isFooterLine reports whether l has the shape of a git trailer footer:
+//   - "BREAKING CHANGE: <value>", or
+//   - "<Token>: <value>" with a colon separator, or
+//   - "<Token> #<value>" issue-reference style (e.g. "Fixes #123"),
+//
+// where Token is a non-empty run of ASCII letters, digits, and dashes, and a
+// non-empty value follows the separator.
+func isFooterLine(l string) bool {
+	if rest := strings.TrimPrefix(l, "BREAKING CHANGE:"); rest != l {
+		return strings.TrimSpace(rest) != ""
+	}
+	if i := strings.Index(l, ": "); i > 0 && isFooterToken(l[:i]) && strings.TrimSpace(l[i+2:]) != "" {
+		return true
+	}
+	if i := strings.Index(l, " #"); i > 0 && isFooterToken(l[:i]) && strings.TrimSpace(l[i+2:]) != "" {
+		return true
+	}
+	return false
+}
+
+// isFooterToken reports whether s is a valid footer token: a non-empty run of
+// ASCII letters, digits, and dashes.
+func isFooterToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // wrapParagraph hard-wraps a single-line paragraph at width, breaking on word

--- a/internal/commits/normalizer.go
+++ b/internal/commits/normalizer.go
@@ -1,0 +1,255 @@
+// Package commits implements Conventional Commits message normalization and
+// validation. It exposes pure, well-tested functions used by the CLI and by the
+// commit-msg git hook to keep the project's history consistent.
+//
+// The supported format follows the Conventional Commits 1.0.0 specification:
+//
+//	<type>(<scope>): <subject>
+//
+//	<body>
+//
+// The normalizer is intentionally strict but constructive: rather than silently
+// accepting malformed input it fixes the trivially fixable (whitespace, type
+// casing, trailing punctuation, body wrapping) and rejects anything that needs
+// a human decision (missing type, unknown type, missing subject).
+package commits
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// MaxSubjectLength is the maximum number of runes allowed in a commit subject.
+const MaxSubjectLength = 72
+
+// BodyWrapWidth is the column at which the commit body is wrapped.
+const BodyWrapWidth = 72
+
+// allowedTypes is the set of Conventional Commit types this project accepts.
+var allowedTypes = map[string]struct{}{
+	"feat":     {},
+	"fix":      {},
+	"docs":     {},
+	"style":    {},
+	"refactor": {},
+	"test":     {},
+	"chore":    {},
+	"perf":     {},
+	"build":    {},
+	"ci":       {},
+}
+
+// Errors returned by the normalizer. They are wrapped so callers can match on
+// the underlying cause with errors.Is.
+var (
+	// ErrEmptyMessage is returned when the message contains no non-comment,
+	// non-whitespace content.
+	ErrEmptyMessage = errors.New("commit message is empty")
+	// ErrMissingType is returned when the subject line is not a Conventional
+	// Commit (no type prefix before the colon).
+	ErrMissingType = errors.New("commit message must start with a conventional commit type")
+	// ErrUnknownType is returned when the type prefix is not in the allowed set.
+	ErrUnknownType = errors.New("commit type is not in the allowed set")
+	// ErrMissingSubject is returned when the type prefix is present but no
+	// subject text follows the colon.
+	ErrMissingSubject = errors.New("commit subject is missing")
+	// ErrSubjectTooLong is returned when the subject exceeds MaxSubjectLength.
+	ErrSubjectTooLong = fmt.Errorf("commit subject exceeds %d characters", MaxSubjectLength)
+	// ErrSubjectLowercase is returned when the subject starts with an uppercase
+	// letter (the rule is "do not capitalize the subject").
+	ErrSubjectLowercase = errors.New("commit subject must not be capitalized")
+)
+
+// Normalize parses, validates, and rewrites a raw commit message so that it
+// conforms to the project's Conventional Commits rules. It returns the
+// canonical form and a non-nil error describing the first unrecoverable
+// problem when the message cannot be normalized.
+//
+// Normalization is idempotent: Normalize(Normalize(m)) == Normalize(m).
+func Normalize(msg string) (string, error) {
+	lines := stripComments(msg)
+	if len(lines) == 0 {
+		return "", ErrEmptyMessage
+	}
+
+	header := lines[0]
+	body := lines[1:]
+
+	typ, scope, subject, err := parseHeader(header)
+	if err != nil {
+		return "", err
+	}
+
+	subject = cleanSubject(subject)
+
+	var b strings.Builder
+	b.WriteString(formatHeader(typ, scope, subject))
+
+	wrapped := wrapBody(body, BodyWrapWidth)
+	if wrapped != "" {
+		b.WriteString("\n\n")
+		b.WriteString(wrapped)
+	}
+
+	return b.String(), nil
+}
+
+// stripComments removes git's commented-out lines (those beginning with "#"),
+// trims trailing whitespace from every line, and drops leading/trailing blank
+// lines. It returns the meaningful lines of the message.
+func stripComments(msg string) []string {
+	rawLines := strings.Split(msg, "\n")
+	out := make([]string, 0, len(rawLines))
+	for _, l := range rawLines {
+		l = strings.TrimRight(l, " \t\r")
+		if strings.HasPrefix(strings.TrimSpace(l), "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	// Drop leading and trailing blank lines.
+	for len(out) > 0 && strings.TrimSpace(out[0]) == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// parseHeader splits the first line into its Conventional Commit components and
+// validates them. The returned type is lower-cased to match the allowed set.
+func parseHeader(header string) (typ, scope, subject string, err error) {
+	header = strings.TrimSpace(header)
+	colon := strings.Index(header, ":")
+	if colon <= 0 {
+		return "", "", "", ErrMissingType
+	}
+	prefix := header[:colon]
+	subject = strings.TrimSpace(header[colon+1:])
+
+	// Split an optional "(scope)" from the type.
+	prefix = strings.TrimSpace(prefix)
+	if strings.HasPrefix(prefix, "(") {
+		// A leading "(" with no type is not a valid conventional header.
+		return "", "", "", ErrMissingType
+	}
+	if open := strings.Index(prefix, "("); open > 0 && strings.HasSuffix(prefix, ")") {
+		typ = prefix[:open]
+		scope = prefix[open+1 : len(prefix)-1]
+	} else {
+		typ = prefix
+	}
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	scope = strings.TrimSpace(scope)
+
+	if typ == "" {
+		return "", "", "", ErrMissingType
+	}
+	if !isAllowedType(typ) {
+		return "", "", "", fmt.Errorf("%w: %q", ErrUnknownType, typ)
+	}
+	if strings.TrimSpace(subject) == "" {
+		return "", "", "", ErrMissingSubject
+	}
+	if utf8.RuneCountInString(subject) > MaxSubjectLength {
+		return "", "", "", ErrSubjectTooLong
+	}
+	if startsUpper(subject) {
+		return "", "", "", ErrSubjectLowercase
+	}
+	return typ, scope, subject, nil
+}
+
+// cleanSubject normalizes the subject text: lowercases a leading uppercase
+// letter is *not* done here (capitalization is a hard error, not a fix), but
+// surrounding whitespace and a trailing period are removed.
+func cleanSubject(subject string) string {
+	s := strings.TrimSpace(subject)
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+// formatHeader reassembles a canonical header line from its components.
+func formatHeader(typ, scope, subject string) string {
+	if scope != "" {
+		return typ + "(" + scope + "): " + subject
+	}
+	return typ + ": " + subject
+}
+
+// wrapBody collapses runs of blank lines, preserves non-blank paragraphs, and
+// hard-wraps each paragraph line to width. Paragraph breaks (a single blank
+// line) are preserved.
+func wrapBody(body []string, width int) string {
+	var paragraphs [][]string
+	var cur []string
+	for _, l := range body {
+		if strings.TrimSpace(l) == "" {
+			if len(cur) > 0 {
+				paragraphs = append(paragraphs, cur)
+				cur = nil
+			}
+			continue
+		}
+		cur = append(cur, strings.TrimSpace(l))
+	}
+	if len(cur) > 0 {
+		paragraphs = append(paragraphs, cur)
+	}
+
+	var b strings.Builder
+	for i, p := range paragraphs {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(wrapParagraph(strings.Join(p, " "), width))
+	}
+	return b.String()
+}
+
+// wrapParagraph hard-wraps a single-line paragraph at width, breaking on word
+// boundaries. A word longer than width is left intact rather than split.
+func wrapParagraph(text string, width int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	lineLen := 0
+	for i, w := range words {
+		if i == 0 {
+			b.WriteString(w)
+			lineLen = len(w)
+			continue
+		}
+		if lineLen+1+len(w) <= width {
+			b.WriteByte(' ')
+			b.WriteString(w)
+			lineLen += 1 + len(w)
+		} else {
+			b.WriteByte('\n')
+			b.WriteString(w)
+			lineLen = len(w)
+		}
+	}
+	return b.String()
+}
+
+// isAllowedType reports whether typ is one of the accepted Conventional Commit
+// types.
+func isAllowedType(typ string) bool {
+	_, ok := allowedTypes[typ]
+	return ok
+}
+
+// startsUpper reports whether the first rune of s is an ASCII uppercase letter.
+func startsUpper(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return r >= 'A' && r <= 'Z'
+}

--- a/internal/commits/normalizer_test.go
+++ b/internal/commits/normalizer_test.go
@@ -34,6 +34,44 @@ func TestNormalize(t *testing.T) {
 			want: "feat(ui): render button",
 		},
 		{
+			name: "breaking-change marker without scope",
+			in:   "feat!: drop support for v1",
+			want: "feat!: drop support for v1",
+		},
+		{
+			name: "breaking-change marker with scope",
+			in:   "feat(api)!: rename public endpoint",
+			want: "feat(api)!: rename public endpoint",
+		},
+		{
+			name: "revert type accepted",
+			in:   "revert: roll back the broken release",
+			want: "revert: roll back the broken release",
+		},
+		{
+			name: "previously-rejected feat! now round-trips",
+			in:   "  FEAT!: remove legacy parser  ",
+			want: "feat!: remove legacy parser",
+		},
+		{
+			name: "BREAKING CHANGE footer preserved verbatim",
+			in:   "feat!: drop v1\n\nThe old API is gone.\n\nBREAKING CHANGE: removes /v1 entirely",
+			want: "feat!: drop v1\n\nThe old API is gone.\n\nBREAKING CHANGE: removes /v1 entirely",
+		},
+		{
+			name: "structured trailers preserved and not reflowed",
+			in: "fix: patch leak\n\nSome long explanatory paragraph that would normally be hard wrapped by the normalizer onto several lines so we can confirm it still wraps while the trailers below stay verbatim.\n\n" +
+				"Fixes #123\n" +
+				"Reviewed-by: Alice\n" +
+				"Nightshift-Task: commit-normalize\n" +
+				"Nightshift-Ref: https://example.com/repo",
+			want: "fix: patch leak\n\nSome long explanatory paragraph that would normally be hard wrapped by\nthe normalizer onto several lines so we can confirm it still wraps while\nthe trailers below stay verbatim.\n\n" +
+				"Fixes #123\n" +
+				"Reviewed-by: Alice\n" +
+				"Nightshift-Task: commit-normalize\n" +
+				"Nightshift-Ref: https://example.com/repo",
+		},
+		{
 			name: "preserves body and wraps long lines",
 			in:   "feat: add thing\n\nthis is a body paragraph that is intentionally far longer than the configured wrap width so it must be hard wrapped onto multiple lines by the normalizer function",
 			want: "feat: add thing\n\n" +
@@ -105,6 +143,11 @@ func TestNormalizeIdempotent(t *testing.T) {
 		"feat: add login screen",
 		"fix(api): handle nil response\n\nLong body that explains the fix in more detail than the subject alone can manage so that we exercise the wrapping path too and then some more words here.",
 		"docs: update README\n\nfirst paragraph\n\nsecond paragraph stays separate",
+		"feat!: drop support for v1",
+		"feat(api)!: rename public endpoint",
+		"revert: roll back the broken release",
+		"fix: patch leak\n\nExplains the fix with a long paragraph that exercises wrapping here.\n\nFixes #123\nNightshift-Task: commit-normalize",
+		"feat!: remove v1\n\nBody before footers.\n\nBREAKING CHANGE: removes /v1 entirely",
 	}
 	for _, in := range cases {
 		once, err := Normalize(in)
@@ -122,7 +165,7 @@ func TestNormalizeIdempotent(t *testing.T) {
 }
 
 func TestAllowedTypes(t *testing.T) {
-	for _, typ := range []string{"feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"} {
+	for _, typ := range []string{"feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci", "revert"} {
 		if !isAllowedType(typ) {
 			t.Errorf("expected %q to be an allowed type", typ)
 		}
@@ -130,4 +173,48 @@ func TestAllowedTypes(t *testing.T) {
 	if isAllowedType("wip") {
 		t.Error("did not expect wip to be allowed")
 	}
+}
+
+func TestFooterDetection(t *testing.T) {
+	t.Run("footer line shapes", func(t *testing.T) {
+		good := []string{
+			"Fixes #123",
+			"BREAKING CHANGE: drop v1",
+			"Co-authored-by: A. Uthor <a@example.com>",
+			"Nightshift-Task: commit-normalize",
+			"Reviewed-by: Alice",
+		}
+		for _, l := range good {
+			if !isFooterLine(l) {
+				t.Errorf("expected %q to be a footer line", l)
+			}
+		}
+		bad := []string{
+			"plain prose",
+			"no separator here",
+			": missing key",
+			"key:",   // no value after separator
+			"Fixes#", // no value after separator
+		}
+		for _, l := range bad {
+			if isFooterLine(l) {
+				t.Errorf("did not expect %q to be a footer line", l)
+			}
+		}
+	})
+
+	t.Run("prose paragraph not treated as footer block", func(t *testing.T) {
+		// A trailing paragraph that mixes footer-shaped and prose lines is not
+		// a footer block and must be reflowed normally.
+		prose := "first line is fine yes and this is plainly long prose that should be hard wrapped by the normalizer onto several lines for sure"
+		in := "docs: note\n\nfirst line is fine: yes\n" + prose
+		got, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The prose paragraph must not be preserved verbatim; it should be wrapped.
+		if strings.Contains(got, prose) {
+			t.Errorf("expected prose to be reflowed, got %q", got)
+		}
+	})
 }

--- a/internal/commits/normalizer_test.go
+++ b/internal/commits/normalizer_test.go
@@ -1,0 +1,133 @@
+package commits
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "valid simple feat",
+			in:   "feat: add login screen",
+			want: "feat: add login screen",
+		},
+		{
+			name: "valid with scope",
+			in:   "fix(api): handle nil response",
+			want: "fix(api): handle nil response",
+		},
+		{
+			name: "trims surrounding whitespace and trailing period",
+			in:   "  docs: update README.  ",
+			want: "docs: update README",
+		},
+		{
+			name: "lowercases an uppercased type",
+			in:   "FEAT(ui): render button",
+			want: "feat(ui): render button",
+		},
+		{
+			name: "preserves body and wraps long lines",
+			in:   "feat: add thing\n\nthis is a body paragraph that is intentionally far longer than the configured wrap width so it must be hard wrapped onto multiple lines by the normalizer function",
+			want: "feat: add thing\n\n" +
+				"this is a body paragraph that is intentionally far longer than the\n" +
+				"configured wrap width so it must be hard wrapped onto multiple lines by\n" +
+				"the normalizer function",
+		},
+		{
+			name: "strips git comment lines",
+			in:   "chore: tidy\n# please enter the commit message\n\nbody here",
+			want: "chore: tidy\n\nbody here",
+		},
+		{
+			name:    "missing type rejected",
+			in:      "just a plain message",
+			wantErr: ErrMissingType,
+		},
+		{
+			name:    "unknown type rejected",
+			in:      "wip: halfway done",
+			wantErr: ErrUnknownType,
+		},
+		{
+			name:    "missing subject rejected",
+			in:      "feat:",
+			wantErr: ErrMissingSubject,
+		},
+		{
+			name:    "capitalized subject rejected",
+			in:      "feat: Add login screen",
+			wantErr: ErrSubjectLowercase,
+		},
+		{
+			name:    "overlong subject rejected",
+			in:      "feat: " + strings.Repeat("a", MaxSubjectLength+1),
+			wantErr: ErrSubjectTooLong,
+		},
+		{
+			name:    "empty message rejected",
+			in:      "\n\n# only comments\n  \n",
+			wantErr: ErrEmptyMessage,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("Normalize(%q): expected error %v, got nil (result %q)", tc.in, tc.wantErr, got)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Normalize(%q): expected error to wrap %v, got %v", tc.in, tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Normalize(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeIdempotent(t *testing.T) {
+	cases := []string{
+		"feat: add login screen",
+		"fix(api): handle nil response\n\nLong body that explains the fix in more detail than the subject alone can manage so that we exercise the wrapping path too and then some more words here.",
+		"docs: update README\n\nfirst paragraph\n\nsecond paragraph stays separate",
+	}
+	for _, in := range cases {
+		once, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("first Normalize(%q) errored: %v", in, err)
+		}
+		twice, err := Normalize(once)
+		if err != nil {
+			t.Fatalf("second Normalize(%q) errored: %v", once, err)
+		}
+		if once != twice {
+			t.Errorf("not idempotent for %q\n once:  %q\n twice: %q", in, once, twice)
+		}
+	}
+}
+
+func TestAllowedTypes(t *testing.T) {
+	for _, typ := range []string{"feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"} {
+		if !isAllowedType(typ) {
+			t.Errorf("expected %q to be an allowed type", typ)
+		}
+	}
+	if isAllowedType("wip") {
+		t.Error("did not expect wip to be allowed")
+	}
+}

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+#
+# Enforces Conventional Commits on every commit message and rewrites the
+# message file into canonical form before the commit is created. Messages that
+# cannot be normalized (missing/unknown type, capitalized or overlong subject)
+# are rejected with a non-zero exit so the commit is aborted.
+#
+# Install:
+#   make install-hooks
+#   # or manually:
+#   ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+#   chmod +x scripts/commit-msg.sh
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: commit-msg <message-file>" >&2
+  exit 1
+fi
+
+MSG_FILE="$1"
+
+# Resolve the nightshift binary: prefer the one on $PATH, fall back to
+# building the current source tree.
+NIGHTSHIFT="$(command -v nightshift || true)"
+if [[ -z "$NIGHTSHIFT" ]]; then
+  NIGHTSHIFT="go run github.com/marcus/nightshift/cmd/nightshift"
+fi
+
+NORMALIZED="$($NIGHTSHIFT commit normalize --file "$MSG_FILE" 2>/tmp/nightshift-commit-msg.err)"
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "🪡 commit-msg: message does not follow Conventional Commits" >&2
+  sed 's/^/    /' /tmp/nightshift-commit-msg.err >&2 || true
+  echo "" >&2
+  echo "    Expected format: <type>(<scope>): <subject>" >&2
+  echo "    Types: feat fix docs style refactor test chore perf build ci" >&2
+  echo "    (rewrite your message, or bypass with: git commit --no-verify)" >&2
+  exit 1
+fi
+
+# Rewrite the message file into canonical form.
+printf '%s\n' "$NORMALIZED" > "$MSG_FILE"
+echo "🪡 commit-msg: normalized"
+exit 0

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -34,8 +34,8 @@ if [[ $STATUS -ne 0 ]]; then
   echo "🪡 commit-msg: message does not follow Conventional Commits" >&2
   sed 's/^/    /' /tmp/nightshift-commit-msg.err >&2 || true
   echo "" >&2
-  echo "    Expected format: <type>(<scope>): <subject>" >&2
-  echo "    Types: feat fix docs style refactor test chore perf build ci" >&2
+  echo "    Expected format: <type>(<scope>)!: <subject>" >&2
+  echo "    Types: feat fix docs style refactor test chore perf build ci revert" >&2
   echo "    (rewrite your message, or bypass with: git commit --no-verify)" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Closes two real Conventional Commits spec gaps in the existing normalizer (`internal/commits/normalizer.go`), which previously rejected the breaking-change marker as an unknown type and reflowed structured git footers into prose.

### Breaking-change marker
- Parse the `!` marker that sits between the type/scope and the colon — `feat!:` and `feat(scope)!:` — in `parseHeader`, and carry a `breaking` flag through `formatHeader` so the canonical form preserves it. Without this, `feat!` was consumed into the type and rejected as unknown.
- Accept the `revert` type.

### Footer preservation
- Detect a trailing footer block — paragraphs whose every line is a git footer (`Fixes #123`, `BREAKING CHANGE:`, `Reviewed-by:`, project trailers like `Nightshift-Task:`) — and emit it **verbatim** instead of hard-wrapping it. Prose paragraphs are still wrapped at 72 columns; only the structured trailer block is left untouched.

### Tests & docs
- Table-driven tests for the `!` marker (with/without scope), `revert`, footer preservation, footer-line shape detection, and `feat!:` round-tripping; `Normalize` confirmed idempotent on all new forms.
- New **Commit messages** section in `README.md` documenting `<type>(<scope>)!: <subject>`, the allowed type set, subject length, and how `nightshift commit normalize` / the `commit-msg` hook consume it.
- `commit-msg.sh` help text now advertises `!` and `revert`.

`gofmt`, `go vet ./...`, and `go test ./...` are green.

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:.
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 0.4
cost-tier: Low (10-50k)
iterations: 1
duration: 56m31s
run-started: 2026-07-26T02:00:04+02:00
nightshift:metadata -->
