### PR TITLE
refactor: modernize interface{} to any in config command

### DIFF
--- a/cmd/nightshift/commands/config.go
+++ b/cmd/nightshift/commands/config.go
@@ -130,9 +130,9 @@ func runConfigGet(key string) error {
 
 	// Format output based on type
 	switch val := value.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		printMap(val, 0)
-	case []interface{}:
+	case []any:
 		printSlice(val, 0)
 	default:
 		fmt.Println(value)
@@ -316,7 +316,7 @@ func validateConfigFile(path string) error {
 	return config.Validate(&cfg)
 }
 
-func parseValue(value string) interface{} {
+func parseValue(value string) any {
 	// Try to parse as bool
 	if value == "true" {
 		return true
@@ -425,14 +425,14 @@ func isZero(v reflect.Value) bool {
 	}
 }
 
-func printMap(m map[string]interface{}, indent int) {
+func printMap(m map[string]any, indent int) {
 	prefix := strings.Repeat("  ", indent)
 	for k, v := range m {
 		switch val := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			fmt.Printf("%s%s:\n", prefix, k)
 			printMap(val, indent+1)
-		case []interface{}:
+		case []any:
 			fmt.Printf("%s%s:\n", prefix, k)
 			printSlice(val, indent+1)
 		default:
@@ -441,11 +441,11 @@ func printMap(m map[string]interface{}, indent int) {
 	}
 }
 
-func printSlice(s []interface{}, indent int) {
+func printSlice(s []any, indent int) {
 	prefix := strings.Repeat("  ", indent)
 	for _, v := range s {
 		switch val := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			fmt.Printf("%s-\n", prefix)
 			printMap(val, indent+1)
 		default:


### PR DESCRIPTION
## Summary
- Replaces the pre-Go-1.18 `interface{}` type with the `any` alias across `cmd/nightshift/commands/config.go` (8 occurrences), a mechanical, behavior-preserving modernization consistent with current Go style conventions and commonly flagged by static analysis tooling.
- `golangci-lint` (the linter configured in `.github/workflows/ci.yml`) could not be run in this sandbox because network access to `proxy.golang.org` is blocked. `gofmt -l -s .`, `go vet ./...`, and `go build ./...` were all clean before and after this change. A manual scan for common default-linter violations (unchecked errors, ineffectual assignments, unclosed resources) found no other issues.

## Test plan
- [x] `gofmt -l -s .` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — succeeds
- [x] `go test ./...` — passes except `TestCurrentBranch` in `internal/orchestrator`, which fails identically on `main` due to a sandbox permission restriction unrelated to this change (cannot copy git hook templates), not a regression from this PR
- [ ] `golangci-lint run` — not run locally (network access to proxy.golang.org unavailable in this sandbox); recommend running in CI

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 0.7
cost-tier: Low (10-50k)
iterations: 1
duration: 5m47s
run-started: 2026-08-22T01:00:04-04:00
nightshift:metadata -->
