### PR TITLE
feat(commits): add breaking-change and commit-msg hook support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git pre-commit and commit-msg hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ selected provider, budget status, projects, and planned tasks. In interactive
 terminals you are prompted for confirmation; in non-TTY environments (cron,
 daemon, CI) confirmation is auto-skipped.
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--dry-run` | `false` | Show preflight summary and exit without executing |
-| `--project`, `-p` | _(all configured)_ | Target a single project directory |
-| `--task`, `-t` | _(auto-select)_ | Run a specific task by name |
-| `--max-projects` | `1` | Max projects to process (ignored when `--project` is set) |
-| `--max-tasks` | `1` | Max tasks per project (ignored when `--task` is set) |
-| `--random-task` | `false` | Pick a random task from eligible tasks instead of the highest-scored one |
-| `--ignore-budget` | `false` | Bypass budget checks (use with caution) |
-| `--yes`, `-y` | `false` | Skip the confirmation prompt |
+| Flag              | Default            | Description                                                              |
+| ----------------- | ------------------ | ------------------------------------------------------------------------ |
+| `--dry-run`       | `false`            | Show preflight summary and exit without executing                        |
+| `--project`, `-p` | _(all configured)_ | Target a single project directory                                        |
+| `--task`, `-t`    | _(auto-select)_    | Run a specific task by name                                              |
+| `--max-projects`  | `1`                | Max projects to process (ignored when `--project` is set)                |
+| `--max-tasks`     | `1`                | Max tasks per project (ignored when `--task` is set)                     |
+| `--random-task`   | `false`            | Pick a random task from eligible tasks instead of the highest-scored one |
+| `--ignore-budget` | `false`            | Bypass budget checks (use with caution)                                  |
+| `--yes`, `-y`     | `false`            | Skip the confirmation prompt                                             |
 
 ```bash
 # Interactive run with preflight summary + confirmation prompt
@@ -141,6 +141,7 @@ nightshift run -p ./my-project -t lint-fix
 ```
 
 Other useful flags:
+
 - `nightshift status --today` to see today's activity summary
 - `nightshift daemon start --foreground` for debug
 - `--category` — filter tasks by category (pr, analysis, options, safe, map, emergency)
@@ -153,8 +154,9 @@ Other useful flags:
 ## Authentication (Subscriptions)
 
 Nightshift supports three AI providers:
+
 - **Claude Code** - Anthropic's Claude via local CLI
-- **Codex** - OpenAI's GPT via local CLI  
+- **Codex** - OpenAI's GPT via local CLI
 - **GitHub Copilot** - GitHub's Copilot via GitHub CLI
 
 ### Claude Code
@@ -258,18 +260,30 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 ## Development
 
-### Pre-commit hooks
+### Git hooks
 
-Install the git pre-commit hook to catch formatting and vet issues before pushing:
+Install both the pre-commit and commit-msg hooks:
 
 ```bash
 make install-hooks
 ```
 
-This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit`. The hook runs:
+This symlinks `scripts/pre-commit.sh` into `.git/hooks/pre-commit` and
+`scripts/commit-msg.sh` into `.git/hooks/commit-msg`.
+
+The **pre-commit** hook runs:
+
 - **gofmt** — flags any staged `.go` files that need formatting
 - **go vet** — catches common correctness issues
 - **go build** — ensures the project compiles
+
+The **commit-msg** hook enforces [Conventional Commits](docs/commit-messages.md).
+Before a commit is created it normalizes the message into canonical form
+(`nightshift commit normalize --file`), fixing trivial issues (type casing,
+trailing punctuation, body wrapping) and flagging breaking changes via the `!`
+indicator (`feat!:`) or a `BREAKING CHANGE:` footer. Messages that cannot be
+normalized — missing or unknown type, capitalized or overlong subject — are
+rejected with a non-zero exit so the commit is aborted.
 
 To bypass in a pinch: `git commit --no-verify`
 

--- a/cmd/nightshift/commands/commit.go
+++ b/cmd/nightshift/commands/commit.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/marcus/nightshift/internal/commits"
+	"github.com/spf13/cobra"
+)
+
+var commitCmd = &cobra.Command{
+	Use:   "commit",
+	Short: "Conventional Commits helpers",
+	Long: `Tools for working with Conventional Commits messages.
+
+Use "commit normalize" to validate and reformat a commit message so it
+follows the project's rules (type prefix, lowercase type, subject length,
+and wrapped body).`,
+}
+
+var commitNormalizeCmd = &cobra.Command{
+	Use:   "normalize [MESSAGE]",
+	Short: "Normalize a commit message to Conventional Commits format",
+	Long: `Validate and rewrite a commit message into canonical Conventional
+Commits form.
+
+The message is read from a positional argument, from a file passed via
+--file (typically .git/COMMIT_EDITMSG by a commit-msg hook), or from stdin
+when no argument and no --file are given.
+
+  nightshift commit normalize "feat: add login"
+  nightshift commit normalize --file .git/COMMIT_EDITMSG
+  git log -1 --pretty=%B | nightshift commit normalize
+
+Use --check to only validate without rewriting; the exit code is non-zero
+when the message does not conform.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		check, _ := cmd.Flags().GetBool("check")
+		file, _ := cmd.Flags().GetString("file")
+
+		raw, err := readCommitMessage(args, file)
+		if err != nil {
+			return err
+		}
+
+		normalized, err := commits.Normalize(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return err
+		}
+
+		if check {
+			fmt.Fprintln(os.Stdout, normalized)
+			return nil
+		}
+		fmt.Fprintln(os.Stdout, normalized)
+		return nil
+	},
+}
+
+func init() {
+	commitNormalizeCmd.Flags().BoolP("check", "c", false, "Only validate; do not rewrite")
+	commitNormalizeCmd.Flags().StringP("file", "f", "", "Read the message from this file (use by the commit-msg hook)")
+	commitCmd.AddCommand(commitNormalizeCmd)
+	rootCmd.AddCommand(commitCmd)
+}
+
+// readCommitMessage resolves the message source in order: positional arg,
+// --file, then stdin.
+func readCommitMessage(args []string, file string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	if file != "" {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", file, err)
+		}
+		return string(b), nil
+	}
+	b, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(b), nil
+}

--- a/cmd/nightshift/commands/commit.go
+++ b/cmd/nightshift/commands/commit.go
@@ -35,36 +35,65 @@ when no argument and no --file are given.
 
 Use --check to only validate without rewriting; the exit code is non-zero
 when the message does not conform.`,
-	Args: cobra.MaximumNArgs(1),
+	Args:          cobra.MaximumNArgs(1),
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		check, _ := cmd.Flags().GetBool("check")
 		file, _ := cmd.Flags().GetString("file")
 
 		raw, err := readCommitMessage(args, file)
 		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
 			return err
 		}
 
 		normalized, err := commits.Normalize(raw)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
 			return err
 		}
 
-		if check {
-			fmt.Fprintln(os.Stdout, normalized)
+		switch {
+		case check:
+			// Validate-only: print nothing on success and never rewrite the
+			// file. The non-zero exit from the error above is what makes
+			// --check usable as a pre-receive / CI gate.
+			return nil
+		case file != "":
+			// Rewrite the message file in place so a commit-msg hook can
+			// normalize the actual commit. Only touch the file when the result
+			// differs, to avoid churning mtime on already-canonical messages.
+			return writeCommitMessageFile(file, normalized)
+		default:
+			fmt.Fprintln(cmd.OutOrStdout(), normalized)
 			return nil
 		}
-		fmt.Fprintln(os.Stdout, normalized)
-		return nil
 	},
 }
 
 func init() {
 	commitNormalizeCmd.Flags().BoolP("check", "c", false, "Only validate; do not rewrite")
-	commitNormalizeCmd.Flags().StringP("file", "f", "", "Read the message from this file (use by the commit-msg hook)")
+	commitNormalizeCmd.Flags().StringP("file", "f", "", "Normalize this message file in place (used by the commit-msg hook)")
 	commitCmd.AddCommand(commitNormalizeCmd)
 	rootCmd.AddCommand(commitCmd)
+}
+
+// writeCommitMessageFile writes normalized to path followed by a trailing
+// newline, but only when it differs from the file's current contents. This
+// keeps already-canonical messages untouched so commit-msg hooks don't churn
+// file mtimes on every commit.
+func writeCommitMessageFile(path, normalized string) error {
+	want := normalized + "\n"
+	if existing, err := os.ReadFile(path); err == nil {
+		if string(existing) == want {
+			return nil
+		}
+	}
+	if err := os.WriteFile(path, []byte(want), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
 }
 
 // readCommitMessage resolves the message source in order: positional arg,

--- a/cmd/nightshift/commands/commit_test.go
+++ b/cmd/nightshift/commands/commit_test.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCommitNormalize executes `nightshift commit normalize` with the given args
+// and captured stdout/stderr, returning the command error (nil on success).
+// Cobra persists flag values across Execute() calls on a shared command, so the
+// --check/--file flags are reset to their defaults before each invocation to
+// keep tests independent.
+func runCommitNormalize(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	for _, name := range []string{"check", "file"} {
+		if f := commitNormalizeCmd.Flags().Lookup(name); f != nil {
+			f.Changed = false
+			_ = f.Value.Set(f.DefValue)
+		}
+	}
+	rootCmd.SetArgs(append([]string{"commit", "normalize"}, args...))
+	var out, errOut bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errOut)
+	err := rootCmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestCommitNormalizeCheckRejectsNonConforming(t *testing.T) {
+	_, errOut, err := runCommitNormalize(t, "--check", "just a plain message")
+	if err == nil {
+		t.Fatal("expected --check to reject a non-conforming message, got nil error")
+	}
+	if !strings.Contains(errOut, "conventional commit type") {
+		t.Errorf("expected diagnostic about missing type on stderr, got: %q", errOut)
+	}
+}
+
+func TestCommitNormalizeCheckSilentOnSuccess(t *testing.T) {
+	out, errOut, err := runCommitNormalize(t, "--check", "feat: add login")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected no stdout in --check mode, got: %q", out)
+	}
+	if errOut != "" {
+		t.Errorf("expected no stderr in --check mode, got: %q", errOut)
+	}
+}
+
+func TestCommitNormalizePrintsToStdoutByDefault(t *testing.T) {
+	out, _, err := runCommitNormalize(t, "  docs: update README.  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "docs: update README\n" {
+		t.Errorf("expected normalized message on stdout, got: %q", out)
+	}
+}
+
+func TestCommitNormalizeFileRewritesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	msgFile := filepath.Join(dir, "COMMIT_EDITMSG")
+	if err := os.WriteFile(msgFile, []byte("FEAT(ui): render button.\n\nbody here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCommitNormalize(t, "--file", msgFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected no stdout when rewriting --file in place, got: %q", out)
+	}
+
+	got, err := os.ReadFile(msgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "feat(ui): render button\n\nbody here\n"
+	if string(got) != want {
+		t.Errorf("file not rewritten in place\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestCommitNormalizeFileIdempotentNoMtimeChurn(t *testing.T) {
+	dir := t.TempDir()
+	msgFile := filepath.Join(dir, "COMMIT_EDITMSG")
+	canonical := "feat: already canonical\n"
+	if err := os.WriteFile(msgFile, []byte(canonical), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(msgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := info.ModTime()
+
+	if _, _, err := runCommitNormalize(t, "--file", msgFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := os.ReadFile(msgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != canonical {
+		t.Errorf("already-canonical file should be unchanged\n got: %q\nwant: %q", got, canonical)
+	}
+	if mt, _ := os.Stat(msgFile); !mt.ModTime().Equal(before) {
+		t.Errorf("expected mtime to be untouched on already-canonical message")
+	}
+}
+
+func TestCommitNormalizeFileCheckDoesNotRewrite(t *testing.T) {
+	dir := t.TempDir()
+	msgFile := filepath.Join(dir, "COMMIT_EDITMSG")
+	original := "feat: keep me\n"
+	if err := os.WriteFile(msgFile, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCommitNormalize(t, "--check", "--file", msgFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := os.ReadFile(msgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Errorf("--check must not rewrite the file\n got: %q\nwant: %q", got, original)
+	}
+}

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -1,0 +1,47 @@
+# Commit Messages
+
+Nightshift uses [Conventional Commits](https://www.conventionalcommits.org/)
+for all commit messages. This keeps the history readable and lets tooling
+derive changelogs automatically.
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+- **type** — one of `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
+  `chore`, `perf`, `build`, `ci`.
+- **scope** — optional, e.g. `fix(api): ...`.
+- **subject** — lowercase, imperative mood, no trailing period, max 72 chars.
+- **body** — optional, wrapped at 72 columns, separated from the subject by a
+  blank line.
+
+## The `commit normalize` command
+
+Validate and reformat a message:
+
+```sh
+nightshift commit normalize "feat: add login screen"
+nightshift commit normalize --file .git/COMMIT_EDITMSG
+git log -1 --pretty=%B | nightshift commit normalize
+```
+
+Add `--check` to validate only. The command exits non-zero when a message
+cannot be normalized (missing/unknown type, capitalized or overlong subject).
+
+## commit-msg hook
+
+To enforce the rules locally, install the hook:
+
+```sh
+make install-hooks
+# or manually:
+ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+```
+
+The hook normalizes your message file in place before the commit is created and
+rejects messages that cannot be fixed automatically. Bypass it with
+`git commit --no-verify`.

--- a/internal/commits/normalizer.go
+++ b/internal/commits/normalizer.go
@@ -1,0 +1,255 @@
+// Package commits implements Conventional Commits message normalization and
+// validation. It exposes pure, well-tested functions used by the CLI and by the
+// commit-msg git hook to keep the project's history consistent.
+//
+// The supported format follows the Conventional Commits 1.0.0 specification:
+//
+//	<type>(<scope>): <subject>
+//
+//	<body>
+//
+// The normalizer is intentionally strict but constructive: rather than silently
+// accepting malformed input it fixes the trivially fixable (whitespace, type
+// casing, trailing punctuation, body wrapping) and rejects anything that needs
+// a human decision (missing type, unknown type, missing subject).
+package commits
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// MaxSubjectLength is the maximum number of runes allowed in a commit subject.
+const MaxSubjectLength = 72
+
+// BodyWrapWidth is the column at which the commit body is wrapped.
+const BodyWrapWidth = 72
+
+// allowedTypes is the set of Conventional Commit types this project accepts.
+var allowedTypes = map[string]struct{}{
+	"feat":     {},
+	"fix":      {},
+	"docs":     {},
+	"style":    {},
+	"refactor": {},
+	"test":     {},
+	"chore":    {},
+	"perf":     {},
+	"build":    {},
+	"ci":       {},
+}
+
+// Errors returned by the normalizer. They are wrapped so callers can match on
+// the underlying cause with errors.Is.
+var (
+	// ErrEmptyMessage is returned when the message contains no non-comment,
+	// non-whitespace content.
+	ErrEmptyMessage = errors.New("commit message is empty")
+	// ErrMissingType is returned when the subject line is not a Conventional
+	// Commit (no type prefix before the colon).
+	ErrMissingType = errors.New("commit message must start with a conventional commit type")
+	// ErrUnknownType is returned when the type prefix is not in the allowed set.
+	ErrUnknownType = errors.New("commit type is not in the allowed set")
+	// ErrMissingSubject is returned when the type prefix is present but no
+	// subject text follows the colon.
+	ErrMissingSubject = errors.New("commit subject is missing")
+	// ErrSubjectTooLong is returned when the subject exceeds MaxSubjectLength.
+	ErrSubjectTooLong = fmt.Errorf("commit subject exceeds %d characters", MaxSubjectLength)
+	// ErrSubjectLowercase is returned when the subject starts with an uppercase
+	// letter (the rule is "do not capitalize the subject").
+	ErrSubjectLowercase = errors.New("commit subject must not be capitalized")
+)
+
+// Normalize parses, validates, and rewrites a raw commit message so that it
+// conforms to the project's Conventional Commits rules. It returns the
+// canonical form and a non-nil error describing the first unrecoverable
+// problem when the message cannot be normalized.
+//
+// Normalization is idempotent: Normalize(Normalize(m)) == Normalize(m).
+func Normalize(msg string) (string, error) {
+	lines := stripComments(msg)
+	if len(lines) == 0 {
+		return "", ErrEmptyMessage
+	}
+
+	header := lines[0]
+	body := lines[1:]
+
+	typ, scope, subject, err := parseHeader(header)
+	if err != nil {
+		return "", err
+	}
+
+	subject = cleanSubject(subject)
+
+	var b strings.Builder
+	b.WriteString(formatHeader(typ, scope, subject))
+
+	wrapped := wrapBody(body, BodyWrapWidth)
+	if wrapped != "" {
+		b.WriteString("\n\n")
+		b.WriteString(wrapped)
+	}
+
+	return b.String(), nil
+}
+
+// stripComments removes git's commented-out lines (those beginning with "#"),
+// trims trailing whitespace from every line, and drops leading/trailing blank
+// lines. It returns the meaningful lines of the message.
+func stripComments(msg string) []string {
+	rawLines := strings.Split(msg, "\n")
+	out := make([]string, 0, len(rawLines))
+	for _, l := range rawLines {
+		l = strings.TrimRight(l, " \t\r")
+		if strings.HasPrefix(strings.TrimSpace(l), "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	// Drop leading and trailing blank lines.
+	for len(out) > 0 && strings.TrimSpace(out[0]) == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// parseHeader splits the first line into its Conventional Commit components and
+// validates them. The returned type is lower-cased to match the allowed set.
+func parseHeader(header string) (typ, scope, subject string, err error) {
+	header = strings.TrimSpace(header)
+	colon := strings.Index(header, ":")
+	if colon <= 0 {
+		return "", "", "", ErrMissingType
+	}
+	prefix := header[:colon]
+	subject = strings.TrimSpace(header[colon+1:])
+
+	// Split an optional "(scope)" from the type.
+	prefix = strings.TrimSpace(prefix)
+	if strings.HasPrefix(prefix, "(") {
+		// A leading "(" with no type is not a valid conventional header.
+		return "", "", "", ErrMissingType
+	}
+	if open := strings.Index(prefix, "("); open > 0 && strings.HasSuffix(prefix, ")") {
+		typ = prefix[:open]
+		scope = prefix[open+1 : len(prefix)-1]
+	} else {
+		typ = prefix
+	}
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	scope = strings.TrimSpace(scope)
+
+	if typ == "" {
+		return "", "", "", ErrMissingType
+	}
+	if !isAllowedType(typ) {
+		return "", "", "", fmt.Errorf("%w: %q", ErrUnknownType, typ)
+	}
+	if strings.TrimSpace(subject) == "" {
+		return "", "", "", ErrMissingSubject
+	}
+	if utf8.RuneCountInString(subject) > MaxSubjectLength {
+		return "", "", "", ErrSubjectTooLong
+	}
+	if startsUpper(subject) {
+		return "", "", "", ErrSubjectLowercase
+	}
+	return typ, scope, subject, nil
+}
+
+// cleanSubject normalizes the subject text: lowercases a leading uppercase
+// letter is *not* done here (capitalization is a hard error, not a fix), but
+// surrounding whitespace and a trailing period are removed.
+func cleanSubject(subject string) string {
+	s := strings.TrimSpace(subject)
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+// formatHeader reassembles a canonical header line from its components.
+func formatHeader(typ, scope, subject string) string {
+	if scope != "" {
+		return typ + "(" + scope + "): " + subject
+	}
+	return typ + ": " + subject
+}
+
+// wrapBody collapses runs of blank lines, preserves non-blank paragraphs, and
+// hard-wraps each paragraph line to width. Paragraph breaks (a single blank
+// line) are preserved.
+func wrapBody(body []string, width int) string {
+	var paragraphs [][]string
+	var cur []string
+	for _, l := range body {
+		if strings.TrimSpace(l) == "" {
+			if len(cur) > 0 {
+				paragraphs = append(paragraphs, cur)
+				cur = nil
+			}
+			continue
+		}
+		cur = append(cur, strings.TrimSpace(l))
+	}
+	if len(cur) > 0 {
+		paragraphs = append(paragraphs, cur)
+	}
+
+	var b strings.Builder
+	for i, p := range paragraphs {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(wrapParagraph(strings.Join(p, " "), width))
+	}
+	return b.String()
+}
+
+// wrapParagraph hard-wraps a single-line paragraph at width, breaking on word
+// boundaries. A word longer than width is left intact rather than split.
+func wrapParagraph(text string, width int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	lineLen := 0
+	for i, w := range words {
+		if i == 0 {
+			b.WriteString(w)
+			lineLen = len(w)
+			continue
+		}
+		if lineLen+1+len(w) <= width {
+			b.WriteByte(' ')
+			b.WriteString(w)
+			lineLen += 1 + len(w)
+		} else {
+			b.WriteByte('\n')
+			b.WriteString(w)
+			lineLen = len(w)
+		}
+	}
+	return b.String()
+}
+
+// isAllowedType reports whether typ is one of the accepted Conventional Commit
+// types.
+func isAllowedType(typ string) bool {
+	_, ok := allowedTypes[typ]
+	return ok
+}
+
+// startsUpper reports whether the first rune of s is an ASCII uppercase letter.
+func startsUpper(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return r >= 'A' && r <= 'Z'
+}

--- a/internal/commits/normalizer.go
+++ b/internal/commits/normalizer.go
@@ -77,7 +77,7 @@ func Normalize(msg string) (string, error) {
 	header := lines[0]
 	body := lines[1:]
 
-	typ, scope, subject, err := parseHeader(header)
+	typ, scope, subject, breaking, err := parseHeader(header)
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +85,7 @@ func Normalize(msg string) (string, error) {
 	subject = cleanSubject(subject)
 
 	var b strings.Builder
-	b.WriteString(formatHeader(typ, scope, subject))
+	b.WriteString(formatHeader(typ, scope, subject, breaking))
 
 	wrapped := wrapBody(body, BodyWrapWidth)
 	if wrapped != "" {
@@ -121,11 +121,13 @@ func stripComments(msg string) []string {
 
 // parseHeader splits the first line into its Conventional Commit components and
 // validates them. The returned type is lower-cased to match the allowed set.
-func parseHeader(header string) (typ, scope, subject string, err error) {
+// The breaking flag is true when the type/scope prefix ends with a "!"
+// (e.g. "feat!:" or "feat(api)!:"), per the Conventional Commits 1.0.0 spec.
+func parseHeader(header string) (typ, scope, subject string, breaking bool, err error) {
 	header = strings.TrimSpace(header)
 	colon := strings.Index(header, ":")
 	if colon <= 0 {
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
 	}
 	prefix := header[:colon]
 	subject = strings.TrimSpace(header[colon+1:])
@@ -134,7 +136,14 @@ func parseHeader(header string) (typ, scope, subject string, err error) {
 	prefix = strings.TrimSpace(prefix)
 	if strings.HasPrefix(prefix, "(") {
 		// A leading "(" with no type is not a valid conventional header.
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
+	}
+	// A trailing "!" after the type/scope marks a breaking change. It must be
+	// stripped before scope validation so "feat(api)!:" is parsed as
+	// feat/(api)/breaking rather than rejected.
+	if strings.HasSuffix(prefix, "!") {
+		breaking = true
+		prefix = strings.TrimSuffix(prefix, "!")
 	}
 	if open := strings.Index(prefix, "("); open > 0 && strings.HasSuffix(prefix, ")") {
 		typ = prefix[:open]
@@ -146,21 +155,21 @@ func parseHeader(header string) (typ, scope, subject string, err error) {
 	scope = strings.TrimSpace(scope)
 
 	if typ == "" {
-		return "", "", "", ErrMissingType
+		return "", "", "", false, ErrMissingType
 	}
 	if !isAllowedType(typ) {
-		return "", "", "", fmt.Errorf("%w: %q", ErrUnknownType, typ)
+		return "", "", "", false, fmt.Errorf("%w: %q", ErrUnknownType, typ)
 	}
 	if strings.TrimSpace(subject) == "" {
-		return "", "", "", ErrMissingSubject
+		return "", "", "", false, ErrMissingSubject
 	}
 	if utf8.RuneCountInString(subject) > MaxSubjectLength {
-		return "", "", "", ErrSubjectTooLong
+		return "", "", "", false, ErrSubjectTooLong
 	}
 	if startsUpper(subject) {
-		return "", "", "", ErrSubjectLowercase
+		return "", "", "", false, ErrSubjectLowercase
 	}
-	return typ, scope, subject, nil
+	return typ, scope, subject, breaking, nil
 }
 
 // cleanSubject normalizes the subject text: lowercases a leading uppercase
@@ -172,12 +181,18 @@ func cleanSubject(subject string) string {
 	return s
 }
 
-// formatHeader reassembles a canonical header line from its components.
-func formatHeader(typ, scope, subject string) string {
-	if scope != "" {
-		return typ + "(" + scope + "): " + subject
+// formatHeader reassembles a canonical header line from its components. When
+// breaking is true the "!" indicator is re-emitted after the type/scope prefix,
+// matching the Conventional Commits 1.0.0 breaking-change form.
+func formatHeader(typ, scope, subject string, breaking bool) string {
+	bang := ""
+	if breaking {
+		bang = "!"
 	}
-	return typ + ": " + subject
+	if scope != "" {
+		return typ + "(" + scope + ")" + bang + ": " + subject
+	}
+	return typ + bang + ": " + subject
 }
 
 // wrapBody collapses runs of blank lines, preserves non-blank paragraphs, and
@@ -205,9 +220,24 @@ func wrapBody(body []string, width int) string {
 		if i > 0 {
 			b.WriteString("\n\n")
 		}
+		if isBreakingFooter(p[0]) {
+			// The BREAKING CHANGE: footer is a trailer, not prose: emit it
+			// verbatim (preserving its original line breaks) instead of
+			// joining its lines into a single wrapped paragraph.
+			b.WriteString(strings.Join(p, "\n"))
+			continue
+		}
 		b.WriteString(wrapParagraph(strings.Join(p, " "), width))
 	}
 	return b.String()
+}
+
+// isBreakingFooter reports whether the given line opens a Conventional Commits
+// "BREAKING CHANGE:" (or "BREAKING-CHANGE:") footer. Both spellings are valid
+// per the 1.0.0 spec.
+func isBreakingFooter(line string) bool {
+	line = strings.TrimSpace(line)
+	return strings.HasPrefix(line, "BREAKING CHANGE:") || strings.HasPrefix(line, "BREAKING-CHANGE:")
 }
 
 // wrapParagraph hard-wraps a single-line paragraph at width, breaking on word

--- a/internal/commits/normalizer_test.go
+++ b/internal/commits/normalizer_test.go
@@ -76,6 +76,31 @@ func TestNormalize(t *testing.T) {
 			in:      "\n\n# only comments\n  \n",
 			wantErr: ErrEmptyMessage,
 		},
+		{
+			name: "breaking-change bang indicator",
+			in:   "feat!: drop support for Go 1.20",
+			want: "feat!: drop support for Go 1.20",
+		},
+		{
+			name: "breaking-change bang indicator with scope",
+			in:   "fix(api)!: change response shape",
+			want: "fix(api)!: change response shape",
+		},
+		{
+			name: "breaking-change footer preserved verbatim",
+			in:   "feat: redesign API\n\nBREAKING CHANGE: the old /v1 endpoints are gone",
+			want: "feat: redesign API\n\nBREAKING CHANGE: the old /v1 endpoints are gone",
+		},
+		{
+			name: "breaking-change hyphen footer preserved verbatim",
+			in:   "feat: redesign API\n\nBREAKING-CHANGE: the old /v1 endpoints are gone",
+			want: "feat: redesign API\n\nBREAKING-CHANGE: the old /v1 endpoints are gone",
+		},
+		{
+			name: "breaking footer not hard-wrapped",
+			in:   "feat: redesign API\n\nBREAKING CHANGE: " + strings.Repeat("word ", 40),
+			want: "feat: redesign API\n\nBREAKING CHANGE: " + strings.Join(strings.Fields(strings.Repeat("word ", 40)), " "),
+		},
 	}
 
 	for _, tc := range tests {
@@ -105,6 +130,8 @@ func TestNormalizeIdempotent(t *testing.T) {
 		"feat: add login screen",
 		"fix(api): handle nil response\n\nLong body that explains the fix in more detail than the subject alone can manage so that we exercise the wrapping path too and then some more words here.",
 		"docs: update README\n\nfirst paragraph\n\nsecond paragraph stays separate",
+		"feat!: drop the legacy CLI\n\nBREAKING CHANGE: the legacy CLI is removed",
+		"fix(api)!: change response shape\n\nBREAKING-CHANGE: payloads no longer include legacy fields",
 	}
 	for _, in := range cases {
 		once, err := Normalize(in)

--- a/internal/commits/normalizer_test.go
+++ b/internal/commits/normalizer_test.go
@@ -1,0 +1,133 @@
+package commits
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "valid simple feat",
+			in:   "feat: add login screen",
+			want: "feat: add login screen",
+		},
+		{
+			name: "valid with scope",
+			in:   "fix(api): handle nil response",
+			want: "fix(api): handle nil response",
+		},
+		{
+			name: "trims surrounding whitespace and trailing period",
+			in:   "  docs: update README.  ",
+			want: "docs: update README",
+		},
+		{
+			name: "lowercases an uppercased type",
+			in:   "FEAT(ui): render button",
+			want: "feat(ui): render button",
+		},
+		{
+			name: "preserves body and wraps long lines",
+			in:   "feat: add thing\n\nthis is a body paragraph that is intentionally far longer than the configured wrap width so it must be hard wrapped onto multiple lines by the normalizer function",
+			want: "feat: add thing\n\n" +
+				"this is a body paragraph that is intentionally far longer than the\n" +
+				"configured wrap width so it must be hard wrapped onto multiple lines by\n" +
+				"the normalizer function",
+		},
+		{
+			name: "strips git comment lines",
+			in:   "chore: tidy\n# please enter the commit message\n\nbody here",
+			want: "chore: tidy\n\nbody here",
+		},
+		{
+			name:    "missing type rejected",
+			in:      "just a plain message",
+			wantErr: ErrMissingType,
+		},
+		{
+			name:    "unknown type rejected",
+			in:      "wip: halfway done",
+			wantErr: ErrUnknownType,
+		},
+		{
+			name:    "missing subject rejected",
+			in:      "feat:",
+			wantErr: ErrMissingSubject,
+		},
+		{
+			name:    "capitalized subject rejected",
+			in:      "feat: Add login screen",
+			wantErr: ErrSubjectLowercase,
+		},
+		{
+			name:    "overlong subject rejected",
+			in:      "feat: " + strings.Repeat("a", MaxSubjectLength+1),
+			wantErr: ErrSubjectTooLong,
+		},
+		{
+			name:    "empty message rejected",
+			in:      "\n\n# only comments\n  \n",
+			wantErr: ErrEmptyMessage,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("Normalize(%q): expected error %v, got nil (result %q)", tc.in, tc.wantErr, got)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Normalize(%q): expected error to wrap %v, got %v", tc.in, tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Normalize(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeIdempotent(t *testing.T) {
+	cases := []string{
+		"feat: add login screen",
+		"fix(api): handle nil response\n\nLong body that explains the fix in more detail than the subject alone can manage so that we exercise the wrapping path too and then some more words here.",
+		"docs: update README\n\nfirst paragraph\n\nsecond paragraph stays separate",
+	}
+	for _, in := range cases {
+		once, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("first Normalize(%q) errored: %v", in, err)
+		}
+		twice, err := Normalize(once)
+		if err != nil {
+			t.Fatalf("second Normalize(%q) errored: %v", once, err)
+		}
+		if once != twice {
+			t.Errorf("not idempotent for %q\n once:  %q\n twice: %q", in, once, twice)
+		}
+	}
+}
+
+func TestAllowedTypes(t *testing.T) {
+	for _, typ := range []string{"feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"} {
+		if !isAllowedType(typ) {
+			t.Errorf("expected %q to be an allowed type", typ)
+		}
+	}
+	if isAllowedType("wip") {
+		t.Error("did not expect wip to be allowed")
+	}
+}

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+#
+# Enforces Conventional Commits on every commit message and rewrites the
+# message file into canonical form before the commit is created. Messages that
+# cannot be normalized (missing/unknown type, capitalized or overlong subject)
+# are rejected with a non-zero exit so the commit is aborted.
+#
+# Install:
+#   make install-hooks
+#   # or manually:
+#   ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+#   chmod +x scripts/commit-msg.sh
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: commit-msg <message-file>" >&2
+  exit 1
+fi
+
+MSG_FILE="$1"
+
+# Resolve the nightshift binary: prefer the one on $PATH, fall back to
+# building the current source tree.
+NIGHTSHIFT="$(command -v nightshift || true)"
+if [[ -z "$NIGHTSHIFT" ]]; then
+  NIGHTSHIFT="go run github.com/marcus/nightshift/cmd/nightshift"
+fi
+
+NORMALIZED="$($NIGHTSHIFT commit normalize --file "$MSG_FILE" 2>/tmp/nightshift-commit-msg.err)"
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "🪡 commit-msg: message does not follow Conventional Commits" >&2
+  sed 's/^/    /' /tmp/nightshift-commit-msg.err >&2 || true
+  echo "" >&2
+  echo "    Expected format: <type>(<scope>): <subject>" >&2
+  echo "    Types: feat fix docs style refactor test chore perf build ci" >&2
+  echo "    (rewrite your message, or bypass with: git commit --no-verify)" >&2
+  exit 1
+fi
+
+# Rewrite the message file into canonical form.
+printf '%s\n' "$NORMALIZED" > "$MSG_FILE"
+echo "🪡 commit-msg: normalized"
+exit 0

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -27,8 +27,13 @@ if [[ -z "$NIGHTSHIFT" ]]; then
   NIGHTSHIFT="go run github.com/marcus/nightshift/cmd/nightshift"
 fi
 
-NORMALIZED="$($NIGHTSHIFT commit normalize --file "$MSG_FILE" 2>/tmp/nightshift-commit-msg.err)"
+# `commit normalize --file` rewrites the message file in place (only when it
+# changes) and exits non-zero with a diagnostic on stderr when the message
+# cannot be normalized.
+set +e
+$NIGHTSHIFT commit normalize --file "$MSG_FILE" >/dev/null 2>/tmp/nightshift-commit-msg.err
 STATUS=$?
+set -e
 
 if [[ $STATUS -ne 0 ]]; then
   echo "🪡 commit-msg: message does not follow Conventional Commits" >&2
@@ -36,11 +41,10 @@ if [[ $STATUS -ne 0 ]]; then
   echo "" >&2
   echo "    Expected format: <type>(<scope>): <subject>" >&2
   echo "    Types: feat fix docs style refactor test chore perf build ci" >&2
+  echo "    (use \"type!\" or a BREAKING CHANGE: footer to flag breaking changes)" >&2
   echo "    (rewrite your message, or bypass with: git commit --no-verify)" >&2
   exit 1
 fi
 
-# Rewrite the message file into canonical form.
-printf '%s\n' "$NORMALIZED" > "$MSG_FILE"
 echo "🪡 commit-msg: normalized"
 exit 0


### PR DESCRIPTION
## Summary

Completes the Conventional Commits message normalizer into a fully spec-compliant, git-hook-ready tool. The base normalizer lived only in a local commit (`c26c5fd`), not on `main`; this PR brings it in and closes the remaining gaps.

## Changes

- **Breaking-change support** (`internal/commits`): parse the Conventional Commits 1.0.0 `!` header indicator (`feat!:` / `fix(api)!:`), preserving the flag through `parseHeader`/`formatHeader`. Recognize the `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer as a trailer and emit it verbatim instead of hard-wrapping it.
- **`--check` fixed** (`cmd/nightshift`): validate-only — silent on success, single diagnostic + non-zero exit on failure, never rewriting the file. Previously it was a no-op that printed the normalized message.
- **In-place `--file`** (`cmd/nightshift`): default mode rewrites the message file in place, but only when the result differs (no mtime churn on already-canonical messages), so a real commit-msg hook can normalize the actual commit.
- **Hook wiring** (`scripts/commit-msg.sh`, `Makefile`): the commit-msg hook now drives the in-place rewrite and hints at breaking-change forms; `make install-hooks` installs both hooks.
- **Docs** (`README.md`): documents both hooks and the Conventional Commits enforcement.
- **Tests**: `feat!:`, `fix(scope)!:`, footer preservation + idempotency, and CLI behavior for `--check` / in-place `--file`.

## Verification

`gofmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/commits/... ./cmd/nightshift/...` all pass.

Closes the commit-normalize task.