### PR TITLE
feat(hooks): add commit-msg hook to normalize commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,4 @@ go test ./...
 - **Style**: Standard Go (gofmt, govet). No magic, explicit is better.
 - **Errors**: Wrap with context, don't swallow.
 - **Tests**: Table-driven, in `_test.go` files alongside code.
+- **Commit messages**: Conventional Commits (`<type>(<scope>)?: <description>`), types: `feat, fix, chore, docs, refactor, perf, ci, test, build, style`. Run `make install-hooks` to enforce this locally via `scripts/commit-msg.sh`.

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ help:
 	@echo "  check         - Run tests and lint"
 	@echo "  install       - Build and install to Go bin directory"
 	@echo "  calibrate-providers - Compare local Claude/Codex session usage for calibration"
-	@echo "  install-hooks  - Install git pre-commit hook"
+	@echo "  install-hooks  - Install git pre-commit and commit-msg hooks"
 	@echo "  help          - Show this help"
 
-# Install git pre-commit hook
+# Install git pre-commit and commit-msg hooks
 install-hooks:
 	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
 	@echo "✓ pre-commit hook installed (.git/hooks/pre-commit → scripts/pre-commit.sh)"
+	@ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg
+	@echo "✓ commit-msg hook installed (.git/hooks/commit-msg → scripts/commit-msg.sh)"

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# commit-msg hook for nightshift
+# Enforces Conventional Commits subject lines: https://www.conventionalcommits.org/
+# Install: make install-hooks  (or: ln -sf ../../scripts/commit-msg.sh .git/hooks/commit-msg)
+set -euo pipefail
+
+MSG_FILE="$1"
+SUBJECT=$(head -n1 "$MSG_FILE")
+
+# Allow merge and revert commits through untouched.
+if [[ "$SUBJECT" =~ ^Merge\  ]] || [[ "$SUBJECT" =~ ^Revert\  ]]; then
+  exit 0
+fi
+
+TYPES="feat|fix|chore|docs|refactor|perf|ci|test|build|style"
+PATTERN="^(${TYPES})(\([a-zA-Z0-9_.-]+\))?!?: .+"
+
+printf "🪡 commit-msg check\n"
+printf "  %-20s" "conventional commit"
+
+if [[ "$SUBJECT" =~ $PATTERN ]]; then
+  echo "✓"
+else
+  echo "✗ FAILED"
+  echo "    Subject must match: <type>(<scope>)?: <description>"
+  echo "    Allowed types: ${TYPES//|/, }"
+  echo "    Got: \"$SUBJECT\""
+  echo ""
+  echo "❌ commit message does not follow Conventional Commits. Fix it or use --no-verify to skip."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/commit-msg.sh`, a Conventional Commits validator for the commit subject line, matching the existing `scripts/pre-commit.sh` style (set -euo pipefail, ✓/✗ output, exit 1 on failure, `--no-verify` escape hatch).
- Wires it into `make install-hooks` alongside the existing pre-commit hook, and updates the `help` text.
- Documents the convention (`<type>(<scope>)?: <description>`, allowed types) in `AGENTS.md` under Conventions.
- Merge and revert commits are allowed through untouched so normal GitHub merge workflows aren't blocked.

## Test plan
- [x] `bash -n scripts/commit-msg.sh`
- [x] Ran the hook against a conforming subject (`fix(budget): correct rollover calc`) — passes
- [x] Ran the hook against a non-conforming subject (`Fixed the budget thing`) — fails with a clear message
- [x] Ran the hook against a merge commit subject — passes
- [x] `make install-hooks` installs both `.git/hooks/pre-commit` and `.git/hooks/commit-msg` symlinks
- [x] `go build ./...` and `go vet ./...` pass (no Go code touched)
- [x] This PR's own commit was made with both hooks installed and passed both checks


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 1.1
cost-tier: Low (10-50k)
iterations: 3
duration: 6m31s
run-started: 2026-08-18T01:00:01-04:00
nightshift:metadata -->
