### PR TITLE
docs: backfill package comment and fix OperationType doc convention

### DIFF
--- a/cmd/provider-calibration/main.go
+++ b/cmd/provider-calibration/main.go
@@ -1,3 +1,10 @@
+// Command provider-calibration compares Codex CLI token usage across
+// codex_originator variants to calibrate per-provider budget attribution.
+//
+// It reads recorded Codex session metrics, groups them by originator, and
+// reports the token attribution that should be applied for each provider so
+// the nightshift budget accounting stays accurate. Run via `make
+// calibrate-providers`.
 package main
 
 import (

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -237,7 +237,7 @@ func ValidateProjectPath(path string) error {
 	return nil
 }
 
-// Operation types for safety checks.
+// OperationType categorizes an operation performed by an agent for safety checks.
 type OperationType string
 
 const (


### PR DESCRIPTION
## Summary

Backfills the two genuine documentation gaps found by measuring real coverage across the Go codebase.

The codebase is already ~100% documented — all 299 exported declarations have Go doc comments, and 24 of 25 packages have package-level doc comments (verified via \`go doc\`). Only two gaps remained, both fixed here:

1. **\`cmd/provider-calibration\`** — the one package without a package doc comment. Added a \`Command\`-prefixed doc comment describing the tool (compares Codex CLI token usage across \`codex_originator\` variants to calibrate per-provider budget attribution; run via \`make calibrate-providers\`).

2. **\`internal/security.OperationType\`** — its doc comment (\`// Operation types for safety checks.\`) violated the Go \"name-first\" doc convention (the comment should begin with the symbol name). Corrected to \`// OperationType categorizes an operation performed by an agent for safety checks.\`

## Verification

- \`go build ./...\` ✓
- \`go vet ./...\` ✓
- \`go build ./cmd/nightshift\` ✓
- \`go doc ./cmd/provider-calibration\` now renders the package comment
- \`go doc internal/security OperationType\` comment now starts with \`OperationType\`

The website docs (\`task-reference.md\`, \`tasks.md\`) were checked and are already in sync with all 59 builtin task types, so no website changes were needed. Scope is intentionally minimal and targets only the genuine gaps.

---
Nightshift-Task: docs-backfill
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:.
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 0.9
cost-tier: Low (10-50k)
iterations: 1
duration: 35m5s
run-started: 2026-08-04T02:11:01+02:00
nightshift:metadata -->
