### PR TITLE
chore: normalize commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+exec "$repository_root/scripts/normalize-commit-message.sh" "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+cd "$repository_root" || exit 1
+exec "$repository_root/scripts/pre-commit.sh" "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-verbose test-race coverage coverage-html lint clean deps check install calibrate-providers install-hooks help
+.PHONY: build test test-commit-normalizer test-verbose test-race coverage coverage-html lint clean deps check install calibrate-providers install-hooks help
 
 # Binary name
 BINARY=nightshift
@@ -18,8 +18,12 @@ calibrate-providers:
 	go run ./cmd/provider-calibration --repo "$$(pwd)" --codex-originator codex_cli_rs --min-user-turns 2
 
 # Run all tests
-test:
+test: test-commit-normalizer
 	go test ./...
+
+# Run commit message normalizer regression tests
+test-commit-normalizer:
+	./tests/commit-message-normalizer.sh
 
 # Run tests with verbose output
 test-verbose:
@@ -64,7 +68,8 @@ check: test lint
 help:
 	@echo "Available targets:"
 	@echo "  build         - Build the binary"
-	@echo "  test          - Run all tests"
+	@echo "  test          - Run shell regression tests and Go tests"
+	@echo "  test-commit-normalizer - Run commit message normalizer regression tests"
 	@echo "  test-verbose  - Run tests with verbose output"
 	@echo "  test-race     - Run tests with race detection"
 	@echo "  coverage      - Run tests with coverage report"
@@ -75,10 +80,9 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Enable repository-managed git hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install repository-managed hooks
 install-hooks:
-	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
-	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@./scripts/install-hooks.sh

--- a/README.md
+++ b/README.md
@@ -301,20 +301,65 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Enable the repository-managed hooks:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+The installer sets the repository-local `core.hooksPath` to `.githooks`. It does
+not change global Git configuration, is safe to run repeatedly, and stops
+without changing anything if the repository already has a different local hook
+path.
+
+The pre-commit hook retains the existing checks:
+
 - **gofmt** - flags any staged `.go` files that need formatting
 - **go vet** - catches common correctness issues
 - **go build** - ensures the project compiles
 
-To bypass in a pinch: `git commit --no-verify`
+The commit-msg hook standardizes future commit subjects. It does not rewrite
+existing history. Subjects use this format:
+
+```text
+type(scope)!: summary
+```
+
+The scope and breaking-change `!` marker are optional. Supported types are
+`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`,
+`style`, and `test`.
+
+The normalizer lowercases the type and scope, removes whitespace around the
+optional scope and `!`, trims the subject, and collapses repeated spaces or tabs
+in the summary. It preserves the body and trailers exactly.
+
+```text
+ FIX (CLI) ! :   Preserve  API IDs
+```
+
+becomes:
+
+```text
+fix(cli)!: Preserve API IDs
+```
+
+Malformed or unsupported subjects fail the commit and remain byte-for-byte
+unchanged so they can be corrected. Git-generated merge, revert, autosquash,
+stash, and combined-commit messages are left alone. Combined-commit detection
+respects `core.commentChar`, `core.commentString`, and automatic comment
+prefixes without exempting ordinary invalid comment-led subjects.
+
+Run the hook regression suite by itself or together with the Go tests:
+
+```bash
+make test-commit-normalizer
+make test
+```
+
+Both hooks propagate failures. To bypass them in a pinch, use the existing
+escape hatch: `git commit --no-verify`.
 
 ## Uninstalling
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -u
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "install-hooks: run this command inside a Git worktree" >&2
+  exit 1
+}
+
+if [ ! -x "$repository_root/.githooks/pre-commit" ] ||
+  [ ! -x "$repository_root/.githooks/commit-msg" ]; then
+  echo "install-hooks: repository-managed hooks are missing or not executable" >&2
+  exit 1
+fi
+
+configured_hooks_path=$(git config --local --get core.hooksPath 2>/dev/null)
+config_status=$?
+
+if [ "$config_status" -eq 0 ]; then
+  if [ "$configured_hooks_path" = ".githooks" ]; then
+    echo "✓ git hooks already configured (core.hooksPath=.githooks)"
+    exit 0
+  fi
+
+  echo "install-hooks: refusing to replace repository-local core.hooksPath=$configured_hooks_path" >&2
+  exit 1
+fi
+
+if [ "$config_status" -ne 1 ]; then
+  echo "install-hooks: could not read repository-local core.hooksPath" >&2
+  exit 1
+fi
+
+if ! git config --local core.hooksPath .githooks; then
+  echo "install-hooks: could not configure repository-local core.hooksPath" >&2
+  exit 1
+fi
+
+echo "✓ git hooks installed (core.hooksPath=.githooks)"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -13,16 +13,24 @@ if [ ! -x "$repository_root/.githooks/pre-commit" ] ||
   exit 1
 fi
 
-configured_hooks_path=$(git config --local --get core.hooksPath 2>/dev/null)
+# Keep a non-newline marker so command substitution cannot discard output
+# separators. This distinguishes one managed value from duplicate, empty, or
+# otherwise conflicting local values.
+configured_hooks_paths_with_marker=$(
+  git config --local --get-all core.hooksPath 2>/dev/null
+  config_status=$?
+  printf 'x'
+  exit "$config_status"
+)
 config_status=$?
 
 if [ "$config_status" -eq 0 ]; then
-  if [ "$configured_hooks_path" = ".githooks" ]; then
+  if [ "$configured_hooks_paths_with_marker" = "$(printf '.githooks\nx')" ]; then
     echo "✓ git hooks already configured (core.hooksPath=.githooks)"
     exit 0
   fi
 
-  echo "install-hooks: refusing to replace repository-local core.hooksPath=$configured_hooks_path" >&2
+  echo "install-hooks: refusing to replace conflicting repository-local core.hooksPath value(s)" >&2
   exit 1
 fi
 

--- a/scripts/normalize-commit-message.sh
+++ b/scripts/normalize-commit-message.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+set -u
+
+usage() {
+  echo "usage: $0 <commit-message-file>" >&2
+}
+
+reject() {
+  echo "commit-msg: $1" >&2
+  echo "expected: type(scope)!: summary" >&2
+  echo "types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test" >&2
+  exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+message_file=$1
+
+if [ ! -f "$message_file" ]; then
+  echo "commit-msg: message file does not exist or is not a regular file: $message_file" >&2
+  exit 2
+fi
+
+if [ ! -r "$message_file" ] || [ ! -w "$message_file" ]; then
+  echo "commit-msg: message file must be readable and writable: $message_file" >&2
+  exit 2
+fi
+
+subject=
+IFS= read -r subject < "$message_file"
+read_status=$?
+if [ "$read_status" -ne 0 ] && [ -z "$subject" ]; then
+  reject "commit message is empty"
+fi
+
+case "$subject" in
+  Merge\ * | Revert\ \"*\" | fixup!\ * | squash!\ * | amend!\ * | \
+    WIP\ on\ *:* | On\ *:\ * | index\ on\ *:* | untracked\ files\ on\ *:*)
+    exit 0
+    ;;
+esac
+
+is_combined_message=0
+commented_probe=$(printf 'probe\n' | git stripspace --comment-lines 2>/dev/null) || commented_probe='# probe'
+case "$commented_probe" in
+  *" probe")
+    comment_prefix=${commented_probe%" probe"}
+    case "$subject" in
+      "$comment_prefix This is a combination of "*)
+        combined_count=${subject#"$comment_prefix This is a combination of "}
+        if printf '%s\n' "$combined_count" | LC_ALL=C grep -Eq '^([2-9]|[1-9][0-9]+) commits\.$'; then
+          is_combined_message=1
+        fi
+        ;;
+    esac
+    ;;
+esac
+
+comment_config_line=$(git config --get-regexp '^core\.comment(char|string)$' 2>/dev/null | tail -n 1)
+comment_setting=${comment_config_line#* }
+if [ "$is_combined_message" -eq 0 ] && [ "$comment_setting" = "auto" ]; then
+  if printf '%s\n' "$subject" |
+    LC_ALL=C grep -Eq '^[#;@!$%^&|:] This is a combination of ([2-9]|[1-9][0-9]+) commits\.$'; then
+    is_combined_message=1
+  fi
+fi
+
+if [ "$is_combined_message" -eq 1 ]; then
+  exit 0
+fi
+
+trimmed_subject=$(
+  printf '%s\n' "$subject" |
+    LC_ALL=C sed \
+      -e 's/[[:blank:]][[:blank:]]*/ /g' \
+      -e 's/^ //' \
+      -e 's/ $//'
+)
+
+case "$trimmed_subject" in
+  *:*)
+    raw_header=${trimmed_subject%%:*}
+    summary=${trimmed_subject#*:}
+    ;;
+  *)
+    reject "subject is not a Conventional Commit"
+    ;;
+esac
+
+header=$(
+  printf '%s\n' "$raw_header" |
+    LC_ALL=C sed \
+      -e 's/^ //' \
+      -e 's/ $//' \
+      -e 's/[[:blank:]]*(/(/' \
+      -e 's/)[[:blank:]]*!$/)!/' \
+      -e 's/[[:blank:]]*!$/!/' |
+    LC_ALL=C tr '[:upper:]' '[:lower:]'
+)
+
+summary=$(
+  printf '%s\n' "$summary" |
+    LC_ALL=C sed \
+      -e 's/[[:blank:]][[:blank:]]*/ /g' \
+      -e 's/^ //' \
+      -e 's/ $//'
+)
+
+if ! printf '%s\n' "$header" |
+  LC_ALL=C grep -Eq '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?!?$'; then
+  reject "subject has an unsupported type or malformed scope"
+fi
+
+if [ -z "$summary" ]; then
+  reject "subject summary is empty"
+fi
+
+normalized_subject="$header: $summary"
+if [ "$normalized_subject" = "$subject" ]; then
+  exit 0
+fi
+
+subject_bytes=$(printf '%s' "$subject" | LC_ALL=C wc -c | tr -d '[:space:]')
+temporary_file=$(mktemp "${message_file}.normalize.XXXXXX") || {
+  echo "commit-msg: could not create a temporary message file" >&2
+  exit 2
+}
+
+cleanup() {
+  rm -f "$temporary_file"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! printf '%s' "$normalized_subject" > "$temporary_file"; then
+  echo "commit-msg: could not write normalized message" >&2
+  exit 2
+fi
+
+if ! dd if="$message_file" bs=1 skip="$subject_bytes" >> "$temporary_file" 2>/dev/null; then
+  echo "commit-msg: could not preserve the commit message body" >&2
+  exit 2
+fi
+
+if ! mv "$temporary_file" "$message_file"; then
+  echo "commit-msg: could not replace the commit message" >&2
+  exit 2
+fi
+
+trap - EXIT HUP INT TERM

--- a/scripts/normalize-commit-message.sh
+++ b/scripts/normalize-commit-message.sh
@@ -145,9 +145,10 @@ if ! dd if="$message_file" bs=1 skip="$subject_bytes" >> "$temporary_file" 2>/de
   exit 2
 fi
 
-if ! mv "$temporary_file" "$message_file"; then
-  echo "commit-msg: could not replace the commit message" >&2
+if ! cat "$temporary_file" > "$message_file"; then
+  echo "commit-msg: could not update the commit message" >&2
   exit 2
 fi
 
+rm -f "$temporary_file"
 trap - EXIT HUP INT TERM

--- a/tests/commit-message-normalizer.sh
+++ b/tests/commit-message-normalizer.sh
@@ -346,29 +346,51 @@ else
 fi
 assert_status "installer is idempotent" 0 "$installer_second_status"
 
-conflict_repository="$temporary_root/conflict-repository"
-git init -q "$conflict_repository"
-mkdir -p "$conflict_repository/.githooks"
-cp "$repository_root/.githooks/commit-msg" "$conflict_repository/.githooks/commit-msg"
-cp "$repository_root/.githooks/pre-commit" "$conflict_repository/.githooks/pre-commit"
-chmod +x "$conflict_repository/.githooks/commit-msg" "$conflict_repository/.githooks/pre-commit"
-git -C "$conflict_repository" config --local core.hooksPath /custom/hooks
+assert_installer_rejects_paths() {
+  conflict_slug=$1
+  conflict_description=$2
+  shift 2
 
-if (
-  cd "$conflict_repository" || exit 1
-  "$installer"
-) >/dev/null 2>&1; then
-  conflict_status=0
-else
-  conflict_status=$?
-fi
-assert_status "installer rejects a conflicting repository-local hook path" 1 "$conflict_status"
-conflict_path=$(git -C "$conflict_repository" config --local --get core.hooksPath)
-if [ "$conflict_path" = "/custom/hooks" ]; then
-  pass "installer leaves a conflicting hook path unchanged"
-else
-  fail "installer leaves a conflicting hook path unchanged"
-fi
+  conflict_repository="$temporary_root/conflict-$conflict_slug"
+  git init -q "$conflict_repository"
+  mkdir -p "$conflict_repository/.githooks"
+  cp "$repository_root/.githooks/commit-msg" "$conflict_repository/.githooks/commit-msg"
+  cp "$repository_root/.githooks/pre-commit" "$conflict_repository/.githooks/pre-commit"
+  chmod +x "$conflict_repository/.githooks/commit-msg" "$conflict_repository/.githooks/pre-commit"
+
+  for conflict_path do
+    git -C "$conflict_repository" config --local --add core.hooksPath "$conflict_path"
+  done
+  cp "$conflict_repository/.git/config" "$conflict_repository/config.before"
+
+  if (
+    cd "$conflict_repository" || exit 1
+    "$installer"
+  ) >/dev/null 2>&1; then
+    conflict_status=0
+  else
+    conflict_status=$?
+  fi
+  assert_status "installer rejects $conflict_description" 1 "$conflict_status"
+  assert_files_equal "installer leaves $conflict_description unchanged" \
+    "$conflict_repository/config.before" "$conflict_repository/.git/config"
+}
+
+assert_installer_rejects_paths "single" \
+  "a conflicting repository-local hook path" \
+  "/custom/hooks"
+assert_installer_rejects_paths "conflict-first" \
+  "multiple hook paths when the managed path is last" \
+  "/custom/hooks" ".githooks"
+assert_installer_rejects_paths "conflict-last" \
+  "multiple hook paths when the managed path is first" \
+  ".githooks" "/custom/hooks"
+assert_installer_rejects_paths "duplicate" \
+  "duplicate repository-local managed hook paths" \
+  ".githooks" ".githooks"
+assert_installer_rejects_paths "empty-last" \
+  "an additional empty repository-local hook path" \
+  ".githooks" ""
 
 printf '1..%d\n' "$tests_run"
 if [ "$tests_failed" -ne 0 ]; then

--- a/tests/commit-message-normalizer.sh
+++ b/tests/commit-message-normalizer.sh
@@ -1,0 +1,286 @@
+#!/bin/sh
+
+set -u
+
+repository_root=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+normalizer="$repository_root/scripts/normalize-commit-message.sh"
+installer="$repository_root/scripts/install-hooks.sh"
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/nightshift-commit-normalizer.XXXXXX") || exit 1
+tests_run=0
+tests_failed=0
+
+cleanup() {
+  rm -rf "$temporary_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+pass() {
+  tests_run=$((tests_run + 1))
+  printf 'ok %d - %s\n' "$tests_run" "$1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  printf 'not ok %d - %s\n' "$tests_run" "$1" >&2
+}
+
+assert_files_equal() {
+  description=$1
+  expected=$2
+  actual=$3
+
+  if cmp -s "$expected" "$actual"; then
+    pass "$description"
+  else
+    fail "$description"
+    diff -u "$expected" "$actual" >&2 || true
+  fi
+}
+
+assert_status() {
+  description=$1
+  expected=$2
+  actual=$3
+
+  if [ "$expected" -eq "$actual" ]; then
+    pass "$description"
+  else
+    fail "$description (expected status $expected, got $actual)"
+  fi
+}
+
+run_normalizer() {
+  message_file=$1
+  (
+    cd "$repository_root" || exit 1
+    "$normalizer" "$message_file"
+  )
+}
+
+valid_message="$temporary_root/valid-message"
+valid_expected="$temporary_root/valid-expected"
+printf ' FIX (CLI) ! :   Preserve\t API   IDs \n\nBody  spacing stays.\n\nNightshift-Task: commit-normalize\nNightshift-Ref: https://github.com/marcus/nightshift\n' > "$valid_message"
+printf 'fix(cli)!: Preserve API IDs\n\nBody  spacing stays.\n\nNightshift-Task: commit-normalize\nNightshift-Ref: https://github.com/marcus/nightshift\n' > "$valid_expected"
+run_normalizer "$valid_message"
+assert_files_equal "normalizes metadata capitalization and whitespace while preserving the body and trailers" "$valid_expected" "$valid_message"
+
+idempotent_copy="$temporary_root/idempotent-copy"
+cp "$valid_message" "$idempotent_copy"
+run_normalizer "$valid_message"
+assert_files_equal "normalization is idempotent" "$idempotent_copy" "$valid_message"
+
+no_newline_message="$temporary_root/no-newline-message"
+no_newline_expected="$temporary_root/no-newline-expected"
+printf 'DOCS: Explain hooks' > "$no_newline_message"
+printf 'docs: Explain hooks' > "$no_newline_expected"
+run_normalizer "$no_newline_message"
+assert_files_equal "preserves a missing final newline" "$no_newline_expected" "$no_newline_message"
+
+supported_types_message="$temporary_root/supported-types-message"
+for supported_type in build chore ci docs feat fix perf refactor revert style test
+do
+  printf '%s: exercise supported type\n' "$supported_type" > "$supported_types_message"
+  if run_normalizer "$supported_types_message" >/dev/null 2>&1; then
+    supported_type_status=0
+  else
+    supported_type_status=$?
+  fi
+  assert_status "accepts supported type: $supported_type" 0 "$supported_type_status"
+done
+
+for invalid_subject in \
+  'Fix the hook' \
+  'release: publish' \
+  'feat(bad scope): add hook' \
+  'fix:   '
+do
+  invalid_slug=$(printf '%s' "$invalid_subject" | cksum | awk '{print $1}')
+  invalid_message="$temporary_root/invalid-$invalid_slug"
+  invalid_copy="$temporary_root/invalid-$invalid_slug.copy"
+  printf '%s\n\nBody must remain unchanged.\n' "$invalid_subject" > "$invalid_message"
+  cp "$invalid_message" "$invalid_copy"
+  if run_normalizer "$invalid_message" >/dev/null 2>&1; then
+    invalid_status=0
+  else
+    invalid_status=$?
+  fi
+  assert_status "rejects malformed subject: $invalid_subject" 1 "$invalid_status"
+  assert_files_equal "leaves rejected message unchanged: $invalid_subject" "$invalid_copy" "$invalid_message"
+done
+
+generated_messages="$temporary_root/generated-messages"
+mkdir "$generated_messages"
+generated_index=0
+for generated_subject in \
+  "Merge branch 'main'" \
+  'Revert "feat: add hook"' \
+  'fixup! feat: add hook' \
+  'squash! feat: add hook' \
+  'amend! feat: add hook' \
+  'WIP on main: 0123456 feat: add hook' \
+  'On main: save work' \
+  'index on main: 0123456 feat: add hook' \
+  'untracked files on main: 0123456 feat: add hook' \
+  '# This is a combination of 2 commits.'
+do
+  generated_index=$((generated_index + 1))
+  generated_message="$generated_messages/$generated_index"
+  generated_copy="$generated_messages/$generated_index.copy"
+  printf '%s\n\nGenerated body.\n' "$generated_subject" > "$generated_message"
+  cp "$generated_message" "$generated_copy"
+  if run_normalizer "$generated_message" >/dev/null 2>&1; then
+    generated_status=0
+  else
+    generated_status=$?
+  fi
+  assert_status "bypasses generated message: $generated_subject" 0 "$generated_status"
+  assert_files_equal "does not rewrite generated message: $generated_subject" "$generated_copy" "$generated_message"
+done
+
+comment_repository="$temporary_root/comment-repository"
+git init -q "$comment_repository"
+comment_message="$comment_repository/message"
+comment_copy="$comment_repository/message.copy"
+
+git -C "$comment_repository" config --local core.commentChar ';'
+printf '; This is a combination of 3 commits.\n' > "$comment_message"
+cp "$comment_message" "$comment_copy"
+(
+  cd "$comment_repository" || exit 1
+  "$normalizer" "$comment_message"
+)
+assert_files_equal "honors core.commentChar for combined messages" "$comment_copy" "$comment_message"
+
+git -C "$comment_repository" config --local --unset-all core.commentChar
+git -C "$comment_repository" config --local core.commentString '//'
+printf '// This is a combination of 10 commits.\n' > "$comment_message"
+cp "$comment_message" "$comment_copy"
+(
+  cd "$comment_repository" || exit 1
+  "$normalizer" "$comment_message"
+)
+assert_files_equal "honors core.commentString for combined messages" "$comment_copy" "$comment_message"
+
+git -C "$comment_repository" config --local --unset-all core.commentString
+git -C "$comment_repository" config --local core.commentChar auto
+printf '; This is a combination of 4 commits.\n' > "$comment_message"
+cp "$comment_message" "$comment_copy"
+(
+  cd "$comment_repository" || exit 1
+  "$normalizer" "$comment_message"
+)
+assert_files_equal "honors an automatically selected Git comment prefix" "$comment_copy" "$comment_message"
+
+git -C "$comment_repository" config --local --unset-all core.commentChar
+git -C "$comment_repository" config --local core.commentString '//'
+printf '// ordinary invalid comment subject\n' > "$comment_message"
+cp "$comment_message" "$comment_copy"
+if (
+  cd "$comment_repository" || exit 1
+  "$normalizer" "$comment_message"
+) >/dev/null 2>&1; then
+  ordinary_comment_status=0
+else
+  ordinary_comment_status=$?
+fi
+assert_status "rejects ordinary comment-led subjects" 1 "$ordinary_comment_status"
+assert_files_equal "leaves rejected comment-led subjects unchanged" "$comment_copy" "$comment_message"
+
+hook_repository="$temporary_root/hook-repository"
+git init -q "$hook_repository"
+mkdir -p "$hook_repository/.githooks" "$hook_repository/scripts"
+cp "$repository_root/.githooks/commit-msg" "$hook_repository/.githooks/commit-msg"
+cp "$repository_root/.githooks/pre-commit" "$hook_repository/.githooks/pre-commit"
+printf '#!/bin/sh\nexit 37\n' > "$hook_repository/scripts/normalize-commit-message.sh"
+printf '#!/bin/sh\nexit 38\n' > "$hook_repository/scripts/pre-commit.sh"
+chmod +x "$hook_repository/.githooks/commit-msg" "$hook_repository/.githooks/pre-commit"
+chmod +x "$hook_repository/scripts/normalize-commit-message.sh" "$hook_repository/scripts/pre-commit.sh"
+printf 'invalid\n' > "$hook_repository/message"
+
+if (
+  cd "$hook_repository" || exit 1
+  ./.githooks/commit-msg message
+) >/dev/null 2>&1; then
+  commit_hook_status=0
+else
+  commit_hook_status=$?
+fi
+assert_status "commit-msg hook propagates normalizer failures" 37 "$commit_hook_status"
+
+if (
+  cd "$hook_repository" || exit 1
+  ./.githooks/pre-commit
+) >/dev/null 2>&1; then
+  precommit_hook_status=0
+else
+  precommit_hook_status=$?
+fi
+assert_status "pre-commit hook propagates existing check failures" 38 "$precommit_hook_status"
+
+install_repository="$temporary_root/install-repository"
+global_config="$temporary_root/global-gitconfig"
+git init -q "$install_repository"
+mkdir -p "$install_repository/.githooks"
+cp "$repository_root/.githooks/commit-msg" "$install_repository/.githooks/commit-msg"
+cp "$repository_root/.githooks/pre-commit" "$install_repository/.githooks/pre-commit"
+chmod +x "$install_repository/.githooks/commit-msg" "$install_repository/.githooks/pre-commit"
+GIT_CONFIG_GLOBAL="$global_config" git config --global core.hooksPath /global/hooks
+
+(
+  cd "$install_repository" || exit 1
+  GIT_CONFIG_GLOBAL="$global_config" "$installer"
+) >/dev/null
+installed_path=$(git -C "$install_repository" config --local --get core.hooksPath)
+if [ "$installed_path" = ".githooks" ]; then
+  pass "installer configures the repository-local shared hook path"
+else
+  fail "installer configures the repository-local shared hook path"
+fi
+
+global_path=$(GIT_CONFIG_GLOBAL="$global_config" git config --global --get core.hooksPath)
+if [ "$global_path" = "/global/hooks" ]; then
+  pass "installer preserves global Git configuration"
+else
+  fail "installer preserves global Git configuration"
+fi
+
+if (
+  cd "$install_repository" || exit 1
+  GIT_CONFIG_GLOBAL="$global_config" "$installer"
+) >/dev/null; then
+  installer_second_status=0
+else
+  installer_second_status=$?
+fi
+assert_status "installer is idempotent" 0 "$installer_second_status"
+
+conflict_repository="$temporary_root/conflict-repository"
+git init -q "$conflict_repository"
+mkdir -p "$conflict_repository/.githooks"
+cp "$repository_root/.githooks/commit-msg" "$conflict_repository/.githooks/commit-msg"
+cp "$repository_root/.githooks/pre-commit" "$conflict_repository/.githooks/pre-commit"
+chmod +x "$conflict_repository/.githooks/commit-msg" "$conflict_repository/.githooks/pre-commit"
+git -C "$conflict_repository" config --local core.hooksPath /custom/hooks
+
+if (
+  cd "$conflict_repository" || exit 1
+  "$installer"
+) >/dev/null 2>&1; then
+  conflict_status=0
+else
+  conflict_status=$?
+fi
+assert_status "installer rejects a conflicting repository-local hook path" 1 "$conflict_status"
+conflict_path=$(git -C "$conflict_repository" config --local --get core.hooksPath)
+if [ "$conflict_path" = "/custom/hooks" ]; then
+  pass "installer leaves a conflicting hook path unchanged"
+else
+  fail "installer leaves a conflicting hook path unchanged"
+fi
+
+printf '1..%d\n' "$tests_run"
+if [ "$tests_failed" -ne 0 ]; then
+  printf '%d test(s) failed\n' "$tests_failed" >&2
+  exit 1
+fi

--- a/tests/commit-message-normalizer.sh
+++ b/tests/commit-message-normalizer.sh
@@ -58,12 +58,57 @@ run_normalizer() {
   )
 }
 
+run_normalizer_in() {
+  working_directory=$1
+  message_file=$2
+  (
+    cd "$working_directory" || exit 1
+    "$normalizer" "$message_file"
+  )
+}
+
 valid_message="$temporary_root/valid-message"
 valid_expected="$temporary_root/valid-expected"
 printf ' FIX (CLI) ! :   Preserve\t API   IDs \n\nBody  spacing stays.\n\nNightshift-Task: commit-normalize\nNightshift-Ref: https://github.com/marcus/nightshift\n' > "$valid_message"
 printf 'fix(cli)!: Preserve API IDs\n\nBody  spacing stays.\n\nNightshift-Task: commit-normalize\nNightshift-Ref: https://github.com/marcus/nightshift\n' > "$valid_expected"
 run_normalizer "$valid_message"
 assert_files_equal "normalizes metadata capitalization and whitespace while preserving the body and trailers" "$valid_expected" "$valid_message"
+
+in_place_message="$temporary_root/in-place-message"
+in_place_expected="$temporary_root/in-place-expected"
+printf ' DOCS :   Preserve file identity\n' > "$in_place_message"
+printf 'docs: Preserve file identity\n' > "$in_place_expected"
+chmod 640 "$in_place_message"
+in_place_inode_before=$(ls -di "$in_place_message" | awk '{print $1}')
+in_place_mode_before=$(ls -ld "$in_place_message" | awk '{print substr($1, 1, 10)}')
+run_normalizer "$in_place_message"
+in_place_inode_after=$(ls -di "$in_place_message" | awk '{print $1}')
+in_place_mode_after=$(ls -ld "$in_place_message" | awk '{print substr($1, 1, 10)}')
+assert_files_equal "normalizes an existing message in place" "$in_place_expected" "$in_place_message"
+if [ "$in_place_inode_after" = "$in_place_inode_before" ]; then
+  pass "preserves the commit message inode"
+else
+  fail "preserves the commit message inode"
+fi
+if [ "$in_place_mode_after" = "$in_place_mode_before" ]; then
+  pass "preserves the commit message mode"
+else
+  fail "preserves the commit message mode"
+fi
+
+symlink_target="$temporary_root/symlink-target"
+symlink_message="$temporary_root/symlink-message"
+symlink_expected="$temporary_root/symlink-expected"
+printf ' TEST :   Preserve symlinks\n' > "$symlink_target"
+printf 'test: Preserve symlinks\n' > "$symlink_expected"
+ln -s "$symlink_target" "$symlink_message"
+run_normalizer "$symlink_message"
+if [ -L "$symlink_message" ]; then
+  pass "preserves a commit message symlink"
+else
+  fail "preserves a commit message symlink"
+fi
+assert_files_equal "updates the target of a commit message symlink" "$symlink_expected" "$symlink_target"
 
 idempotent_copy="$temporary_root/idempotent-copy"
 cp "$valid_message" "$idempotent_copy"
@@ -146,30 +191,36 @@ comment_copy="$comment_repository/message.copy"
 git -C "$comment_repository" config --local core.commentChar ';'
 printf '; This is a combination of 3 commits.\n' > "$comment_message"
 cp "$comment_message" "$comment_copy"
-(
-  cd "$comment_repository" || exit 1
-  "$normalizer" "$comment_message"
-)
+if run_normalizer_in "$comment_repository" "$comment_message"; then
+  comment_char_status=0
+else
+  comment_char_status=$?
+fi
+assert_status "accepts a combined message using core.commentChar" 0 "$comment_char_status"
 assert_files_equal "honors core.commentChar for combined messages" "$comment_copy" "$comment_message"
 
 git -C "$comment_repository" config --local --unset-all core.commentChar
 git -C "$comment_repository" config --local core.commentString '//'
 printf '// This is a combination of 10 commits.\n' > "$comment_message"
 cp "$comment_message" "$comment_copy"
-(
-  cd "$comment_repository" || exit 1
-  "$normalizer" "$comment_message"
-)
+if run_normalizer_in "$comment_repository" "$comment_message"; then
+  comment_string_status=0
+else
+  comment_string_status=$?
+fi
+assert_status "accepts a combined message using core.commentString" 0 "$comment_string_status"
 assert_files_equal "honors core.commentString for combined messages" "$comment_copy" "$comment_message"
 
 git -C "$comment_repository" config --local --unset-all core.commentString
 git -C "$comment_repository" config --local core.commentChar auto
 printf '; This is a combination of 4 commits.\n' > "$comment_message"
 cp "$comment_message" "$comment_copy"
-(
-  cd "$comment_repository" || exit 1
-  "$normalizer" "$comment_message"
-)
+if run_normalizer_in "$comment_repository" "$comment_message"; then
+  comment_auto_status=0
+else
+  comment_auto_status=$?
+fi
+assert_status "accepts a combined message using an automatic comment prefix" 0 "$comment_auto_status"
 assert_files_equal "honors an automatically selected Git comment prefix" "$comment_copy" "$comment_message"
 
 git -C "$comment_repository" config --local --unset-all core.commentChar
@@ -217,6 +268,46 @@ else
   precommit_hook_status=$?
 fi
 assert_status "pre-commit hook propagates existing check failures" 38 "$precommit_hook_status"
+
+commit_repository="$temporary_root/commit-repository"
+git init -q "$commit_repository"
+mkdir -p "$commit_repository/.githooks" "$commit_repository/scripts"
+cp "$repository_root/.githooks/commit-msg" "$commit_repository/.githooks/commit-msg"
+cp "$repository_root/.githooks/pre-commit" "$commit_repository/.githooks/pre-commit"
+cp "$normalizer" "$commit_repository/scripts/normalize-commit-message.sh"
+printf '#!/bin/sh\nexit 0\n' > "$commit_repository/scripts/pre-commit.sh"
+chmod +x "$commit_repository/.githooks/commit-msg" "$commit_repository/.githooks/pre-commit"
+chmod +x "$commit_repository/scripts/normalize-commit-message.sh" "$commit_repository/scripts/pre-commit.sh"
+git -C "$commit_repository" config user.name "Commit Normalizer Test"
+git -C "$commit_repository" config user.email "commit-normalizer@example.com"
+git -C "$commit_repository" config core.hooksPath .githooks
+
+if git -C "$commit_repository" commit --allow-empty -m ' FEAT (CLI) :   Normalize   commits' >/dev/null 2>&1; then
+  git_commit_status=0
+else
+  git_commit_status=$?
+fi
+assert_status "normalizes a message during an end-to-end Git commit" 0 "$git_commit_status"
+committed_subject=$(git -C "$commit_repository" log -1 --format=%s)
+if [ "$committed_subject" = "feat(cli): Normalize commits" ]; then
+  pass "records the normalized subject in Git history"
+else
+  fail "records the normalized subject in Git history"
+fi
+
+commit_count_before=$(git -C "$commit_repository" rev-list --count HEAD)
+if git -C "$commit_repository" commit --allow-empty -m 'invalid subject' >/dev/null 2>&1; then
+  invalid_commit_status=0
+else
+  invalid_commit_status=$?
+fi
+assert_status "rejects an invalid message during an end-to-end Git commit" 1 "$invalid_commit_status"
+commit_count_after=$(git -C "$commit_repository" rev-list --count HEAD)
+if [ "$commit_count_after" = "$commit_count_before" ]; then
+  pass "does not create a commit after commit-msg rejection"
+else
+  fail "does not create a commit after commit-msg rejection"
+fi
 
 install_repository="$temporary_root/install-repository"
 global_config="$temporary_root/global-gitconfig"


### PR DESCRIPTION
## Summary

- add a repository-managed Conventional Commit normalizer for future commits only; existing history is not rewritten
- normalize unambiguous type, scope, and whitespace while preserving bodies, Nightshift trailers, and commit-message file identity
- exempt Git-generated merge, revert, autosquash, stash, and combined-commit messages, including custom comment prefixes
- adopt `.githooks` without dropping the existing formatting, vet, and build checks
- add a conflict-safe, repository-local hook installer plus shell regression coverage and developer documentation

## Iteration 3

- inspect every repository-local `core.hooksPath` value instead of only the last value
- reject ambiguous duplicate, conflicting, reordered, and empty additional hook-path values without modifying `.git/config`
- add regression coverage for both value orderings and the empty-value edge case

## Verification

- `make test-commit-normalizer` (74 assertions)
- `make test` (74 shell assertions and all Go tests)
- `sh -n scripts/normalize-commit-message.sh scripts/install-hooks.sh .githooks/commit-msg .githooks/pre-commit tests/commit-message-normalizer.sh`
- end-to-end accepted and rejected Git commit coverage (included in the shell suite)
- `git diff --check docs-backfill`
