### PR TITLE
docs: backfill missing CLI commands in cli-reference.md

### DIFF
--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -19,6 +19,12 @@ title: CLI Reference
 | `nightshift logs` | Stream or export logs |
 | `nightshift stats` | Token usage statistics |
 | `nightshift daemon` | Background scheduler |
+| `nightshift config` | View and modify configuration |
+| `nightshift init` | Create a nightshift.yaml configuration file |
+| `nightshift install` | Install a system service (launchd/systemd/cron) |
+| `nightshift uninstall` | Remove the installed system service |
+| `nightshift report` | Show structured reports from recent runs |
+| `nightshift busfactor` | Analyze code ownership concentration |
 
 ## Run Options
 
@@ -82,6 +88,81 @@ nightshift budget snapshot --local-only
 nightshift budget history -n 10
 nightshift budget calibrate
 ```
+
+## Config Commands
+
+`nightshift config` shows the merged configuration (global + project) when run without a subcommand.
+
+```bash
+nightshift config                                     # Show merged configuration
+nightshift config get budget.max_percent              # Get a value by key path
+nightshift config get providers.claude.enabled
+nightshift config set budget.max_percent 15           # Set a value (writes project config, or global if none exists)
+nightshift config set logging.level debug --global    # Force write to global config
+nightshift config validate                             # Validate global, project, and merged configs
+```
+
+| Flag | Command | Description |
+|------|---------|-------------|
+| `--global`, `-g` | `config set` | Write to global config instead of project config |
+
+## Project Setup Commands
+
+```bash
+nightshift init                          # Create nightshift.yaml in the current directory
+nightshift init --global                 # Create global config at ~/.config/nightshift/config.yaml
+nightshift init --force                  # Overwrite an existing config without prompting
+
+nightshift install                       # Install a system service, auto-detecting the init system
+nightshift install launchd               # macOS: install a LaunchAgent
+nightshift install systemd               # Linux: install a user systemd unit
+nightshift install cron                  # Universal: install a crontab entry
+nightshift uninstall                     # Remove the installed system service
+```
+
+| Flag | Command | Default | Description |
+|------|---------|---------|-------------|
+| `--global` | `init` | `false` | Create global config instead of project config |
+| `--force`, `-f` | `init` | `false` | Overwrite existing config without prompting |
+
+## Reporting Commands
+
+```bash
+nightshift report                        # Overview of last night's runs
+nightshift report --report tasks         # Report type: overview | tasks | projects | budget | raw
+nightshift report --period last-7d       # Time period: last-night | last-run | last-24h | last-7d | today | yesterday | all
+nightshift report --since 2024-01-01 --until 2024-01-07
+nightshift report --format json          # Output format: fancy | plain | markdown | json
+nightshift report --paths                # Include report/log file paths
+
+nightshift busfactor                     # Analyze bus factor for the current directory
+nightshift busfactor ~/code/myproject    # Analyze a specific repository or directory
+nightshift busfactor --since 2024-01-01 --until 2024-06-01
+nightshift busfactor --file "internal/**/*.go"
+nightshift busfactor --json
+nightshift busfactor --save              # Persist results to the database
+```
+
+See [docs/bus-factor.md](https://github.com/marcus/nightshift/blob/main/docs/bus-factor.md) for details on the bus factor, Herfindahl index, and Gini coefficient metrics.
+
+| Flag | Command | Default | Description |
+|------|---------|---------|-------------|
+| `--report`, `-r` | `report` | `overview` | Report type: overview \| tasks \| projects \| budget \| raw |
+| `--period`, `-p` | `report` | `last-night` | Time period: last-night \| last-run \| last-24h \| last-7d \| today \| yesterday \| all |
+| `--runs`, `-n` | `report` | `3` | Max runs to include (0 = all) |
+| `--since` | `report` | | Start time (YYYY-MM-DD, YYYY-MM-DD HH:MM, or RFC3339) |
+| `--until` | `report` | | End time (YYYY-MM-DD, YYYY-MM-DD HH:MM, or RFC3339) |
+| `--format` | `report` | `fancy` | Output format: fancy \| plain \| markdown \| json |
+| `--no-color` | `report` | `false` | Disable ANSI colors |
+| `--paths` | `report` | `false` | Include report/log file paths |
+| `--max-items` | `report` | `5` | Max highlights per run |
+| `--path`, `-p` | `busfactor` | | Repository or directory path (can also be passed as the first argument) |
+| `--json` | `busfactor` | `false` | Output as JSON |
+| `--since` | `busfactor` | | Start date (RFC3339 or YYYY-MM-DD) |
+| `--until` | `busfactor` | | End date (RFC3339 or YYYY-MM-DD) |
+| `--file`, `-f` | `busfactor` | | Analyze specific file or pattern |
+| `--save` | `busfactor` | `false` | Save results to database |
+| `--db` | `busfactor` | | Database path (uses config if not set) |
 
 ## Global Flags
 


### PR DESCRIPTION
## Summary
- `website/docs/cli-reference.md` documented only 10 of the 16 top-level `nightshift` commands actually registered in `cmd/nightshift/commands` (per the `AddCommand` calls in `root.go`/each command file).
- Adds the missing commands — `config` (`get`/`set`/`validate`), `init`, `install`/`uninstall`, `report`, and `busfactor` — to the Core Commands table.
- Adds new `## Config Commands`, `## Project Setup Commands`, and `## Reporting Commands` sections with example usage and flag tables, sourced from each command's actual `Use`/`Short`/`Long` text and cobra flag definitions in the corresponding `.go` files.
- Cross-references `docs/bus-factor.md` for detailed bus-factor metric explanations, matching how `busfactor` is already documented elsewhere (`docs/bus-factor.md`, `website/docs/scheduling.md`, `troubleshooting.md`).

## Test plan
- [x] Manually cross-checked each documented flag/default against the `cobra.Command` and `Flags()` definitions in `config.go`, `init.go`, `install.go`, `report.go`, and `busfactor.go`.
- [x] Visually reviewed the updated `cli-reference.md` for formatting consistency (tables, code blocks, headers) with existing sections.
- [ ] `cd website && npm install && npm run build` — not run in this environment (no network-fetched `node_modules`); recommend running in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 1.2
cost-tier: Low (10-50k)
iterations: 1
duration: 5m23s
run-started: 2026-08-21T01:00:05-04:00
nightshift:metadata -->
