### PR TITLE
docs: surface the orphaned troubleshooting page in site navigation

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -42,4 +42,8 @@ nightshift run
 - [Installation](/docs/installation) — All installation methods
 - [Quick Start](/docs/quick-start) — Get running in 2 minutes
 - [Configuration](/docs/configuration) — Customize budgets, schedules, and tasks
-- [Tasks](/docs/tasks) — Browse the 20+ built-in tasks
+- [Tasks](/docs/tasks) — Browse the 59 built-in tasks
+- [Budget](/docs/budget) — How budget tracking and calibration work
+- [Scheduling](/docs/scheduling) — Run Nightshift automatically
+- [CLI Reference](/docs/cli-reference) — Every command and flag
+- [Troubleshooting](/docs/troubleshooting) — Fixes for common problems

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,7 +15,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Reference',
-      items: ['cli-reference', 'integrations'],
+      items: ['cli-reference', 'integrations', 'troubleshooting'],
     },
   ],
 };


### PR DESCRIPTION
## Scope chosen

Deliberately minimal: two files, fixing one verified navigation defect.

- `website/sidebars.js` — add `troubleshooting` to the **Reference** category.
- `website/docs/intro.md` — extend **Next Steps** with Budget, Scheduling, CLI Reference, and Troubleshooting links; correct the task count from "20+" to 59.

### The defect

`website/docs/troubleshooting.md` has existed with valid frontmatter but was never listed in `sidebars.js`. Docusaurus therefore rendered it at `/docs/troubleshooting` with **no sidebar entry and no prev/next links** — reachable only if you already knew the URL.

Evidence, from the generated `globalData.json` before this change: every doc carried `"sidebar":"docsSidebar"` except `troubleshooting`, which had no `sidebar` key at all. After the change it reads `'sidebar': 'docsSidebar'` and the Reference category resolves to `['CLI Reference', 'Integrations', 'Troubleshooting']`.

## Assumptions

- **Verified-only claims.** Every added link target was confirmed to exist in `website/docs/`. The task count of 59 was read from `internal/tasks/tasks.go` (59 `Name:` entries) and matches the existing claim in `website/docs/task-reference.md`. Nothing was inferred from convention.
- **Minimal scope over volume.** Based on `origin/main` so the diff is exactly the change under review.

## Gaps deliberately left unaddressed

A survey found this repo's documentation surface almost entirely claimed by **30 open, unmerged `docs:` PRs**. Rather than add overlapping work, these verified-but-already-covered gaps were skipped:

- README completeness — 12 open PRs touch `README.md`.
- CLI reference expansion, incl. the full `nightshift logs` flag table — 11 open PRs touch `cli-reference.md`; #227 already adds the complete `logs` table, #223 the `report` flags, #210 the reports/diagnostics section.
- Architecture overview — #227, #181, #182.
- `CONTRIBUTING.md` — #181, #182, #212.
- Go doc comments on exported symbols — #214, #175, #187, #196. An AST sweep of all 22 packages found **0 undocumented exported symbols**; the only 46 hits were grouped const members that already carry idiomatic trailing comments.

**Disclosure:** the one-line `sidebars.js` fix also appears in #149, #196, and #199. It is included here so this PR stands alone; whichever merges first makes the others a no-op.

## Verification

| Command | Result |
|---|---|
| `npm run build` (website) | `[SUCCESS] Generated static files in "build".` — no broken-link failures |
| `go build -v ./...` | exit 0 |
| `go test ./...` | all 21 packages `ok`, 0 failures |
| pre-commit hook | `go vet` and `go build` both passed |

Sidebar fix confirmed in the regenerated `globalData.json` as quoted above.

Nightshift-Task: docs-backfill
Nightshift-Ref: https://github.com/marcus/nightshift
